### PR TITLE
Batch D — motion pipeline: live probe, motion-spec, MOTION-* rules, filmstrip

### DIFF
--- a/agents/hand.md
+++ b/agents/hand.md
@@ -161,6 +161,51 @@ board leaves. Use it. Path: `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography
 motion,components,craft,expressive}.md`. Read whichever file covers the gap, pull the
 relevant condition→choice→reason entry, and record it in `omd decision`.
 
+## Write the motion spec before building anything
+
+Attribution.md does for colour and type what the motion spec does for animation. Before
+writing any CSS transition or animation, write `.omd/motion-spec.md`. One scene per
+block. The build implements the spec and nothing else — an animation not in the spec
+does not ship.
+
+Format — every field is required for every scene:
+
+```
+## Scene: hero entrance (trigger: load)
+- Trigger: load
+- Target: .hero h1, .hero p, .hero .cta
+- Properties: opacity (0 → 1), transform (translateY(16px) → none)
+- Duration: 280ms — motion-study-1 (stripe.com): measured 260–300ms entrance window
+- Easing: cubic-bezier(0.0, 0.0, 0.2, 1) — motion-study-1: ease-out feel, measured
+- Stagger: 60ms between siblings — theory/motion.md: 40–80ms is perceivable without theatrical delay
+
+## Scene: nav link hover (trigger: :hover)
+- Trigger: :hover
+- Target: nav a
+- Properties: color, background-color
+- Duration: 140ms — motion-study-1: hover feedback under 150ms reads as instant
+- Easing: ease-out
+- Stagger: none (single element)
+
+## Scene: section card entrance (trigger: scroll / IntersectionObserver)
+- Trigger: scroll
+- Target: .cards > .card
+- Properties: opacity (0 → 1), transform (translateY(24px) → none)
+- Duration: 320ms — motion-study-2 (linear.app): scroll entrances slightly slower than load
+- Easing: cubic-bezier(0.2, 0.0, 0.0, 1.0) — motion-study-2: measured
+- Stagger: 50ms per card
+```
+
+If the board has no motion study, stop and report — the same rule as for typography.
+The orchestrator will re-run scout with a motion-study requirement.
+
+The spec is how you prove you did not reach for 500ms ease-in-out out of habit. Every
+duration and easing must cite a board capture or a theory reference. `omd check
+--category motion` will verify: MOTION-UNIFORM fires when every node shares one
+duration and default keywords, MOTION-NO-REDUCED fires when the motion layer has no
+prefers-reduced-motion accommodation, and MOTION-LAYOUT-THRASH fires when width/height/
+top/left appear in transition-property.
+
 ## Framework detection
 
 Before writing a single file, read `package.json` in the working directory if it exists.

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -33,9 +33,10 @@ interface Opts {
   noLog?: boolean;
   selector?: string;
   image?: boolean;
+  filmstrip?: boolean;
 }
 
-const FLAGS = new Set(['json', 'no-log', 'image']);
+const FLAGS = new Set(['json', 'no-log', 'image', 'filmstrip']);
 const ALIASES: Record<string, keyof Opts> = { o: 'out', 'no-log': 'noLog' };
 
 function parseArgs(args: string[]): Opts {
@@ -74,9 +75,22 @@ async function cmdIr(opts: Opts): Promise<never> {
 }
 
 async function cmdRender(opts: Opts): Promise<never> {
-  const { renderPage, parseViewport } = await import('../core/render/index.ts');
+  const { renderPage, renderFilmstrip, parseViewport } = await import('../core/render/index.ts');
   const target = opts._[0];
   if (!target) usage();
+
+  if (opts.filmstrip) {
+    // Filmstrip: 4–6 viewport screenshots at ~300ms intervals, plus an HTML index.
+    // The HTML index is the deliverable: eye reads it to see what appeared when.
+    const out = opts.out ?? 'filmstrip.html';
+    mkdirSync(dirname(resolve(out)), { recursive: true });
+    const frames = await renderFilmstrip(target, { viewport: parseViewport(opts.viewport), out });
+    // Report the index path (sans extension already included) alongside the frame count.
+    const indexPath = out.endsWith('.html') || out.endsWith('.htm') ? out : `${out}.html`;
+    console.log(`${indexPath}  (${frames.length} frames)`);
+    process.exit(0);
+  }
+
   const out = opts.out ?? 'shot.png';
   mkdirSync(dirname(resolve(out)), { recursive: true });
   await renderPage(target, { viewport: parseViewport(opts.viewport), out });
@@ -457,6 +471,7 @@ function usage(): never {
     'usage: omd <command>\n\n'
     + '  ir <page> [-o f]                            rendered DOM -> Design IR\n'
     + '  render <page> -o shot.png [--viewport WxH]  headless screenshot\n'
+    + '  render <page> --filmstrip -o f.html [--viewport WxH]  load-time filmstrip\n'
     + '  check [<page>|--ir f] [--json] [--category slop] [--no-log]\n'
     + '  coach                                        trends across `omd check` history\n'
     + '\n'

--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -163,6 +163,18 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
         .map((ms, i) => (ms > 0 ? (timingFns[i % timingFns.length] ?? null) : null))
         .filter((v): v is string => v !== null && v.length > 0)
       : [];
+    // CSS properties being transitioned, indexed parallel to transitionDurationsRaw.
+    // 'all' and 'none' are excluded so MOTION-LAYOUT-THRASH can match named layout
+    // properties (width/height/top/left/margin) without false-positives from 'all'.
+    const transitionPropsRaw = cs.transitionProperty
+      .split(',')
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0 && v !== 'none' && v !== 'all');
+    const transitionProperties = transitionPropsRaw.length > 0
+      ? transitionDurationsRaw
+        .map((ms, i) => (ms > 0 ? (transitionPropsRaw[i % transitionPropsRaw.length] ?? null) : null))
+        .filter((v): v is string => v !== null && v.length > 0)
+      : [];
     const animationNames = cs.animationName
       .split(',')
       .map((v) => v.trim())
@@ -180,7 +192,12 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
     ]));
     if (allDurations.length > 0 || animationNames.length > 0) {
       // Renamed from `transitionDurations` (F5): this list holds animation durations too.
-      node.motion = { durations: allDurations, animationNames, easings };
+      node.motion = {
+        durations: allDurations,
+        animationNames,
+        easings,
+        ...(transitionProperties.length > 0 ? { properties: transitionProperties } : {}),
+      };
     }
 
     const text = ownText(el);

--- a/core/ref/invariants.ts
+++ b/core/ref/invariants.ts
@@ -131,6 +131,20 @@ export function extractInvariants(ir: Ir): Invariants {
     ? round(interaction.focusVisible / interaction.tabStops, 2)
     : 0;
 
+  // Motion probe: attached by probeMotion() in core/render/index.ts. Absent on IRs
+  // captured before the probe existed — read defensively to keep old refs loading cleanly.
+  // PROBE LIMIT: rAF-driven libs (GSAP) are not visible to getAnimations(); their absence
+  // from animatedProperties is a correct measurement, not a missing field.
+  const motionProbe = ir.meta?.['motion'] as
+    | { animatedProperties?: string[]; hasReducedMotion?: boolean; scrollChoreography?: Array<{ step: number; fired: number; entered: number }> }
+    | null
+    | undefined;
+  const animatedProperties = motionProbe?.animatedProperties
+    ? [...motionProbe.animatedProperties].sort()
+    : [];
+  const hasReducedMotion = motionProbe?.hasReducedMotion ?? false;
+  const scrollChoreography = motionProbe?.scrollChoreography ?? [];
+
   return {
     spacingLadder, radiusLadder, elevationLevels, centeredRatio, tokenCoverage, paddingWeight,
     typeScale,
@@ -141,5 +155,8 @@ export function extractInvariants(ir: Ir): Invariants {
     animatedShare,
     hoverCoverage,
     focusCoverage,
+    animatedProperties,
+    hasReducedMotion,
+    scrollChoreography,
   };
 }

--- a/core/ref/store.ts
+++ b/core/ref/store.ts
@@ -15,6 +15,10 @@ function withInvariantDefaults(invariants: Invariants | null | undefined): Invar
     animatedShare: invariants.animatedShare ?? 0,
     hoverCoverage: invariants.hoverCoverage ?? 0,
     focusCoverage: invariants.focusCoverage ?? 0,
+    // Motion probe fields — absent on references captured before the live probe was added.
+    animatedProperties: invariants.animatedProperties ?? [],
+    hasReducedMotion: invariants.hasReducedMotion ?? false,
+    scrollChoreography: invariants.scrollChoreography ?? [],
   };
 }
 

--- a/core/render/index.ts
+++ b/core/render/index.ts
@@ -1,8 +1,8 @@
 import { pathToFileURL } from 'node:url';
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname, basename, join } from 'node:path';
 import { extractInPage } from '../ir/dom.ts';
-import type { RawIr } from '../types.ts';
+import type { MotionMeasurement, RawIr } from '../types.ts';
 
 const MAX_NODES = 4000;
 
@@ -129,6 +129,195 @@ async function probeInteraction(page: import('playwright').Page): Promise<Intera
   }
 }
 
+// ── Motion probe helpers ────────────────────────────────────────────────────
+//
+// These functions run inside the page (injected via page.evaluate stringification).
+// They must stay self-contained: no imports, no closure over module scope, and no
+// syntax that does not survive TypeScript type-stripping to plain JS.
+//
+// PROBE LIMIT: document.getAnimations() sees CSS animations, CSS transitions (WAAPI
+// path), and explicit WAAPI calls including Framer Motion. It does NOT see rAF-driven
+// libraries such as GSAP or Anime.js — those animate via requestAnimationFrame and
+// bypass the Animation API entirely. A GSAP-only page will correctly report zero
+// animations here. This limit is documented on MotionMeasurement and propagated to
+// Invariants.animatedProperties so callers are never surprised.
+
+function captureMotionSnapshot(): Array<{ duration: number; easing: string; properties: string[]; playState: string }> {
+  const doc = document as unknown as { getAnimations?: (opts?: { subtree: boolean }) => unknown[] };
+  const anims: unknown[] = doc.getAnimations?.({ subtree: true }) ?? [];
+  const result: Array<{ duration: number; easing: string; properties: string[]; playState: string }> = [];
+  for (const anim of anims) {
+    const a = anim as { effect?: unknown; playState: string };
+    const effect = a.effect;
+    if (!effect) continue;
+    const eff = effect as { getComputedTiming?: () => { duration?: unknown; easing?: string }; getKeyframes?: () => Record<string, unknown>[] };
+    const timing = eff.getComputedTiming?.() ?? {};
+    const duration = typeof timing.duration === 'number' ? timing.duration : 0;
+    const easing = timing.easing ?? 'linear';
+    const properties: string[] = [];
+    try {
+      if (typeof eff.getKeyframes === 'function') {
+        const skip = new Set(['offset', 'easing', 'composite', 'computedOffset']);
+        for (const kf of eff.getKeyframes()) {
+          for (const k of Object.keys(kf)) {
+            if (!skip.has(k) && !properties.includes(k)) properties.push(k);
+          }
+        }
+      }
+    } catch { /* getKeyframes unsupported in some browser states */ }
+    result.push({ duration, easing, properties, playState: a.playState });
+  }
+  return result;
+}
+
+function checkReducedMotionInPage(): boolean {
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        // CSSMediaRule.type === 4
+        if ((rule as unknown as { type: number }).type === 4) {
+          const text: string =
+            (rule as unknown as { conditionText?: string; media?: { mediaText?: string } }).conditionText
+            ?? (rule as unknown as { media?: { mediaText?: string } }).media?.mediaText
+            ?? '';
+          if (text.includes('prefers-reduced-motion')) return true;
+        }
+      }
+    } catch { /* cross-origin stylesheet: skip */ }
+  }
+  return false;
+}
+
+/**
+ * Live animation probe. Reads document.getAnimations({subtree:true}) at three timepoints
+ * and steps through scroll positions to record per-step choreography data.
+ *
+ * A probe failure (no Animation API, page error, or Playwright timeout) returns null
+ * rather than throwing — capture must never break because motion could not be measured.
+ */
+async function probeMotion(page: import('playwright').Page): Promise<MotionMeasurement | null> {
+  const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+  try {
+    type Snap = Array<{ duration: number; easing: string; properties: string[]; playState: string }>;
+
+    // Three-snapshot timeline: capture animation state at load, 500ms, and 1500ms.
+    // Entrance animations typically complete within this window; scroll-triggered ones do not.
+    const snap0 = await page.evaluate(`(${captureMotionSnapshot.toString()})()`) as Snap;
+    await sleep(500);
+    const snap500 = await page.evaluate(`(${captureMotionSnapshot.toString()})()`) as Snap;
+    await sleep(1000); // 1500ms total
+    const snap1500 = await page.evaluate(`(${captureMotionSnapshot.toString()})()`) as Snap;
+
+    const hasReducedMotion = await page.evaluate(`(${checkReducedMotionInPage.toString()})()`) as boolean;
+
+    // Scroll choreography: step by 25% viewport height, record animation and element counts.
+    const viewportHeight = page.viewportSize()?.height ?? 800;
+    const scrollStep = Math.round(viewportHeight * 0.25);
+    const scrollChoreography: MotionMeasurement['scrollChoreography'] = [];
+
+    for (let step = 1; step <= 4; step++) {
+      await page.evaluate((y: number) => window.scrollTo({ top: y, behavior: 'instant' }), step * scrollStep);
+      await sleep(150); // brief settle for scroll-triggered animations to start
+      const stepData = await page.evaluate(() => {
+        const doc = document as unknown as { getAnimations?: (opts?: { subtree: boolean }) => Array<{ playState: string }> };
+        const anims = doc.getAnimations?.({ subtree: true }) ?? [];
+        const fired = anims.filter((a) => a.playState === 'running').length;
+        const vH = window.innerHeight;
+        const entered = Array.from(document.querySelectorAll('*')).filter((el) => {
+          const rect = el.getBoundingClientRect();
+          if (rect.top < 0 || rect.bottom > vH || rect.width === 0 || rect.height === 0) return false;
+          const cs = getComputedStyle(el);
+          const transDur = parseFloat(cs.transitionDuration) || 0;
+          const animDur = parseFloat(cs.animationDuration) || 0;
+          const hasAnim = cs.animationName !== 'none' && animDur > 0;
+          return transDur > 0 || hasAnim;
+        }).length;
+        return { fired, entered };
+      }) as { fired: number; entered: number };
+      scrollChoreography.push({ step, fired: stepData.fired, entered: stepData.entered });
+    }
+
+    // Reset scroll so subsequent operations (e.g. screenshot) see the top of the page.
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
+
+    const allProps = [...snap0, ...snap500, ...snap1500].flatMap((a) => a.properties);
+    const animatedProperties = [...new Set(allProps)].sort();
+
+    return {
+      snapshots: [
+        { t: 0, animations: snap0 },
+        { t: 500, animations: snap500 },
+        { t: 1500, animations: snap1500 },
+      ],
+      animatedProperties,
+      hasReducedMotion,
+      scrollChoreography,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── Filmstrip ───────────────────────────────────────────────────────────────
+
+/**
+ * Captures 4–6 viewport screenshots at ~300ms intervals from load, then writes:
+ *   - numbered frame PNGs: `<base>-frame-0.png`, `<base>-frame-1.png`, …
+ *   - an HTML index at `<base>.html` that lays frames out horizontally
+ *
+ * The HTML index is the deliverable: `omd-eye` reads it to see what appeared when.
+ * No image-compositing dependency is needed — the HTML renders the filmstrip in the
+ * browser, and the eye reads the rendered result.
+ *
+ * Returns the paths of the frame PNGs (not the index).
+ */
+export async function renderFilmstrip(
+  target: string,
+  opts: { viewport: Viewport; out: string; frames?: number; interval?: number },
+): Promise<string[]> {
+  const frameCount = Math.min(Math.max(opts.frames ?? 5, 4), 6);
+  const interval = opts.interval ?? 300;
+  const base = opts.out.replace(/\.html$/i, '');
+  const dir = dirname(resolve(base));
+  const name = basename(base);
+
+  return withPage(target, opts.viewport, async (page) => {
+    mkdirSync(dir, { recursive: true });
+    const framePaths: string[] = [];
+
+    for (let i = 0; i < frameCount; i++) {
+      if (i > 0) await new Promise<void>((r) => setTimeout(r, interval));
+      const framePath = join(dir, `${name}-frame-${i}.png`);
+      // Viewport screenshot (not fullPage) so each frame shows the same viewport region
+      // and the temporal sequence is directly comparable.
+      await page.screenshot({ path: framePath, fullPage: false });
+      framePaths.push(framePath);
+    }
+
+    // HTML index: frames laid out horizontally so the eye can see the temporal sequence.
+    const indexPath = join(dir, `${name}.html`);
+    const figures = framePaths.map((p, i) =>
+      `<figure><figcaption>t=${i * interval}ms</figcaption>`
+      + `<img src="${basename(p)}" loading="lazy" alt="frame ${i}"></figure>`,
+    );
+    const html = [
+      '<!doctype html><meta charset="utf-8">',
+      `<title>Filmstrip — ${name}</title>`,
+      '<style>',
+      'body{margin:0;background:#111;color:#ddd;font:11px/1.4 system-ui;',
+      '     display:flex;gap:3px;padding:8px;overflow-x:auto;min-height:100vh}',
+      'figure{margin:0;flex-shrink:0;text-align:center}',
+      'figcaption{padding:4px 0 6px}',
+      'img{display:block;height:320px;width:auto;border:1px solid #333}',
+      '</style>',
+      ...figures,
+    ].join('\n');
+    writeFileSync(indexPath, html);
+
+    return framePaths;
+  });
+}
+
 export function extractIr(target: string, opts: { viewport: Viewport; selector?: string | null }): Promise<RawIr> {
   return withPage(target, opts.viewport, async (page) => {
     // Node strips the types, so toString() yields runnable JS for the browser.
@@ -136,6 +325,7 @@ export function extractIr(target: string, opts: { viewport: Viewport; selector?:
       `(${extractInPage.toString()})(${MAX_NODES}, ${JSON.stringify(opts.selector ?? null)})`,
     ) as RawIr;
     const interaction = await probeInteraction(page);
-    return { ...raw, meta: { ...(raw.meta ?? {}), interaction } };
+    const motion = await probeMotion(page);
+    return { ...raw, meta: { ...(raw.meta ?? {}), interaction, motion } };
   });
 }

--- a/core/rules/builtin/motion.yaml
+++ b/core/rules/builtin/motion.yaml
@@ -1,0 +1,74 @@
+# MOTION-* rules: deterministic checks for motion implementation quality.
+# Every rule warns — never errors. A deliberate choice can overrule any with `omd decision`.
+#
+# Category 'motion' is separate from 'slop': these are craft defects in animation
+# execution (missing reduced-motion support, layout thrash, uniform rhythm), not
+# design-mean convergence failures. Separate category means `omd check --category motion`
+# runs only these, leaving slop and a11y unaffected.
+#
+# Data sources available to rules:
+#   node.motion.properties  — CSS transition-property values (static IR, from dom.ts)
+#   ir.meta.motion          — live probe data (probeMotion in core/render/index.ts)
+#
+# PROBE LIMIT: GSAP and rAF-driven animation libraries are NOT visible to
+# document.getAnimations(). A GSAP-only page reads as zero live animations here —
+# that is a correct measurement of what the API can see, not a probe failure.
+# Rules that read ir.meta.motion check defensively for probe presence (ir.meta.motion
+# exists and has the expected fields) before asserting. They skip gracefully when the
+# probe was not run or returned null.
+#
+# MOTION-SLOW-HOVER was studied and dropped: node.motion.durations lists ALL transition
+# durations (entrance animations + hover transitions) without distinguishing between them.
+# A rule firing on any interactive node with duration > 200ms would have false positives
+# from entrance animations. No deterministic path exists; the rule is omitted rather than
+# faked. See Plan.md #11c for the analysis.
+
+# A page with live animations but no prefers-reduced-motion media query exposes every
+# user who prefers reduced motion to the full animation load. The fix is a single media
+# query block wrapping the entire motion layer. The rule only fires when the live probe
+# measured at least one animated property — a page with no live animations is fine either
+# way, and a pre-probe IR (no ir.meta.motion) cannot be checked.
+- id: MOTION-NO-REDUCED
+  layer: 1
+  category: motion
+  severity: warn
+  when: "node.parent === null && ir.meta && ir.meta.motion && Array.isArray(ir.meta.motion.animatedProperties) && ir.meta.motion.animatedProperties.length > 0"
+  assert: "ir.meta.motion.hasReducedMotion === true"
+  message: "Animations present but no prefers-reduced-motion media query found. Users who opt out of motion see the full animation load. Wrap the entire motion layer: @media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; } }"
+
+# Animating layout properties (width, height, top, left, margin, padding) forces the
+# browser to recalculate layout on every frame — a full layout pass that triggers
+# cascading reflow through the subtree. Animate transform and opacity instead: they run
+# on the compositor thread, never touch layout, and are the only two properties that can
+# be GPU-accelerated without a layout recalculation.
+#
+# The rule reads node.motion.properties (static IR) which lists the CSS transition-property
+# values on this node, excluding 'all' and 'none'. If transition-property is 'all', the
+# specific properties are unknown and the rule does not fire — this is the conservative
+# (non-faking) path. Only explicitly named layout properties are flagged.
+- id: MOTION-LAYOUT-THRASH
+  layer: 1
+  category: motion
+  severity: warn
+  when: "node.motion && Array.isArray(node.motion.properties) && node.motion.properties.length > 0"
+  value: "node.motion.properties.filter(p => ['width','height','top','right','bottom','left','margin','margin-top','margin-right','margin-bottom','margin-left','padding','padding-top','padding-right','padding-bottom','padding-left'].includes(p))"
+  assert: "value.length === 0"
+  message: "Layout property animated: {value}. Animating width/height/top/left/margin/padding forces a full layout recalculation on every frame. Animate transform (translate, scale) and opacity instead — they run on the compositor thread and never touch layout."
+
+# Three or more animated nodes, every one with the same duration, and the easing
+# vocabulary contains only CSS keyword defaults (ease, ease-in, ease-out, ease-in-out,
+# linear). This is the signature of generated work: "500ms ease-in-out on everything."
+# A considered motion system varies duration by role (entrance is slower than hover;
+# exit is faster than entrance) and uses a measured easing curve from the motion study.
+#
+# Fires on the root node (once per page). Null return from the IIFE means "condition not
+# met" — either fewer than 3 animated nodes, or durations vary, or a real cubic-bezier
+# is in use. Any of those is sufficient to silence the rule.
+- id: MOTION-UNIFORM
+  layer: 1
+  category: motion
+  severity: warn
+  when: "node.parent === null"
+  value: "(() => { const animated = ir.nodes.filter(n => n.motion && n.motion.durations && n.motion.durations.length > 0); if (animated.length < 3) return null; const allDurations = animated.flatMap(n => n.motion.durations); const unique = [...new Set(allDurations)]; if (unique.length !== 1) return null; const allEasings = [...new Set(animated.flatMap(n => n.motion.easings))]; const defaults = new Set(['ease','linear','ease-in','ease-out','ease-in-out','step-start','step-end']); if (!allEasings.every(e => defaults.has(e))) return null; return { count: animated.length, duration: unique[0], easings: allEasings }; })()"
+  assert: "value === null"
+  message: "Motion uniform signature: {value}. Every animated node shares one duration and only CSS keyword easings. This is the generated-work signature. Vary duration by role (entrance ≠ hover ≠ exit) and use a measured easing curve (cubic-bezier) from the motion study rather than keyword defaults."

--- a/core/types.ts
+++ b/core/types.ts
@@ -65,6 +65,13 @@ export interface RawNode {
     animationNames: string[];
     /** Timing functions in play on this node, e.g. "ease-out", "cubic-bezier(...)". */
     easings: string[];
+    /**
+     * CSS properties being transitioned (from transition-property). Only specific property
+     * names are included; 'all' and 'none' are excluded so MOTION-LAYOUT-THRASH can check
+     * for named layout properties (width/height/top/left/margin) deterministically without
+     * false-positives from the 'all' shorthand.
+     */
+    properties?: string[];
   };
 }
 
@@ -128,8 +135,11 @@ export type Layer = 1 | 2;
  * `slop` is different. Nothing here is broken — the design has simply converged on the
  * mean of everything the model has seen. Each rule is a heuristic and can be wrong about
  * a deliberate choice, which is why every one of them is a warning and none is an error.
+ * `motion` covers craft defects in animation execution: missing reduced-motion support,
+ * layout thrash, uniform rhythm. Separate from `slop` because these are implementation
+ * correctness issues, not design-mean convergence failures.
  */
-export type Category = 'a11y' | 'system' | 'slop';
+export type Category = 'a11y' | 'system' | 'slop' | 'motion';
 
 export interface Rule {
   id: string;
@@ -219,6 +229,58 @@ export interface Invariants {
   hoverCoverage: number;
   /** focusVisible / tabStops, 2dp. 0 when tabStops is 0 or the probe failed (unmeasured). */
   focusCoverage: number;
+
+  /**
+   * CSS properties actually animated, collected from the live motion probe via
+   * document.getAnimations({subtree:true}). Sorted, deduplicated.
+   *
+   * NOTE: rAF-driven libraries (GSAP, Anime.js) animate via requestAnimationFrame and
+   * do not register with the browser's Animation API. A GSAP-only page reads as [] here —
+   * that is a correct measurement of what getAnimations() can see, not a probe failure.
+   * Only CSS animations, CSS transitions (WAAPI path), and explicit WAAPI calls (including
+   * Framer Motion's WAAPI path) appear here.
+   */
+  animatedProperties: string[];
+  /**
+   * True when at least one stylesheet contains a @media (prefers-reduced-motion) block.
+   * False when the probe was not run or found no such block.
+   */
+  hasReducedMotion: boolean;
+  /**
+   * Scroll choreography sampled at 25%, 50%, 75%, 100% of viewport height.
+   * step: 1-indexed scroll step; fired: running animations at that position;
+   * entered: in-viewport elements with a non-zero transition or animation at that position.
+   * Empty when the probe was not run.
+   */
+  scrollChoreography: Array<{ step: number; fired: number; entered: number }>;
+}
+
+/**
+ * Live motion probe data attached to ir.meta.motion by probeMotion() in
+ * core/render/index.ts. Absent on IRs captured before this probe was added;
+ * all consuming code reads defensively (presence check before access).
+ *
+ * PROBE LIMIT: rAF-driven libraries (GSAP, Anime.js) animate via requestAnimationFrame
+ * and do not register with document.getAnimations(). Their effects are invisible to this
+ * probe — a GSAP-only page reports animatedProperties: []. Only CSS animations, CSS
+ * transitions exposed via WAAPI, and explicit WAAPI calls (Framer Motion's WAAPI path)
+ * are captured. This limit is surfaced in Invariants.animatedProperties.
+ */
+export interface MotionMeasurement {
+  /** Animation states sampled at t=0ms, t=500ms, t=1500ms after load. */
+  snapshots: Array<{
+    t: number;
+    animations: Array<{ duration: number; easing: string; properties: string[]; playState: string }>;
+  }>;
+  /** Union of all animated CSS properties across all snapshots, sorted. */
+  animatedProperties: string[];
+  /** True when at least one stylesheet has a @media (prefers-reduced-motion) block. */
+  hasReducedMotion: boolean;
+  /**
+   * Scroll-triggered choreography: per 25%vh step, animation count and animated-element
+   * count visible at that scroll position.
+   */
+  scrollChoreography: Array<{ step: number; fired: number; entered: number }>;
 }
 
 /**

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -325,6 +325,13 @@ eye reads those as the design system; an inline hex is reported as a defect, cor
 Typography comes from the reference type studies — a chosen scale and faces with a reason —
 never from defaults; motion durations and easing come from the motion study.
 
+**Before writing any animation code**, `omd:hand` writes `.omd/motion-spec.md` — a scene
+inventory that documents every animation the build will contain: trigger (load/scroll/hover),
+target selector, animated properties, duration and easing with a motion-study citation, and
+stagger. The build implements the spec and nothing else. An animation that does not appear
+in the spec does not ship. This is how "멋있는 애니메이션 넣어줘" resolves to a specific
+set of cited numbers rather than to 500ms ease-in-out from habit.
+
 The words are part of the build, and they are where generated work confesses first. The
 hand writes copy under two absolute rules: **the frame's language never appears on the
 page** (`omd check` measures this — five consecutive words shared with `.omd/` is
@@ -350,10 +357,16 @@ omd render <page> -o .omd/.cache/build-desktop.png --viewport 1280x800
 omd render <page> -o .omd/.cache/build-mobile.png  --viewport 375x812
 # Read both PNGs. Actually look at them.
 
+omd render <page> --filmstrip -o .omd/.cache/filmstrip.html --viewport 1280x800
+# Read the filmstrip HTML. Four to six frames at 300ms intervals: this is what the user
+# sees during load. The eye receives this alongside the static screenshots and can tell
+# what appeared when — something a static render cannot show.
+
 omd check  <page> --json           --viewport 1280x800   # deterministic findings, desktop
 omd check  <page> --json           --viewport 375x812    # deterministic findings, mobile
 omd check  <page> --category slop  --viewport 1280x800   # slop, desktop
 omd check  <page> --category slop  --viewport 375x812    # slop, mobile (hit-area fires here)
+omd check  <page> --category motion --viewport 1280x800  # motion: MOTION-NO-REDUCED, MOTION-LAYOUT-THRASH, MOTION-UNIFORM
 ```
 
 `omd check` computes contrast ratios, hit areas, spacing, token coverage, **and slop**. Never
@@ -405,10 +418,11 @@ omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come 
 
 Only when the copy is clean does the eye see the page.
 
-Finally spawn `omd:eye` on the built page. Hand it both the desktop and mobile screenshots
-and the combined findings from both viewport runs. It sees the renders and the findings and
-nothing about why you built it that way. It cannot defend your reasoning because it does not
-have it.
+Finally spawn `omd:eye` on the built page. Hand it the desktop screenshot, the mobile
+screenshot, the filmstrip, and the combined findings from all viewport runs (including
+motion). The filmstrip tells the eye what appeared when during load — information that a
+static render cannot carry. It sees the renders and the findings and nothing about why you
+built it that way. It cannot defend your reasoning because it does not have it.
 
 ---
 

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -163,6 +163,51 @@ instructions: |
   motion,components,craft,expressive}.md`. Read whichever file covers the gap, pull the
   relevant condition→choice→reason entry, and record it in `omd decision`.
 
+  ## Write the motion spec before building anything
+
+  Attribution.md does for colour and type what the motion spec does for animation. Before
+  writing any CSS transition or animation, write `.omd/motion-spec.md`. One scene per
+  block. The build implements the spec and nothing else — an animation not in the spec
+  does not ship.
+
+  Format — every field is required for every scene:
+
+  ```
+  ## Scene: hero entrance (trigger: load)
+  - Trigger: load
+  - Target: .hero h1, .hero p, .hero .cta
+  - Properties: opacity (0 → 1), transform (translateY(16px) → none)
+  - Duration: 280ms — motion-study-1 (stripe.com): measured 260–300ms entrance window
+  - Easing: cubic-bezier(0.0, 0.0, 0.2, 1) — motion-study-1: ease-out feel, measured
+  - Stagger: 60ms between siblings — theory/motion.md: 40–80ms is perceivable without theatrical delay
+
+  ## Scene: nav link hover (trigger: :hover)
+  - Trigger: :hover
+  - Target: nav a
+  - Properties: color, background-color
+  - Duration: 140ms — motion-study-1: hover feedback under 150ms reads as instant
+  - Easing: ease-out
+  - Stagger: none (single element)
+
+  ## Scene: section card entrance (trigger: scroll / IntersectionObserver)
+  - Trigger: scroll
+  - Target: .cards > .card
+  - Properties: opacity (0 → 1), transform (translateY(24px) → none)
+  - Duration: 320ms — motion-study-2 (linear.app): scroll entrances slightly slower than load
+  - Easing: cubic-bezier(0.2, 0.0, 0.0, 1.0) — motion-study-2: measured
+  - Stagger: 50ms per card
+  ```
+
+  If the board has no motion study, stop and report — the same rule as for typography.
+  The orchestrator will re-run scout with a motion-study requirement.
+
+  The spec is how you prove you did not reach for 500ms ease-in-out out of habit. Every
+  duration and easing must cite a board capture or a theory reference. `omd check
+  --category motion` will verify: MOTION-UNIFORM fires when every node shares one
+  duration and default keywords, MOTION-NO-REDUCED fires when the motion layer has no
+  prefers-reduced-motion accommodation, and MOTION-LAYOUT-THRASH fires when width/height/
+  top/left appear in transition-property.
+
   ## Framework detection
 
   Before writing a single file, read `package.json` in the working directory if it exists.

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -325,6 +325,13 @@ eye reads those as the design system; an inline hex is reported as a defect, cor
 Typography comes from the reference type studies — a chosen scale and faces with a reason —
 never from defaults; motion durations and easing come from the motion study.
 
+**Before writing any animation code**, `omd-hand` writes `.omd/motion-spec.md` — a scene
+inventory that documents every animation the build will contain: trigger (load/scroll/hover),
+target selector, animated properties, duration and easing with a motion-study citation, and
+stagger. The build implements the spec and nothing else. An animation that does not appear
+in the spec does not ship. This is how "멋있는 애니메이션 넣어줘" resolves to a specific
+set of cited numbers rather than to 500ms ease-in-out from habit.
+
 The words are part of the build, and they are where generated work confesses first. The
 hand writes copy under two absolute rules: **the frame's language never appears on the
 page** (`omd check` measures this — five consecutive words shared with `.omd/` is
@@ -350,10 +357,16 @@ omd render <page> -o .omd/.cache/build-desktop.png --viewport 1280x800
 omd render <page> -o .omd/.cache/build-mobile.png  --viewport 375x812
 # Read both PNGs. Actually look at them.
 
+omd render <page> --filmstrip -o .omd/.cache/filmstrip.html --viewport 1280x800
+# Read the filmstrip HTML. Four to six frames at 300ms intervals: this is what the user
+# sees during load. The eye receives this alongside the static screenshots and can tell
+# what appeared when — something a static render cannot show.
+
 omd check  <page> --json           --viewport 1280x800   # deterministic findings, desktop
 omd check  <page> --json           --viewport 375x812    # deterministic findings, mobile
 omd check  <page> --category slop  --viewport 1280x800   # slop, desktop
 omd check  <page> --category slop  --viewport 375x812    # slop, mobile (hit-area fires here)
+omd check  <page> --category motion --viewport 1280x800  # motion: MOTION-NO-REDUCED, MOTION-LAYOUT-THRASH, MOTION-UNIFORM
 ```
 
 `omd check` computes contrast ratios, hit areas, spacing, token coverage, **and slop**. Never
@@ -405,10 +418,11 @@ omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come 
 
 Only when the copy is clean does the eye see the page.
 
-Finally spawn `omd-eye` on the built page. Hand it both the desktop and mobile screenshots
-and the combined findings from both viewport runs. It sees the renders and the findings and
-nothing about why you built it that way. It cannot defend your reasoning because it does not
-have it.
+Finally spawn `omd-eye` on the built page. Hand it the desktop screenshot, the mobile
+screenshot, the filmstrip, and the combined findings from all viewport runs (including
+motion). The filmstrip tells the eye what appeared when during load — information that a
+static render cannot carry. It sees the renders and the findings and nothing about why you
+built it that way. It cannot defend your reasoning because it does not have it.
 
 ---
 

--- a/test/contamination-defense.test.ts
+++ b/test/contamination-defense.test.ts
@@ -15,6 +15,7 @@ const base: Invariants = {
   typeScale: [13, 14, 16, 21], fontFamilies: ['inter'], weightLadder: [400, 510],
   motionDurations: [100, 160], easingVocab: ['ease', 'ease-out'], animatedShare: 0.05,
   hoverCoverage: 0, focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 const distinct: Invariants = {
@@ -23,6 +24,7 @@ const distinct: Invariants = {
   typeScale: [16, 24, 48], fontFamilies: ['georgia'], weightLadder: [400, 700],
   motionDurations: [], easingVocab: [], animatedShare: 0,
   hoverCoverage: 0, focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 const ref: Reference = {

--- a/test/distance-regression.test.ts
+++ b/test/distance-regression.test.ts
@@ -19,6 +19,7 @@ const LINEAR: Invariants = {
   animatedShare: 0.05,
   hoverCoverage: 0,
   focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 const WARN = 0.6;
@@ -63,6 +64,7 @@ test('identity is exactly 1 and symmetry holds after the rewrite', () => {
     typeScale: [18, 30], fontFamilies: ['georgia'], weightLadder: [400, 700],
     motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   };
   assert.equal(similarity(LINEAR, other), similarity(other, LINEAR));
 });
@@ -73,6 +75,7 @@ test('an opposite design scores far below the threshold', () => {
     typeScale: [18, 30], fontFamilies: ['georgia'], weightLadder: [400, 700],
     motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   };
   assert.ok(similarity(LINEAR, opposite) < 0.3);
 });
@@ -107,6 +110,7 @@ test('empty ladders never yield NaN', () => {
     spacingLadder: [], radiusLadder: [], elevationLevels: 0, centeredRatio: 0, tokenCoverage: 1, paddingWeight: 0,
     typeScale: [], fontFamilies: [], weightLadder: [], motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   };
   for (const s of [similarity(LINEAR, empty), similarity(empty, LINEAR), similarity(empty, empty)]) {
     assert.ok(Number.isFinite(s) && s >= 0 && s <= 1);

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -1,0 +1,290 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { normalize } from '../core/ir/normalize.ts';
+import { loadRules, check } from '../core/rules/engine.ts';
+import { extractInvariants } from '../core/ref/invariants.ts';
+import { saveRef, loadRefs } from '../core/ref/store.ts';
+import type { Invariants, RawIr, RawNode, Reference } from '../core/types.ts';
+
+const BUILTIN_DIR = fileURLToPath(new URL('../core/rules/builtin/', import.meta.url)).replace(/\/$/, '');
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-motion-'));
+
+// Load only the motion rules to keep test assertions tight.
+const motionRules = loadRules(BUILTIN_DIR).filter((r) => r.category === 'motion');
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeIr(nodes: Partial<RawNode>[], meta?: Record<string, unknown>): ReturnType<typeof normalize> {
+  const full = nodes.map((n, i) => ({
+    id: `n${i}`,
+    name: 'div',
+    type: 'FRAME' as const,
+    path: `body/div${i}`,
+    parent: i === 0 ? null : 'n0',
+    box: { x: 0, y: 0, w: 100, h: 100 },
+    children: [],
+    ...n,
+  }));
+  return normalize({ nodes: full, meta } as RawIr);
+}
+
+// ── MOTION-NO-REDUCED ────────────────────────────────────────────────────────
+
+test('MOTION-NO-REDUCED fires when probe found live animations and hasReducedMotion is false', () => {
+  const ir = makeIr([{ parent: null }], {
+    motion: { animatedProperties: ['transform', 'opacity'], hasReducedMotion: false, scrollChoreography: [], snapshots: [] },
+  });
+  const v = check(ir, motionRules);
+  assert.ok(v.some((x) => x.id === 'MOTION-NO-REDUCED'), 'expected MOTION-NO-REDUCED to fire');
+});
+
+test('MOTION-NO-REDUCED does not fire when hasReducedMotion is true', () => {
+  const ir = makeIr([{ parent: null }], {
+    motion: { animatedProperties: ['transform'], hasReducedMotion: true, scrollChoreography: [], snapshots: [] },
+  });
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-REDUCED'));
+});
+
+test('MOTION-NO-REDUCED does not fire when ir.meta.motion is absent (pre-probe IR)', () => {
+  // Old refs captured before the motion probe was added have no ir.meta.motion.
+  const ir = makeIr([{ parent: null }]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-REDUCED'));
+});
+
+test('MOTION-NO-REDUCED does not fire when animatedProperties is empty (no live animations detected)', () => {
+  // A page with CSS transitions in stylesheets but none running at probe time reads as [].
+  const ir = makeIr([{ parent: null }], {
+    motion: { animatedProperties: [], hasReducedMotion: false, scrollChoreography: [], snapshots: [] },
+  });
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-REDUCED'));
+});
+
+// ── MOTION-LAYOUT-THRASH ─────────────────────────────────────────────────────
+
+test('MOTION-LAYOUT-THRASH fires when width is in transition properties', () => {
+  const ir = makeIr([{
+    motion: { durations: [300], animationNames: [], easings: ['ease'], properties: ['width'] },
+  }]);
+  const v = check(ir, motionRules);
+  assert.ok(v.some((x) => x.id === 'MOTION-LAYOUT-THRASH'), 'expected MOTION-LAYOUT-THRASH for width');
+});
+
+test('MOTION-LAYOUT-THRASH fires on all named layout properties', () => {
+  const layoutProps = ['height', 'top', 'right', 'bottom', 'left', 'margin', 'margin-top',
+    'margin-right', 'margin-bottom', 'margin-left', 'padding', 'padding-top',
+    'padding-right', 'padding-bottom', 'padding-left'];
+  for (const prop of layoutProps) {
+    const ir = makeIr([{
+      motion: { durations: [200], animationNames: [], easings: ['ease-out'], properties: [prop] },
+    }]);
+    const v = check(ir, motionRules);
+    assert.ok(v.some((x) => x.id === 'MOTION-LAYOUT-THRASH'), `expected MOTION-LAYOUT-THRASH for ${prop}`);
+  }
+});
+
+test('MOTION-LAYOUT-THRASH does not fire for transform and opacity', () => {
+  const ir = makeIr([{
+    motion: { durations: [160], animationNames: [], easings: ['ease-out'], properties: ['transform', 'opacity'] },
+  }]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-LAYOUT-THRASH'));
+});
+
+test('MOTION-LAYOUT-THRASH does not fire when motion.properties is absent (no named transition-property)', () => {
+  // A node with motion durations but no properties array — e.g. transition-property: all
+  // was excluded from the extraction because it is not a specific named property.
+  const ir = makeIr([{
+    motion: { durations: [160], animationNames: [], easings: ['ease-out'] },
+  }]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-LAYOUT-THRASH'));
+});
+
+// ── MOTION-UNIFORM ───────────────────────────────────────────────────────────
+
+test('MOTION-UNIFORM fires when 3+ animated nodes share one duration and only default easings', () => {
+  // 500ms ease-in-out everywhere — the canonical generated-work signature.
+  const ir = makeIr([
+    { parent: null },
+    { motion: { durations: [500], animationNames: [], easings: ['ease-in-out'] } },
+    { motion: { durations: [500], animationNames: [], easings: ['ease-in-out'] } },
+    { motion: { durations: [500], animationNames: [], easings: ['ease-in-out'] } },
+  ]);
+  const v = check(ir, motionRules);
+  assert.ok(v.some((x) => x.id === 'MOTION-UNIFORM'), 'expected MOTION-UNIFORM to fire');
+});
+
+test('MOTION-UNIFORM does not fire when durations vary', () => {
+  const ir = makeIr([
+    { parent: null },
+    { motion: { durations: [160], animationNames: [], easings: ['ease-out'] } },
+    { motion: { durations: [280], animationNames: [], easings: ['ease-out'] } },
+    { motion: { durations: [400], animationNames: [], easings: ['ease-out'] } },
+  ]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-UNIFORM'));
+});
+
+test('MOTION-UNIFORM does not fire when a cubic-bezier is in the easing vocabulary', () => {
+  // A measured easing curve breaks the "only defaults" condition.
+  const ir = makeIr([
+    { parent: null },
+    { motion: { durations: [500], animationNames: [], easings: ['cubic-bezier(0.2,0,0,1)'] } },
+    { motion: { durations: [500], animationNames: [], easings: ['cubic-bezier(0.2,0,0,1)'] } },
+    { motion: { durations: [500], animationNames: [], easings: ['cubic-bezier(0.2,0,0,1)'] } },
+  ]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-UNIFORM'));
+});
+
+test('MOTION-UNIFORM does not fire with only 2 animated nodes', () => {
+  // The rule requires at least 3 — two nodes sharing a duration is not a pattern.
+  const ir = makeIr([
+    { parent: null },
+    { motion: { durations: [500], animationNames: [], easings: ['ease-in-out'] } },
+    { motion: { durations: [500], animationNames: [], easings: ['ease-in-out'] } },
+  ]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-UNIFORM'));
+});
+
+test('MOTION-UNIFORM does not fire when mixed easings include a non-default keyword', () => {
+  // step-start and step-end are in the default set; a real cubic-bezier is not.
+  const ir = makeIr([
+    { parent: null },
+    { motion: { durations: [300], animationNames: [], easings: ['ease-out'] } },
+    { motion: { durations: [300], animationNames: [], easings: ['ease-out', 'cubic-bezier(0.4,0,0.2,1)'] } },
+    { motion: { durations: [300], animationNames: [], easings: ['ease-out'] } },
+  ]);
+  const v = check(ir, motionRules);
+  assert.ok(!v.some((x) => x.id === 'MOTION-UNIFORM'));
+});
+
+// ── Invariants: new fields from ir.meta.motion ───────────────────────────────
+
+test('extractInvariants reads animatedProperties and hasReducedMotion from ir.meta.motion', () => {
+  const ir = makeIr([{ parent: null }], {
+    motion: {
+      animatedProperties: ['opacity', 'transform'],
+      hasReducedMotion: true,
+      scrollChoreography: [{ step: 1, fired: 2, entered: 3 }],
+      snapshots: [],
+    },
+  });
+  const inv = extractInvariants(ir);
+  assert.deepEqual(inv.animatedProperties, ['opacity', 'transform']);
+  assert.equal(inv.hasReducedMotion, true);
+  assert.equal(inv.scrollChoreography.length, 1);
+  assert.equal(inv.scrollChoreography[0]?.fired, 2);
+  assert.equal(inv.scrollChoreography[0]?.entered, 3);
+});
+
+test('extractInvariants returns safe defaults when ir.meta.motion is absent (pre-probe IR)', () => {
+  const ir = makeIr([{ parent: null }]);
+  const inv = extractInvariants(ir);
+  assert.deepEqual(inv.animatedProperties, []);
+  assert.equal(inv.hasReducedMotion, false);
+  assert.deepEqual(inv.scrollChoreography, []);
+});
+
+test('extractInvariants sorts animatedProperties for stable output', () => {
+  const ir = makeIr([{ parent: null }], {
+    motion: {
+      animatedProperties: ['transform', 'color', 'opacity'],
+      hasReducedMotion: false,
+      scrollChoreography: [],
+      snapshots: [],
+    },
+  });
+  const inv = extractInvariants(ir);
+  assert.deepEqual(inv.animatedProperties, ['color', 'opacity', 'transform']);
+});
+
+// ── Backward compat: loadRefs handles old refs without motion probe fields ───
+
+test('loadRefs backfills new motion fields on references saved before the probe was added', () => {
+  const dir = project();
+  // Simulate an old ref: Invariants object without animatedProperties/hasReducedMotion/scrollChoreography.
+  const oldRef: Reference = {
+    source: 'https://example.com',
+    component: 'page',
+    kind: 'page',
+    capturedAt: '2024-01-01T00:00:00.000Z',
+    invariants: {
+      spacingLadder: [4, 8],
+      radiusLadder: [4],
+      elevationLevels: 1,
+      centeredRatio: 0,
+      tokenCoverage: 0.5,
+      paddingWeight: 8,
+      typeScale: [14, 16],
+      fontFamilies: ['inter'],
+      weightLadder: [400],
+      motionDurations: [160],
+      easingVocab: ['ease-out'],
+      animatedShare: 0.1,
+      hoverCoverage: 0,
+      focusCoverage: 0,
+      // animatedProperties, hasReducedMotion, scrollChoreography intentionally absent
+    } as Invariants,
+    principles: [],
+  };
+  saveRef(dir, oldRef);
+  const [loaded] = loadRefs(dir);
+  assert.ok(loaded, 'reference should load without error');
+  assert.deepEqual(loaded?.invariants?.animatedProperties, [], 'animatedProperties backfilled to []');
+  assert.equal(loaded?.invariants?.hasReducedMotion, false, 'hasReducedMotion backfilled to false');
+  assert.deepEqual(loaded?.invariants?.scrollChoreography, [], 'scrollChoreography backfilled to []');
+});
+
+test('loadRefs preserves existing motion probe fields if present', () => {
+  const dir = project();
+  const newRef: Reference = {
+    source: 'https://example.com',
+    component: 'page',
+    kind: 'page',
+    capturedAt: '2025-01-01T00:00:00.000Z',
+    invariants: {
+      spacingLadder: [4, 8],
+      radiusLadder: [4],
+      elevationLevels: 1,
+      centeredRatio: 0,
+      tokenCoverage: 0.5,
+      paddingWeight: 8,
+      typeScale: [14, 16],
+      fontFamilies: ['inter'],
+      weightLadder: [400],
+      motionDurations: [160],
+      easingVocab: ['ease-out'],
+      animatedShare: 0.1,
+      hoverCoverage: 0.8,
+      focusCoverage: 0.9,
+      animatedProperties: ['opacity', 'transform'],
+      hasReducedMotion: true,
+      scrollChoreography: [{ step: 1, fired: 3, entered: 5 }],
+    },
+    principles: [],
+  };
+  saveRef(dir, newRef);
+  const [loaded] = loadRefs(dir);
+  assert.deepEqual(loaded?.invariants?.animatedProperties, ['opacity', 'transform']);
+  assert.equal(loaded?.invariants?.hasReducedMotion, true);
+  assert.equal(loaded?.invariants?.scrollChoreography?.[0]?.fired, 3);
+});
+
+// ── motion probe browser path coverage note ──────────────────────────────────
+//
+// probeMotion() in core/render/index.ts requires a real browser (Playwright). Its
+// browser path is covered by the integration tests in test/ref-granularity.test.ts,
+// which run `omd ref add` against a real HTML fixture — the same path that calls
+// extractIr() → probeMotion(). That test does not assert on motion-specific fields
+// because slop.html has no CSS animations; the probe runs and returns an empty result.
+// The pure parts (invariants extraction, rule evaluation, backward compat) are covered
+// by the unit tests above.

--- a/test/principles.test.ts
+++ b/test/principles.test.ts
@@ -19,6 +19,7 @@ const ref = (): Reference => ({
     spacingLadder: [4, 8], radiusLadder: [4, 8], elevationLevels: 3, centeredRatio: 0.09, tokenCoverage: 0.7, paddingWeight: 10,
     typeScale: [14, 16], fontFamilies: ['inter'], weightLadder: [400], motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   },
   principles: [],
 });

--- a/test/ref-granularity.test.ts
+++ b/test/ref-granularity.test.ts
@@ -110,6 +110,7 @@ const INV: Invariants = {
   typeScale: [14, 16], fontFamilies: ['inter'], weightLadder: [400, 600],
   motionDurations: [150], easingVocab: ['ease-out'], animatedShare: 0.04,
   hoverCoverage: 0, focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 test('distances skips unmeasured references rather than scoring them zero', () => {

--- a/test/reference.test.ts
+++ b/test/reference.test.ts
@@ -124,6 +124,7 @@ const base: Invariants = {
   typeScale: [13, 14, 16, 21], fontFamilies: ['inter'], weightLadder: [400, 510],
   motionDurations: [100, 160], easingVocab: ['ease', 'ease-out'], animatedShare: 0.05,
   hoverCoverage: 0, focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 test('a page identical to a reference scores 1', () => {
@@ -136,6 +137,7 @@ test('similarity is symmetric and bounded to 0..1', () => {
     typeScale: [16, 24, 32], fontFamilies: ['georgia'], weightLadder: [400, 700],
     motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   };
   const ab = similarity(base, other);
   assert.equal(ab, similarity(other, base));
@@ -157,6 +159,7 @@ test('copying spacing and radius plus type scores higher than copying spacing an
     typeScale: [16, 24, 32], fontFamilies: ['georgia'], weightLadder: [400, 700],
     motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   };
   const spacingRadiusOnly: Invariants = { ...opposite, spacingLadder: base.spacingLadder, radiusLadder: base.radiusLadder };
   const spacingRadiusType: Invariants = {
@@ -173,6 +176,7 @@ test('an empty ladder never divides by zero', () => {
     spacingLadder: [], radiusLadder: [], elevationLevels: 0, centeredRatio: 0, tokenCoverage: 1, paddingWeight: 0,
     typeScale: [], fontFamilies: [], weightLadder: [], motionDurations: [], easingVocab: [], animatedShare: 0,
     hoverCoverage: 0, focusCoverage: 0,
+    animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
   };
   const s = similarity(base, empty);
   assert.ok(Number.isFinite(s) && s >= 0 && s <= 1);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -16,7 +16,7 @@ test('loadRules reads every builtin rule and validates required fields', () => {
     }
     assert.ok(['error', 'warn'].includes(r.severity));
     assert.ok([1, 2].includes(r.layer));
-    assert.ok(['a11y', 'system', 'slop'].includes(r.category));
+    assert.ok(['a11y', 'system', 'slop', 'motion'].includes(r.category));
   }
 });
 

--- a/test/signal.test.ts
+++ b/test/signal.test.ts
@@ -29,6 +29,7 @@ const LINEAR: Invariants = {
   animatedShare: 0.05,
   hoverCoverage: 0.75,
   focusCoverage: 0.8,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 /** danluu.com-shaped: almost no design decisions of any kind. */
@@ -47,6 +48,7 @@ const DANLUU: Invariants = {
   animatedShare: 0,
   hoverCoverage: 0,
   focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
 };
 
 test('a danluu-shaped page scores low and names what is missing', () => {


### PR DESCRIPTION
Plan.md item #11 (11a/11b/11c). 222→241 tests. MOTION-SLOW-HOVER dropped rather than faked (hover durations indistinguishable in aggregate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)