### PR TITLE
v0.5.0 — voice studies, English .omd records, self-citation ban

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
   "owner": {
     "name": "3x-haust"
   },
-  "version": "0.4.2",
+  "version": "0.5.0",
   "plugins": [
     {
       "name": "omd",
       "description": "The design cognition loop: doubt the brief, measure real references (type and motion included), build once, look at the render, reframe. Plus a deterministic slop linter and a de-AI copy pass.",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "author": {
         "name": "3x-haust"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omd",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem. Ships a slop linter that makes 'looks AI-generated' a checkable claim.",
   "author": {
     "name": "3x-haust",

--- a/agents/framer.md
+++ b/agents/framer.md
@@ -28,8 +28,12 @@ Exactly one of:
   - an observed pattern in a named competitor, described concretely
   - a sentence the user themselves said
 
-"In my opinion" is not evidence. "Users generally want" is not evidence. If you cannot
-find any, say so and propose no reframing. **A brief that survives interrogation is a
+"In my opinion" is not evidence. "Users generally want" is not evidence. And the
+pipeline's own operating manual is not evidence: citing this skill's instructions, a
+capture quota, or a line number from an omd SKILL.md is the tool testifying about
+itself. When the product under design happens to be omd, its public claims — the
+README, the release notes — are fair evidence like any competitor's; its internal
+rules never are. If you cannot find any, say so and propose no reframing. **A brief that survives interrogation is a
 successful outcome**, not a failed one — it is now a frame that someone checked.
 
 **The trade.** What gets thrown away if the reframing is accepted, and what is gained.
@@ -38,6 +42,10 @@ A reframing that costs nothing is not a reframing; it is a restatement.
 ## How you finish
 
     omd frame set --problem "..." --reframe "..." --why "<citation>"
+
+Write the record in English, whatever language the brief arrived in. Everything under
+`.omd/` is an engineering artifact read by later runs and later tools; the user's
+language belongs in what the user sees, not in the pipeline's files.
 
 Nobody signs this and nothing waits on it. It records what the problem is currently
 believed to be, and the loop may prove it wrong once something has been rendered and

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -121,6 +121,14 @@ reader gets, what it costs, what happens next. If you catch yourself typing "we 
 "no ~ here", "이 사이트는 ~하지 않습니다", delete the sentence and write the positive
 fact it was hiding.
 
+**3. Copy cites the voice study the way fonts cite the type study.** The board carries
+at least one capture chosen for how it writes; your sentences follow its measured
+register — opening moves, CTA verbs, formality level, rhythm — not the register of
+translated marketing. Korean copy in particular follows what real Korean products
+sound like (the study will have named the 어체 and the vocabulary temperature); if you
+catch yourself translating an English slogan into Korean, delete it and write the
+sentence a Korean product would have written first.
+
 And the prose itself, Korean or English, must not read machine-made. The tells, from
 the im-not-ai taxonomy — avoid all of them:
 - mechanical enumeration (첫째/둘째/셋째, "Firstly/Secondly")
@@ -205,6 +213,10 @@ page. Never estimate a contrast ratio, a padding value, or a duration. Run the c
 You do not critique your own work; a separate agent does that precisely because it has
 no attachment to your reasoning. You do not quietly change the committed structure — if
 the build proves it wrong, say so plainly and stop; the reframe step exists for that.
+
+Everything you write under `.omd/` — attribution, decisions — is in English, whatever
+language the page speaks. The page speaks the user's language; the records speak the
+pipeline's.
 
 ## How you finish
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -61,6 +61,15 @@ The composition contract:
   sidebar made them lose their place" is evidence no measurement produces.
 - **Mood or image references** (`--image`) when the concept requires them — a poster, a
   book cover, a material. Reasoning only; say what the image argues, not what it shows.
+- **At least 1 voice study** (`--image`, since prose is unmeasurable) — a site chosen
+  for *how it writes*, not how it looks. Read its actual copy and extract principles
+  about the words: how the hero sentence opens, what verbs the CTAs use, sentence
+  rhythm, what the site never says. For a Korean brief this study must be a real
+  Korean product (토스, 당근, 배민, 리디 — earning their place by register match, not
+  fame): note the formality level (해요체/합니다체/한다체), how features get named,
+  where Sino-Korean gives way to native vocabulary. Translated English marketing is
+  the loudest prose tell there is, and the hand can only avoid it if someone measured
+  what native product copy actually sounds like.
 
 ## The search protocol
 
@@ -175,3 +184,7 @@ measurements — never pictures, never "make it look like".
 
 End on that text, never on a tool call — the orchestrator receives only your final
 message, and a run whose last act is `omd ref principles` hands back nothing.
+
+Write the board — justifications, principles, contradictions — in English, whatever
+language the brief arrived in; quote copy verbatim in its own language. `.omd/` is an
+engineering artifact, not a user-facing document.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Design cognition loop for Codex and Claude Code — frame, diverge, see, reframe",
   "type": "module",
   "bin": {

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -30,6 +30,7 @@ omd ref add <url> --as motion-study-1              # chosen for its motion — m
 omd ref add <url> --as motion-study-2              # different domain, different vocabulary
 omd ref add <pin-url> --as mood --image            # unrenderable — reasoning only
 omd ref add <reddit-url> --as list-debate --image  # community: what people felt and why (minimum 2)
+omd ref add <url> --as voice-study --image           # how a real product writes
 omd ref principles <url> --as <name> --add "..."   # why it works, one sentence
 omd ref list
 ```

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -36,6 +36,12 @@ came here because they did not want to do this work.
 Run the whole loop. Show them the result. Tell them what you decided and why. Every decision
 is written down with its reason, so they can overrule any of it afterwards.
 
+**The records are English; the surface is the user's.** Everything written under
+`.omd/` — frame, decisions, attribution, principles — is in English regardless of the
+brief's language, because later runs and later tools read those files. The page copy and
+every sentence shown to the user stay in the user's language. Neither ever quotes the
+other.
+
 **The design lives where the user asked for it.** Pin the working directory before
 anything else: the directory the skill was invoked in, stated as an absolute path in
 every subagent prompt. Every `omd` command — yours and every agent's — runs from there,

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -36,8 +36,12 @@ instructions: |
     - an observed pattern in a named competitor, described concretely
     - a sentence the user themselves said
 
-  "In my opinion" is not evidence. "Users generally want" is not evidence. If you cannot
-  find any, say so and propose no reframing. **A brief that survives interrogation is a
+  "In my opinion" is not evidence. "Users generally want" is not evidence. And the
+  pipeline's own operating manual is not evidence: citing this skill's instructions, a
+  capture quota, or a line number from an omd SKILL.md is the tool testifying about
+  itself. When the product under design happens to be omd, its public claims — the
+  README, the release notes — are fair evidence like any competitor's; its internal
+  rules never are. If you cannot find any, say so and propose no reframing. **A brief that survives interrogation is a
   successful outcome**, not a failed one — it is now a frame that someone checked.
 
   **The trade.** What gets thrown away if the reframing is accepted, and what is gained.
@@ -46,6 +50,10 @@ instructions: |
   ## How you finish
 
       omd frame set --problem "..." --reframe "..." --why "<citation>"
+
+  Write the record in English, whatever language the brief arrived in. Everything under
+  `.omd/` is an engineering artifact read by later runs and later tools; the user's
+  language belongs in what the user sees, not in the pipeline's files.
 
   Nobody signs this and nothing waits on it. It records what the problem is currently
   believed to be, and the loop may prove it wrong once something has been rendered and

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -123,6 +123,14 @@ instructions: |
   "no ~ here", "이 사이트는 ~하지 않습니다", delete the sentence and write the positive
   fact it was hiding.
 
+  **3. Copy cites the voice study the way fonts cite the type study.** The board carries
+  at least one capture chosen for how it writes; your sentences follow its measured
+  register — opening moves, CTA verbs, formality level, rhythm — not the register of
+  translated marketing. Korean copy in particular follows what real Korean products
+  sound like (the study will have named the 어체 and the vocabulary temperature); if you
+  catch yourself translating an English slogan into Korean, delete it and write the
+  sentence a Korean product would have written first.
+
   And the prose itself, Korean or English, must not read machine-made. The tells, from
   the im-not-ai taxonomy — avoid all of them:
   - mechanical enumeration (첫째/둘째/셋째, "Firstly/Secondly")
@@ -207,6 +215,10 @@ instructions: |
   You do not critique your own work; a separate agent does that precisely because it has
   no attachment to your reasoning. You do not quietly change the committed structure — if
   the build proves it wrong, say so plainly and stop; the reframe step exists for that.
+
+  Everything you write under `.omd/` — attribution, decisions — is in English, whatever
+  language the page speaks. The page speaks the user's language; the records speak the
+  pipeline's.
 
   ## How you finish
 

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -72,6 +72,15 @@ instructions: |
     sidebar made them lose their place" is evidence no measurement produces.
   - **Mood or image references** (`--image`) when the concept requires them — a poster, a
     book cover, a material. Reasoning only; say what the image argues, not what it shows.
+  - **At least 1 voice study** (`--image`, since prose is unmeasurable) — a site chosen
+    for *how it writes*, not how it looks. Read its actual copy and extract principles
+    about the words: how the hero sentence opens, what verbs the CTAs use, sentence
+    rhythm, what the site never says. For a Korean brief this study must be a real
+    Korean product (토스, 당근, 배민, 리디 — earning their place by register match, not
+    fame): note the formality level (해요체/합니다체/한다체), how features get named,
+    where Sino-Korean gives way to native vocabulary. Translated English marketing is
+    the loudest prose tell there is, and the hand can only avoid it if someone measured
+    what native product copy actually sounds like.
 
   ## The search protocol
 
@@ -186,3 +195,7 @@ instructions: |
 
   End on that text, never on a tool call — the orchestrator receives only your final
   message, and a run whose last act is `omd ref principles` hands back nothing.
+
+  Write the board — justifications, principles, contradictions — in English, whatever
+  language the brief arrived in; quote copy verbatim in its own language. `.omd/` is an
+  engineering artifact, not a user-facing document.

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -30,6 +30,7 @@ omd ref add <url> --as motion-study-1              # chosen for its motion — m
 omd ref add <url> --as motion-study-2              # different domain, different vocabulary
 omd ref add <pin-url> --as mood --image            # unrenderable — reasoning only
 omd ref add <reddit-url> --as list-debate --image  # community: what people felt and why (minimum 2)
+omd ref add <url> --as voice-study --image           # how a real product writes
 omd ref principles <url> --as <name> --add "..."   # why it works, one sentence
 omd ref list
 ```

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -36,6 +36,12 @@ came here because they did not want to do this work.
 Run the whole loop. Show them the result. Tell them what you decided and why. Every decision
 is written down with its reason, so they can overrule any of it afterwards.
 
+**The records are English; the surface is the user's.** Everything written under
+`.omd/` — frame, decisions, attribution, principles — is in English regardless of the
+brief's language, because later runs and later tools read those files. The page copy and
+every sentence shown to the user stay in the user's language. Neither ever quotes the
+other.
+
 **The design lives where the user asked for it.** Pin the working directory before
 anything else: the directory the skill was invoked in, stated as an absolute path in
 every subagent prompt. Every `omd` command — yours and every agent's — runs from there,


### PR DESCRIPTION
## What

- **Voice study capture** — the scout now captures at least one site chosen for *how it writes*: hero opening moves, CTA verbs, formality level (해요체/합니다체), rhythm. Korean briefs study real Korean products (토스, 당근, 배민, 리디), and the hand's copy must cite the voice study the way its fonts cite the type study. Fixes the "카피가 AI 말투" problem at its source: nobody had measured what native product copy sounds like.
- **`.omd/` records are English** — frame, decisions, attribution, board principles are engineering artifacts read by later runs; they no longer inherit the brief's language. The page and user-facing messages stay in the user's language.
- **Self-citation ban** — the framer may not cite omd's own skill instructions, quotas, or SKILL.md line numbers as evidence. When the product being designed is omd itself, its public claims (README, release notes) are fair; its internal rules never are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)