### PR TITLE
Batch B — SLOP-COPY-KO rules + attribution audit

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync, readdirSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stringify } from 'yaml';
@@ -8,6 +8,7 @@ import { writeFrameRecord, reframe, setGenerator, logDecision, logChoice, tasteP
 import { logRun, readHistory } from '../core/history/index.ts';
 import { analyse } from '../core/coach/index.ts';
 import { findLeakedRationale } from '../core/rules/leakage.ts';
+import { checkAttribution } from '../core/rules/attribution.ts';
 import type { Category, Layer, RawIr, Violation } from '../core/types.ts';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -105,9 +106,30 @@ async function cmdCheck(opts: Opts): Promise<never> {
     // check() does, not just --category, or `--layer 2` still emits leak findings.
     .filter((v) => (!categories || categories.includes(v.category)) && (!layers || layers.includes(v.layer)));
 
+  // Attribution audit: only active when .omd/attribution.md exists. Verifies that every
+  // token group used on the page is accounted for, and every row's source points to a real
+  // capture or theory reference. Keeps attribution honest without requiring it of every page.
+  const attrViolations: Violation[] = [];
+  const attrPath = join(process.cwd(), '.omd', 'attribution.md');
+  if (existsSync(attrPath)) {
+    const attrMd = readFileSync(attrPath, 'utf8');
+    const refsDir = join(process.cwd(), '.omd', 'refs');
+    const captureNames = existsSync(refsDir)
+      ? readdirSync(refsDir).filter((f) => f.endsWith('.json')).map((f) => f.slice(0, -5))
+      : [];
+    const theoryDir = join(root, 'core', 'theory');
+    const theoryNames = existsSync(theoryDir)
+      ? readdirSync(theoryDir).filter((f) => f.endsWith('.md')).map((f) => f.slice(0, -3))
+      : [];
+    attrViolations.push(
+      ...checkAttribution(ir, attrMd, captureNames, theoryNames)
+        .filter((v) => (!categories || categories.includes(v.category)) && (!layers || layers.includes(v.layer))),
+    );
+  }
+
   // Code-unit order, not localeCompare — same determinism guarantee as check() itself.
   const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
-  const combined: Violation[] = [...violations, ...leaks].sort((a, b) => cmp(a.path, b.path) || cmp(a.id, b.id));
+  const combined: Violation[] = [...violations, ...leaks, ...attrViolations].sort((a, b) => cmp(a.path, b.path) || cmp(a.id, b.id));
 
   if (opts.json) process.stdout.write(JSON.stringify(combined));
   else for (const v of combined) console.log(`[${v.severity}] ${v.id} ${v.path}: ${v.message}`);

--- a/core/rules/attribution.ts
+++ b/core/rules/attribution.ts
@@ -1,0 +1,159 @@
+import type { Ir, Violation } from '../types.ts';
+
+/**
+ * Token group names that attribution.md must cover.
+ *
+ * A group is "present" when the page's token map contains at least one key whose
+ * prefix belongs to that group. Two formats are supported:
+ *
+ *   Flat CSS custom property map (runtime, from dom.ts):
+ *     { "color-brand-primary": "#FF5A1F", "spacing-md": "16", ... }
+ *     — keys are CSS variable names with the leading `--` stripped.
+ *
+ *   Nested Figma-style map (fixture / hand-written):
+ *     { color: { "brand/primary": "#FF5A1F" }, spacing: { md: 16 } }
+ *     — top-level key is already the group name.
+ */
+const GROUP_PREFIXES: Record<string, string[]> = {
+  color: ['color', 'fill', 'bg', 'surface', 'foreground', 'background'],
+  type: ['font', 'type', 'heading', 'body'],
+  spacing: ['spacing', 'space', 'gap', 'padding', 'margin', 'inset'],
+  radius: ['radius', 'corner', 'rounded'],
+  motion: ['motion', 'duration', 'ease', 'transition', 'timing', 'animation', 'delay'],
+};
+
+const ALL_GROUPS = Object.keys(GROUP_PREFIXES);
+
+/** Returns the set of token groups that are actually present in the IR. */
+function tokenGroups(tokens: Record<string, unknown>): Set<string> {
+  const groups = new Set<string>();
+
+  for (const [key, value] of Object.entries(tokens)) {
+    const lower = key.toLowerCase();
+
+    // Nested format: the top-level key IS the group name.
+    if (typeof value === 'object' && value !== null && ALL_GROUPS.includes(lower)) {
+      groups.add(lower);
+      continue;
+    }
+
+    // Flat CSS custom property format: match by prefix.
+    for (const [group, prefixes] of Object.entries(GROUP_PREFIXES)) {
+      if (prefixes.some((p) => lower === p || lower.startsWith(`${p}-`) || lower.startsWith(`${p}/`))) {
+        groups.add(group);
+        break;
+      }
+    }
+  }
+
+  return groups;
+}
+
+/** One row from the attribution.md table: { group, source }. */
+interface AttributionRow {
+  group: string;
+  source: string;
+}
+
+/**
+ * Parse an attribution.md Markdown table.
+ *
+ * Expected format (header name is case-insensitive; leading/trailing whitespace ignored):
+ *
+ *   | Group | Source |
+ *   |---|---|
+ *   | color | linear-com.hero |
+ *   | type  | theory/typography |
+ */
+function parseAttributionRows(md: string): AttributionRow[] {
+  const rows: AttributionRow[] = [];
+  for (const line of md.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) continue;
+    const cells = trimmed.slice(1, -1).split('|').map((c) => c.trim());
+    if (cells.length < 2) continue;
+    const [group, source] = cells as [string, string];
+    if (!group || !source) continue;
+    // Skip the header row and separator rows.
+    if (group.toLowerCase() === 'group' || /^[-: ]+$/.test(group)) continue;
+    rows.push({ group: group.toLowerCase(), source });
+  }
+  return rows;
+}
+
+/**
+ * Verify that a row's source is a known reference: either a capture slug stored in
+ * `.omd/refs/` or a theory-pack file referenced as `theory/<name>`.
+ *
+ * @param source    The source string from the attribution row.
+ * @param captureNames  Slugs (filenames without .json) found in .omd/refs/.
+ * @param theoryNames   Base names (without .md) of files in the theory pack.
+ */
+function isKnownSource(source: string, captureNames: string[], theoryNames: string[]): boolean {
+  if (captureNames.includes(source)) return true;
+  if (source.startsWith('theory/')) {
+    const name = source.slice('theory/'.length);
+    return theoryNames.includes(name);
+  }
+  return false;
+}
+
+/**
+ * Attribution audit — the deterministic complement to the attribution.md prompt contract.
+ *
+ * Only called when `.omd/attribution.md` exists (the caller is responsible for that guard).
+ *
+ * Two violation codes:
+ *
+ *   ATTR-MISSING         A token group is present on the page but has no row in
+ *                        attribution.md. The designer borrowed a token family and did not
+ *                        say where it came from.
+ *
+ *   ATTR-UNKNOWN-SOURCE  A row's source is neither a capture name in .omd/refs/ nor a
+ *                        theory/<name> reference. The attribution points to something the
+ *                        tool cannot verify — a typo, a deleted reference, or a free-form
+ *                        note that slipped in where a slug belongs.
+ */
+export function checkAttribution(
+  ir: Ir,
+  attributionMd: string,
+  captureNames: string[],
+  theoryNames: string[],
+): Violation[] {
+  const violations: Violation[] = [];
+  const rows = parseAttributionRows(attributionMd);
+  const attributedGroups = new Set(rows.map((r) => r.group));
+  const presentGroups = tokenGroups((ir.tokens ?? {}) as Record<string, unknown>);
+
+  // ATTR-MISSING: token group on the page, no row in attribution.md.
+  for (const group of [...presentGroups].sort()) {
+    if (attributedGroups.has(group)) continue;
+    violations.push({
+      id: 'ATTR-MISSING',
+      severity: 'warn',
+      layer: 1,
+      category: 'system',
+      nodeId: 'page',
+      path: 'attribution',
+      value: group,
+      message: `Token group "${group}" is used on this page but has no row in .omd/attribution.md. Record where this ${group} system came from before the decision disappears.`,
+    });
+  }
+
+  // ATTR-UNKNOWN-SOURCE: row exists, but the source cannot be verified.
+  for (const { group, source } of rows) {
+    if (isKnownSource(source, captureNames, theoryNames)) continue;
+    violations.push({
+      id: 'ATTR-UNKNOWN-SOURCE',
+      severity: 'warn',
+      layer: 1,
+      category: 'system',
+      nodeId: 'page',
+      path: 'attribution',
+      value: `${group}: ${source}`,
+      message: `Attribution row for "${group}" names source "${source}", which is neither a capture slug in .omd/refs/ nor a theory/<name> reference. Fix the slug or re-run omd ref add for that source.`,
+    });
+  }
+
+  return violations;
+}

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -91,6 +91,35 @@
   assert: "!/you won't find [^.]{0,40} here|we (?:won't|will never) (?:bore|spam|waste)|\\b(?:no|zero) (?:ads|clutter|distractions|gimmicks)[,.]? just\\b|이런 (?:내용|것)[은는] 없|(?:여기|이 페이지)에는 [가-힣 ]{0,15}(?:광고|잡동사니|군더더기)[가는은]? 없/i.test(value)"
   message: "Self-negating meta-copy: \"{value}\". The page is announcing what it refuses to do — the model quoting its own brief. Delete this sentence and write the positive fact it was hiding: what the reader gets, what it costs, what happens next."
 
+# Korean AI writing patterns promoted from the im-not-ai taxonomy.
+#
+# Three classes, all S1 (deterministically AI-flavoured in UI copy):
+#
+# C-11 — a sentence-opening connective directly followed by a comma (그러나, / 하지만, /
+# 또한, / 따라서, / 즉,). Standard Korean prose does not punctuate these with a comma;
+# the comma is a direct trace of English "However," and "Therefore," translated by a model.
+# Narrow by design: only the exact five connectives fire; the comma+space pair is required so
+# "또한 그날 밤" (ordinary adverb) passes cleanly.
+#
+# D류 — 알아보겠습니다 / 살펴보겠습니다. The "let us now examine" structural openers that
+# appear in AI-generated explanatory content. On a product page they expose the model's
+# essay skeleton. A human copywriter writes what the product does, not that we will look at
+# what the product does.
+#
+# F2 rule: drop a pattern rather than ship one that fires on legitimate prose. A-19 겹조사
+# (-에서의/-으로의) was studied and dropped: "서울에서의 하루" is unambiguous legitimate Korean
+# so the pattern is too trigger-happy to promote. "둘째,/셋째," was also studied and retained
+# in this rule rather than SLOP-COPY because it completes the 첫째-둘째-셋째 enumeration
+# family already flagged by SLOP-COPY.
+- id: SLOP-COPY-KO
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.text) && node.text.length > 8"
+  value: "node.text"
+  assert: "!/(?:그러나|하지만|또한|따라서|즉),[ \\t]|살펴보겠습니다|알아보겠습니다|둘째[,，]|셋째[,，]/u.test(value)"
+  message: "Korean AI writing pattern: \"{value}\". A connective followed by a comma (그러나,/또한,), a structural 살펴보겠습니다/알아보겠습니다opener, or a 둘째/셋째 enumeration all trace the model's essay skeleton, not the product's actual claim. Write the specific fact this sentence was hiding."
+
 - id: SLOP-TRIPLE-CARD
   layer: 1
   category: slop

--- a/test/attribution.test.ts
+++ b/test/attribution.test.ts
@@ -1,0 +1,215 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { normalize } from '../core/ir/normalize.ts';
+import { checkAttribution } from '../core/rules/attribution.ts';
+import type { RawIr, RawNode } from '../core/types.ts';
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+
+const run = (args: string[], cwd?: string) =>
+  spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', ...(cwd ? { cwd } : {}) });
+
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-attribution-'));
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function irWithTokens(tokens: Record<string, unknown>): ReturnType<typeof normalize> {
+  const node: RawNode = {
+    id: 'r1',
+    name: 'Root',
+    type: 'FRAME',
+    path: 'Root',
+    parent: null,
+    box: { x: 0, y: 0, w: 1440, h: 900 },
+    children: [],
+  };
+  const raw: RawIr = { nodes: [node], tokens: tokens as Record<string, string> };
+  return normalize(raw);
+}
+
+// Flat token map: keys use the CSS custom property naming convention (-- stripped).
+const COLOR_TOKENS = { 'color-brand-primary': '#FF5A1F', 'color-surface': '#FFFFFF' };
+const TYPE_TOKENS = { 'font-size-lg': '18px', 'font-family-base': 'Inter' };
+const SPACING_TOKENS = { 'spacing-md': '16px', 'spacing-lg': '24px' };
+const RADIUS_TOKENS = { 'radius-sm': '4px', 'radius-md': '8px' };
+const MOTION_TOKENS = { 'duration-fast': '150ms', 'ease-out': 'cubic-bezier(0,0,0.3,1)' };
+
+// Nested (Figma-style) token map: top-level key is the group name.
+const NESTED_COLOR_TOKENS = { color: { 'brand/primary': '#FF5A1F' } };
+const NESTED_TYPE_TOKENS = { font: { 'size-lg': '18px' } };
+
+const CAPTURE_NAMES = ['linear.com.hero', 'apple.com.global', 'stripe.com.pricing'];
+const THEORY_NAMES = ['color', 'typography', 'layout', 'motion', 'expressive', 'components', 'craft'];
+
+// ── ATTR-MISSING ─────────────────────────────────────────────────────────────
+
+test('ATTR-MISSING fires when a color token group is on the page but attribution.md has no color row', () => {
+  const ir = irWithTokens(COLOR_TOKENS);
+  const md = `| Group | Source |\n|---|---|\n| type | linear.com.hero |\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.ok(v.some((x) => x.id === 'ATTR-MISSING' && String(x.value) === 'color'), 'expected ATTR-MISSING for color');
+});
+
+test('ATTR-MISSING fires for every unattributed group, not just the first', () => {
+  const ir = irWithTokens({ ...COLOR_TOKENS, ...SPACING_TOKENS });
+  const md = `| Group | Source |\n|---|---|\n`;  // empty table, no rows
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  const ids = v.filter((x) => x.id === 'ATTR-MISSING').map((x) => x.value).sort();
+  assert.deepEqual(ids, ['color', 'spacing']);
+});
+
+test('ATTR-MISSING does not fire when every present token group has a matching row', () => {
+  const ir = irWithTokens({ ...COLOR_TOKENS, ...TYPE_TOKENS });
+  const md = [
+    '| Group | Source |',
+    '|---|---|',
+    '| color | linear.com.hero |',
+    '| type  | theory/typography |',
+  ].join('\n');
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.equal(v.filter((x) => x.id === 'ATTR-MISSING').length, 0);
+});
+
+test('ATTR-MISSING handles flat CSS property names for all five token groups', () => {
+  const ir = irWithTokens({
+    ...COLOR_TOKENS,
+    ...TYPE_TOKENS,
+    ...SPACING_TOKENS,
+    ...RADIUS_TOKENS,
+    ...MOTION_TOKENS,
+  });
+  const md = `| Group | Source |\n|---|---|\n`;  // nothing attributed
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  const missing = v.filter((x) => x.id === 'ATTR-MISSING').map((x) => String(x.value)).sort();
+  assert.deepEqual(missing, ['color', 'motion', 'radius', 'spacing', 'type']);
+});
+
+test('ATTR-MISSING handles nested (Figma-style) token maps', () => {
+  const ir = irWithTokens({ ...NESTED_COLOR_TOKENS, ...NESTED_TYPE_TOKENS });
+  const md = `| Group | Source |\n|---|---|\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  const missing = v.filter((x) => x.id === 'ATTR-MISSING').map((x) => String(x.value)).sort();
+  assert.ok(missing.includes('color'), 'expected color in missing');
+});
+
+test('ATTR-MISSING does not fire when the page has no tokens at all', () => {
+  const ir = irWithTokens({});
+  const md = `| Group | Source |\n|---|---|\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.equal(v.filter((x) => x.id === 'ATTR-MISSING').length, 0);
+});
+
+// ── ATTR-UNKNOWN-SOURCE ───────────────────────────────────────────────────────
+
+test('ATTR-UNKNOWN-SOURCE fires when a row source is neither a capture name nor a theory ref', () => {
+  const ir = irWithTokens(COLOR_TOKENS);
+  const md = `| Group | Source |\n|---|---|\n| color | some-random-text |\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.ok(v.some((x) => x.id === 'ATTR-UNKNOWN-SOURCE'), 'expected ATTR-UNKNOWN-SOURCE');
+});
+
+test('ATTR-UNKNOWN-SOURCE does not fire when source is a known capture slug', () => {
+  const ir = irWithTokens(COLOR_TOKENS);
+  const md = `| Group | Source |\n|---|---|\n| color | linear.com.hero |\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.equal(v.filter((x) => x.id === 'ATTR-UNKNOWN-SOURCE').length, 0);
+});
+
+test('ATTR-UNKNOWN-SOURCE does not fire when source is a theory/<name> reference', () => {
+  const ir = irWithTokens(TYPE_TOKENS);
+  const md = `| Group | Source |\n|---|---|\n| type | theory/typography |\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.equal(v.filter((x) => x.id === 'ATTR-UNKNOWN-SOURCE').length, 0);
+});
+
+test('ATTR-UNKNOWN-SOURCE fires for theory/<name> when the name is not in the theory pack', () => {
+  const ir = irWithTokens(COLOR_TOKENS);
+  const md = `| Group | Source |\n|---|---|\n| color | theory/nonexistent |\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.ok(v.some((x) => x.id === 'ATTR-UNKNOWN-SOURCE'), 'expected ATTR-UNKNOWN-SOURCE for unknown theory ref');
+});
+
+test('ATTR-UNKNOWN-SOURCE and ATTR-MISSING can both fire in the same run', () => {
+  // spacing is on the page (ATTR-MISSING); color row points to an invalid source (ATTR-UNKNOWN-SOURCE)
+  const ir = irWithTokens({ ...COLOR_TOKENS, ...SPACING_TOKENS });
+  const md = `| Group | Source |\n|---|---|\n| color | typo-slug-here |\n`;
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  assert.ok(v.some((x) => x.id === 'ATTR-MISSING' && String(x.value) === 'spacing'));
+  assert.ok(v.some((x) => x.id === 'ATTR-UNKNOWN-SOURCE'));
+});
+
+test('checkAttribution returns empty when attribution.md has no table rows', () => {
+  const ir = irWithTokens(COLOR_TOKENS);
+  const md = '# Attribution\n\nNo table yet.\n';
+  const v = checkAttribution(ir, md, CAPTURE_NAMES, THEORY_NAMES);
+  // ATTR-MISSING should still fire (tokens present, no row), but no ATTR-UNKNOWN-SOURCE
+  assert.equal(v.filter((x) => x.id === 'ATTR-UNKNOWN-SOURCE').length, 0);
+});
+
+// ── CLI integration ───────────────────────────────────────────────────────────
+
+test('CLI: omd check exits 1 and reports ATTR-MISSING when attribution.md exists but group is unattributed', () => {
+  const dir = project();
+  mkdirSync(join(dir, '.omd'), { recursive: true });
+
+  // Write an attribution.md with no rows — page has color tokens, nothing attributed.
+  writeFileSync(join(dir, '.omd', 'attribution.md'), '| Group | Source |\n|---|---|\n');
+
+  const irPath = join(dir, 'page.json');
+  const raw: RawIr = {
+    nodes: [{ id: 'r1', name: 'Root', type: 'FRAME', path: 'Root', parent: null, box: { x: 0, y: 0, w: 1440, h: 900 }, children: [] }],
+    tokens: { 'color-brand': '#FF5A1F' } as Record<string, string>,
+  };
+  writeFileSync(irPath, JSON.stringify(raw));
+
+  const r = run(['check', '--ir', irPath, '--no-log'], dir);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout, /ATTR-MISSING/);
+});
+
+test('CLI: omd check does not report ATTR-MISSING or ATTR-UNKNOWN-SOURCE when no attribution.md is present', () => {
+  const dir = project();
+  // No .omd/attribution.md — attribution check is inactive.
+  const irPath = join(dir, 'page.json');
+  const raw: RawIr = {
+    nodes: [{ id: 'r1', name: 'Root', type: 'FRAME', path: 'Root', parent: null, box: { x: 0, y: 0, w: 1440, h: 900 }, children: [] }],
+    tokens: { 'color-brand': '#FF5A1F' } as Record<string, string>,
+  };
+  writeFileSync(irPath, JSON.stringify(raw));
+
+  const r = run(['check', '--ir', irPath, '--no-log'], dir);
+  assert.doesNotMatch(r.stdout, /ATTR-MISSING/);
+  assert.doesNotMatch(r.stdout, /ATTR-UNKNOWN-SOURCE/);
+});
+
+test('CLI: omd check exits 0 when all token groups are properly attributed', () => {
+  const dir = project();
+  mkdirSync(join(dir, '.omd', 'refs'), { recursive: true });
+
+  // Write a fake capture so the source slug resolves.
+  writeFileSync(join(dir, '.omd', 'refs', 'example.com.hero.json'), JSON.stringify({
+    source: 'https://example.com', component: 'hero', kind: 'page',
+    capturedAt: new Date().toISOString(), invariants: null, principles: [],
+  }));
+  writeFileSync(join(dir, '.omd', 'attribution.md'), [
+    '| Group | Source |',
+    '|---|---|',
+    '| color | example.com.hero |',
+  ].join('\n'));
+
+  const irPath = join(dir, 'page.json');
+  const raw: RawIr = {
+    nodes: [{ id: 'r1', name: 'Root', type: 'FRAME', path: 'Root', parent: null, box: { x: 0, y: 0, w: 1440, h: 900 }, children: [] }],
+    tokens: { 'color-brand': '#FF5A1F' } as Record<string, string>,
+  };
+  writeFileSync(irPath, JSON.stringify(raw));
+
+  const r = run(['check', '--ir', irPath, '--no-log'], dir);
+  assert.doesNotMatch(r.stdout, /ATTR-MISSING/);
+  assert.doesNotMatch(r.stdout, /ATTR-UNKNOWN-SOURCE/);
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -148,6 +148,57 @@ test('SLOP-PINK-ELEPHANT fires on Korean self-negating meta-copy', () => {
   }
 });
 
+test('SLOP-COPY-KO fires on C-11: sentence-opening connective followed by a comma', () => {
+  const positives = [
+    '또한, 이 제품은 빠릅니다.',
+    '그러나, 문제가 있습니다.',
+    '하지만, 우리는 다르게 접근합니다.',
+    '따라서, 결론을 도출할 수 있습니다.',
+    '즉, 핵심은 단순함입니다.',
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-COPY-KO'), `expected SLOP-COPY-KO for: ${text}`);
+  }
+});
+
+test('SLOP-COPY-KO does not fire when the same connectives appear without a comma', () => {
+  const negatives = [
+    '또한 그날 밤 모두가 모였다.',        // 또한 as adverb, no comma
+    '그러나 이것은 다른 문제다.',          // connective without comma
+    '하지만 우리는 여기까지 왔다.',        // same
+    '따라서 이 결론은 타당하다.',          // same
+    '즉 이렇게 말할 수 있다.',             // same
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-COPY-KO'), `unexpected SLOP-COPY-KO for: ${text}`);
+  }
+});
+
+test('SLOP-COPY-KO fires on AI structural openers 살펴보겠습니다 and 알아보겠습니다', () => {
+  const positives = [
+    '이번 글에서는 주요 기능을 살펴보겠습니다.',
+    '이 제품에 대해 자세히 알아보겠습니다.',
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-COPY-KO'), `expected SLOP-COPY-KO for: ${text}`);
+  }
+});
+
+test('SLOP-COPY-KO fires on 둘째, and 셋째, list-enumeration patterns', () => {
+  const positives = [
+    '둘째, 디자인의 일관성이 중요합니다.',
+    '셋째, 사용자 경험을 최우선으로 합니다.',
+    '셋째，세 번째 이유는 다음과 같습니다.',  // ideographic comma variant
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-COPY-KO'), `expected SLOP-COPY-KO for: ${text}`);
+  }
+});
+
 test('SLOP-PINK-ELEPHANT does not fire on legitimate negative-statement copy', () => {
   const negatives = [
     // privacy / policy copy


### PR DESCRIPTION
Plan.md items #3, #4. 193→212 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)