### PR TITLE
Batch A — framework-aware hand, version-sync test, dual-viewport SEE, omd doctor

### DIFF
--- a/agents/hand.md
+++ b/agents/hand.md
@@ -161,6 +161,24 @@ board leaves. Use it. Path: `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography
 motion,components,craft,expressive}.md`. Read whichever file covers the gap, pull the
 relevant condition→choice→reason entry, and record it in `omd decision`.
 
+## Framework detection
+
+Before writing a single file, read `package.json` in the working directory if it exists.
+
+- If `react`, `next`, `vue`, `svelte`, or `@sveltejs/kit` appears in `dependencies` or
+  `devDependencies`, the project is already a framework project. Follow its conventions:
+  match the component file structure already in the tree, use the CSS approach the project
+  already uses (CSS modules, Tailwind, plain CSS — whichever is wired), and write
+  components in the same language (`.tsx`, `.vue`, `.svelte`) the project already uses.
+  If you cannot determine the pattern from package.json alone, read one existing component
+  before writing anything new.
+- If no package.json exists or it names no recognised framework, use the stack the brief
+  specifies. If the brief is silent on stack, build plain HTML + CSS + minimal vanilla JS
+  — the least infrastructure that delivers the design.
+
+The point of this step is that a React project that ships a raw `index.html` alongside its
+component tree has two design systems competing. Match what is there.
+
 ## Build mechanics
 
 **Design system first, components second.** Before a single component exists, the `:root`

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stringify } from 'yaml';
@@ -354,6 +354,52 @@ async function cmdRefDistance(opts: Opts): Promise<never> {
   process.exit(0);
 }
 
+async function cmdDoctor(): Promise<never> {
+  let allPass = true;
+
+  function report(label: string, pass: boolean, detail?: string): void {
+    console.log(`${pass ? 'pass' : 'fail'}  ${label}${detail ? `  (${detail})` : ''}`);
+    if (!pass) allPass = false;
+  }
+
+  // Node version: package.json engines requires >=22.18
+  const parts = process.versions.node.split('.').map(Number);
+  const [major = 0, minor = 0] = parts;
+  const nodeOk = major > 22 || (major === 22 && minor >= 18);
+  report('node >=22.18', nodeOk, process.versions.node);
+
+  // Playwright importability + chromium executable
+  try {
+    const { chromium } = await import('playwright');
+    const exePath = chromium.executablePath();
+    const exeExists = existsSync(exePath);
+    report('playwright chromium', exeExists, exeExists ? 'found' : `not found: ${exePath}`);
+  } catch {
+    report('playwright chromium', false, 'playwright not importable — run: npx playwright install chromium');
+  }
+
+  // .omd/ writability at cwd
+  const omdDir = join(process.cwd(), '.omd');
+  try {
+    mkdirSync(omdDir, { recursive: true });
+    const probe = join(omdDir, '.doctor-probe');
+    writeFileSync(probe, '');
+    try { unlinkSync(probe); } catch { /* ignore */ }
+    report('.omd/ writable', true);
+  } catch (e) {
+    report('.omd/ writable', false, e instanceof Error ? e.message : String(e));
+  }
+
+  // Theory-pack files — resolved relative to the CLI's own root
+  const theoryFiles = ['color.md', 'typography.md', 'layout.md', 'motion.md', 'expressive.md', 'components.md', 'craft.md'];
+  for (const f of theoryFiles) {
+    const path = join(root, 'core', 'theory', f);
+    report(`theory/${f}`, existsSync(path));
+  }
+
+  process.exit(allPass ? 0 : 1);
+}
+
 function usage(): never {
   console.error(
     'usage: omd <command>\n\n'
@@ -376,7 +422,9 @@ function usage(): never {
     + '  ref list                                    one line per saved reference\n'
     + '  ref distance <page>                         compare a page to every saved reference\n'
     + '  ref principles <source> --as C --add "..."   record why a reference works\n'
-    + '  ref show <source> --as C                    invariants + principles',
+    + '  ref show <source> --as C                    invariants + principles\n'
+    + '\n'
+    + '  doctor                                       check environment prerequisites',
   );
   process.exit(1);
 }
@@ -437,6 +485,8 @@ async function main(): Promise<never> {
     if (sub === 'show') return cmdRefShow(opts);
     return usage();
   }
+
+  if (cmd === 'doctor') return cmdDoctor();
 
   if (cmd === 'choose') return cmdChoose(parseArgs(args.slice(1)));
 

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -56,6 +56,15 @@ above the design belongs to nothing.
 > Novice designers solve the problem they were given.
 > Expert designers interrogate it first. That is the largest measured gap between them.
 
+Before anything else, run `omd doctor` quietly from the working directory. If any check
+fails, surface the failure lines to the user in one sentence and stop — a missing Playwright
+installation or an unwritable `.omd/` will break every subsequent step, and discovering
+that mid-loop wastes everything before it.
+
+```bash
+omd doctor
+```
+
 Spawn `omd:framer`. It returns the given problem, a reframing, and — mandatory — **evidence**:
 a cited review, a support ticket, a datum, an observed pattern in a named competitor, or a
 sentence the user themselves said. "I think" is not evidence, and `omd frame set` rejects a
@@ -306,6 +315,11 @@ omd decision "Committed to a conversational structure" --why "serves the concept
 Spawn **one** `omd:hand` and build the committed structure. Real files, real CSS, real components.
 All the tokens belong here, on the one thing that ships.
 
+`omd render` and `omd check` accept a dev-server URL just as readily as a static file path —
+pass `http://localhost:3000` (or whichever port the framework uses) wherever a page
+argument is required. For a framework project, start the dev server before running either
+command; for a static build, pass the file path directly.
+
 Declare colour, spacing, radius, **type, and motion** as custom properties on `:root`. The
 eye reads those as the design system; an inline hex is reported as a defect, correctly.
 Typography comes from the reference type studies — a chosen scale and faces with a reason —
@@ -327,10 +341,19 @@ the chance it might be.
 
 You did not make what you think you made.
 
+Render at both viewports, then hand **both** screenshots to the eye. A clamp that works at
+1280px can collapse to nothing at 375px; a margin-note that floats correctly on desktop can
+cover body text on mobile. One render is a blind spot.
+
 ```bash
-omd render <page> -o .omd/.cache/build.png    # then Read the PNG. Actually look at it.
-omd check  <page> --json                      # deterministic findings
-omd check  <page> --category slop             # the ones that matter most
+omd render <page> -o .omd/.cache/build-desktop.png --viewport 1280x800
+omd render <page> -o .omd/.cache/build-mobile.png  --viewport 375x812
+# Read both PNGs. Actually look at them.
+
+omd check  <page> --json           --viewport 1280x800   # deterministic findings, desktop
+omd check  <page> --json           --viewport 375x812    # deterministic findings, mobile
+omd check  <page> --category slop  --viewport 1280x800   # slop, desktop
+omd check  <page> --category slop  --viewport 375x812    # slop, mobile (hit-area fires here)
 ```
 
 `omd check` computes contrast ratios, hit areas, spacing, token coverage, **and slop**. Never
@@ -382,8 +405,10 @@ omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come 
 
 Only when the copy is clean does the eye see the page.
 
-Finally spawn `omd:eye` on the built page. It sees the screenshot and the findings and nothing
-about why you built it that way. It cannot defend your reasoning because it does not have it.
+Finally spawn `omd:eye` on the built page. Hand it both the desktop and mobile screenshots
+and the combined findings from both viewport runs. It sees the renders and the findings and
+nothing about why you built it that way. It cannot defend your reasoning because it does not
+have it.
 
 ---
 

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -163,6 +163,24 @@ instructions: |
   motion,components,craft,expressive}.md`. Read whichever file covers the gap, pull the
   relevant condition→choice→reason entry, and record it in `omd decision`.
 
+  ## Framework detection
+
+  Before writing a single file, read `package.json` in the working directory if it exists.
+
+  - If `react`, `next`, `vue`, `svelte`, or `@sveltejs/kit` appears in `dependencies` or
+    `devDependencies`, the project is already a framework project. Follow its conventions:
+    match the component file structure already in the tree, use the CSS approach the project
+    already uses (CSS modules, Tailwind, plain CSS — whichever is wired), and write
+    components in the same language (`.tsx`, `.vue`, `.svelte`) the project already uses.
+    If you cannot determine the pattern from package.json alone, read one existing component
+    before writing anything new.
+  - If no package.json exists or it names no recognised framework, use the stack the brief
+    specifies. If the brief is silent on stack, build plain HTML + CSS + minimal vanilla JS
+    — the least infrastructure that delivers the design.
+
+  The point of this step is that a React project that ships a raw `index.html` alongside its
+  component tree has two design systems competing. Match what is there.
+
   ## Build mechanics
 
   **Design system first, components second.** Before a single component exists, the `:root`

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -56,6 +56,15 @@ above the design belongs to nothing.
 > Novice designers solve the problem they were given.
 > Expert designers interrogate it first. That is the largest measured gap between them.
 
+Before anything else, run `omd doctor` quietly from the working directory. If any check
+fails, surface the failure lines to the user in one sentence and stop — a missing Playwright
+installation or an unwritable `.omd/` will break every subsequent step, and discovering
+that mid-loop wastes everything before it.
+
+```bash
+omd doctor
+```
+
 Spawn `omd-framer`. It returns the given problem, a reframing, and — mandatory — **evidence**:
 a cited review, a support ticket, a datum, an observed pattern in a named competitor, or a
 sentence the user themselves said. "I think" is not evidence, and `omd frame set` rejects a
@@ -306,6 +315,11 @@ omd decision "Committed to a conversational structure" --why "serves the concept
 Spawn **one** `omd-hand` and build the committed structure. Real files, real CSS, real components.
 All the tokens belong here, on the one thing that ships.
 
+`omd render` and `omd check` accept a dev-server URL just as readily as a static file path —
+pass `http://localhost:3000` (or whichever port the framework uses) wherever a page
+argument is required. For a framework project, start the dev server before running either
+command; for a static build, pass the file path directly.
+
 Declare colour, spacing, radius, **type, and motion** as custom properties on `:root`. The
 eye reads those as the design system; an inline hex is reported as a defect, correctly.
 Typography comes from the reference type studies — a chosen scale and faces with a reason —
@@ -327,10 +341,19 @@ the chance it might be.
 
 You did not make what you think you made.
 
+Render at both viewports, then hand **both** screenshots to the eye. A clamp that works at
+1280px can collapse to nothing at 375px; a margin-note that floats correctly on desktop can
+cover body text on mobile. One render is a blind spot.
+
 ```bash
-omd render <page> -o .omd/.cache/build.png    # then Read the PNG. Actually look at it.
-omd check  <page> --json                      # deterministic findings
-omd check  <page> --category slop             # the ones that matter most
+omd render <page> -o .omd/.cache/build-desktop.png --viewport 1280x800
+omd render <page> -o .omd/.cache/build-mobile.png  --viewport 375x812
+# Read both PNGs. Actually look at them.
+
+omd check  <page> --json           --viewport 1280x800   # deterministic findings, desktop
+omd check  <page> --json           --viewport 375x812    # deterministic findings, mobile
+omd check  <page> --category slop  --viewport 1280x800   # slop, desktop
+omd check  <page> --category slop  --viewport 375x812    # slop, mobile (hit-area fires here)
 ```
 
 `omd check` computes contrast ratios, hit areas, spacing, token coverage, **and slop**. Never
@@ -382,8 +405,10 @@ omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come 
 
 Only when the copy is clean does the eye see the page.
 
-Finally spawn `omd-eye` on the built page. It sees the screenshot and the findings and nothing
-about why you built it that way. It cannot defend your reasoning because it does not have it.
+Finally spawn `omd-eye` on the built page. Hand it both the desktop and mobile screenshots
+and the combined findings from both viewport runs. It sees the renders and the findings and
+nothing about why you built it that way. It cannot defend your reasoning because it does not
+have it.
 
 ---
 

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+
+const run = (args: string[], cwd?: string) =>
+  spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', ...(cwd ? { cwd } : {}) });
+
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-doctor-'));
+
+// omd doctor prints one line per check: "pass  <label>" or "fail  <label>".
+// The test does not assert exit code because the playwright/chromium check may
+// legitimately fail in a fresh CI environment — that is exactly what doctor is
+// designed to surface, not a test defect.
+
+test('omd doctor prints a line for each expected check', () => {
+  const r = run(['doctor'], project());
+
+  // Every output line is either "pass  …" or "fail  …"
+  const lines = r.stdout.trim().split('\n').filter((l) => l.length > 0);
+  assert.ok(lines.length > 0, 'doctor produced no output');
+  for (const line of lines) {
+    assert.match(line, /^(pass|fail)\s+/, `unexpected line format: ${line}`);
+  }
+});
+
+test('omd doctor reports node version check', () => {
+  const r = run(['doctor'], project());
+  assert.match(r.stdout, /node >=22\.18/);
+});
+
+test('omd doctor passes the node version check on the current runtime', () => {
+  const r = run(['doctor'], project());
+  // We require node >=22.18; the test suite itself runs on this node, so it must pass.
+  assert.match(r.stdout, /^pass\s+node >=22\.18/m);
+});
+
+test('omd doctor reports theory-pack presence', () => {
+  const r = run(['doctor'], project());
+  assert.match(r.stdout, /theory\/color\.md/);
+  assert.match(r.stdout, /theory\/typography\.md/);
+  assert.match(r.stdout, /theory\/expressive\.md/);
+});
+
+test('omd doctor passes all theory-pack checks when run from the repo', () => {
+  // Theory files live at <repo>/core/theory/ — always present in a checkout.
+  const r = run(['doctor'], project());
+  const theoryLines = r.stdout.split('\n').filter((l) => l.includes('theory/'));
+  assert.ok(theoryLines.length > 0, 'no theory lines in output');
+  for (const line of theoryLines) {
+    assert.match(line, /^pass\s+theory\//, `theory file missing: ${line}`);
+  }
+});
+
+test('omd doctor reports .omd/ writability', () => {
+  const r = run(['doctor'], project());
+  assert.match(r.stdout, /\.omd\/ writable/);
+});
+
+test('omd doctor passes .omd/ writability in a writable temp dir', () => {
+  const r = run(['doctor'], project());
+  assert.match(r.stdout, /^pass\s+\.omd\/ writable/m);
+});

--- a/test/version-sync.test.ts
+++ b/test/version-sync.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('plugin.json, marketplace.json (top-level and plugins[0]), and package.json versions all match', () => {
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as { version: string };
+  const plugin = JSON.parse(readFileSync(join(root, '.claude-plugin', 'plugin.json'), 'utf8')) as { version: string };
+  const marketplace = JSON.parse(readFileSync(join(root, '.claude-plugin', 'marketplace.json'), 'utf8')) as {
+    version: string;
+    plugins: Array<{ version: string }>;
+  };
+
+  assert.equal(plugin.version, pkg.version, 'plugin.json version must match package.json');
+  assert.equal(marketplace.version, pkg.version, 'marketplace.json top-level version must match package.json');
+  assert.equal(marketplace.plugins[0]!.version, pkg.version, 'marketplace.json plugins[0].version must match package.json');
+});


### PR DESCRIPTION
Plan.md items #1, #2, #5, #10. 185→193 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)