### PR TITLE
Batch E — capture resilience, site drift check, clean-board replacement contract

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -165,6 +165,62 @@ the concept requires.
 Every reference gets one line: why it is here, against the concept. If you cannot
 justify it, drop it.
 
+## Blocked sites: demote, don't retry
+
+`omd ref add` throws a blocked-page error when it detects a Cloudflare interstitial,
+HTTP 403/5xx, or near-empty body (< 200 visible chars). When this happens:
+
+- Do **not** retry the same URL. A site that blocks headless browsers once will block
+  again, and a retry loop is how the scout stalls without making progress.
+- Demote the URL to `--image` if you can construct useful reasoning from what you know
+  about the site's reputation and design choices without capturing its DOM. An `--image`
+  capture that honestly notes "blocked; principles from public discourse only" is more
+  honest than a hollow IR.
+- If you cannot construct useful reasoning — the site is unknown or too generic to
+  reason about without seeing it — discard it and advance to the next candidate.
+- A blocked site does not leave a slot empty. Either the `--image` demoted capture fills
+  the slot, or the replacement obligation (see below) requires a new search.
+
+## Rejection obligates replacement
+
+Every rejected capture — whether rejected for slop contamination, low signal, kinship,
+blocked access, or inadequate principles — leaves a gap in the board's composition
+contract. **That gap must be filled.** The board is made of what passed, not of what was
+available.
+
+When you reject a capture, the next action is a replacement search, not a note that the
+slot is empty. The replacement search must differ in two ways:
+
+1. **Different query.** The original query found a problematic candidate; a variant of
+   the same query will likely find the same pool. Search from a different angle: if the
+   first query was a craft query, try a domain query; if it was a competitor query, try
+   a theory query.
+2. **Different source tier.** If the rejected capture came from tier 4 (anonymous search
+   result), search tier 3 (personal portfolios) or higher. If it came from tier 3, try
+   tier 2 (live product pages) or tier 1 (human-juried curation). Moving up the trust
+   hierarchy is not optional — the rejection signal is evidence that the tier you were
+   searching was producing contaminated results.
+
+The scout does not stop until every slot in the composition contract is filled with a
+capture that passed:
+
+- **Whole pages (3–4)**: all `slopCount < 2`, all from tier 2 or above, or tier 3/4
+  with `slopCount = 0` and a named, specific design decision.
+- **Components (one per inventory item)**: clean capture with a tight selector.
+- **Typography studies (minimum 2)**: from different registers; principles name why the
+  pairing works.
+- **Motion studies (minimum 2, 4 when the brief implies animation)**: from different
+  domains; motionDurations and easingVocab were actually read.
+- **Voice study (minimum 1)**: a real product, not a template. Copy checked against
+  SLOP-COPY / SLOP-COPY-KO before the study is considered collected.
+- **Community references (minimum 2)**: `--image`, unmeasurable, from real discourse —
+  not listicles.
+
+Anti-references — captures kept explicitly to document what to avoid — do **not** count
+toward this floor. A board of eighteen anti-references is a board of zero references.
+The composition contract is satisfied only by captures that passed, and the scout does
+not stop until the slots are filled.
+
 ## Slop-contaminated captures do not go on the board
 
 `omd ref add` now prints two quality checks: a design-signal score and a slop finding
@@ -177,6 +233,8 @@ may only be kept as an explicitly-stated anti-reference: one that is on the boar
 uses the indigo-violet gradient and triple feature cards — both patterns to reject" is
 a legitimate anti-reference. Dropping it entirely is also correct. Treating it as a
 positive reference is not: you would be training the build on the mean.
+
+Rejection for slop triggers the replacement obligation above.
 
 ## Low-signal pages do not count
 

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -34,6 +34,8 @@ interface Opts {
   selector?: string;
   image?: boolean;
   filmstrip?: boolean;
+  /** Directory of pages for cross-page site consistency check (`omd check --site <dir>`). */
+  site?: string;
 }
 
 const FLAGS = new Set(['json', 'no-log', 'image', 'filmstrip']);
@@ -98,7 +100,92 @@ async function cmdRender(opts: Opts): Promise<never> {
   process.exit(0);
 }
 
+/**
+ * Cross-page site consistency check: `omd check --site <dir>`.
+ *
+ * Loads every .html file (and .json IR cache) in the given directory, extracts
+ * IR for each page, compares their design ladders and token coverage, and warns
+ * when pages disagree. The comparison logic (checkSite) is pure; only the
+ * extraction here touches the browser.
+ *
+ * CLI shape: `omd check --site ./dist` — all .html files in the directory.
+ *            Multiple positional args also work: `omd check a.html b.html`
+ *            (when --site is absent and opts._ has ≥2 entries).
+ */
+async function cmdCheckSite(opts: Opts): Promise<never> {
+  const { normalize } = await import('../core/ir/normalize.ts');
+  const { extractInvariants } = await import('../core/ref/invariants.ts');
+  const { checkSite } = await import('../core/site/index.ts');
+  const { extractIr, parseViewport } = await import('../core/render/index.ts');
+
+  // Resolve the list of page paths: either --site <dir> (glob all HTML files)
+  // or multiple positional args.
+  let pagePaths: string[] = [];
+  if (opts.site) {
+    const dir = resolve(opts.site);
+    const { readdirSync: rds } = await import('node:fs');
+    try {
+      pagePaths = rds(dir)
+        .filter((f) => f.endsWith('.html') || f.endsWith('.htm'))
+        .map((f) => join(dir, f))
+        .sort();
+    } catch (e) {
+      console.error(`cannot read directory: ${opts.site} — ${e instanceof Error ? e.message : String(e)}`);
+      process.exit(1);
+    }
+    if (pagePaths.length === 0) {
+      console.error(`no .html files found in: ${opts.site}`);
+      process.exit(1);
+    }
+  } else {
+    // Multiple positional args
+    pagePaths = opts._.map((p) => resolve(p));
+  }
+
+  if (pagePaths.length < 2) {
+    console.error('--site requires at least 2 pages to compare; use `omd check <page>` for a single-page check');
+    process.exit(1);
+  }
+
+  const viewport = parseViewport(opts.viewport);
+
+  const pages: Array<{ path: string; invariants: import('../core/types.ts').Invariants; tokens?: Record<string, string> }> = [];
+  for (const pagePath of pagePaths) {
+    try {
+      const raw = await extractIr(pagePath, { viewport, selector: null });
+      const ir = normalize(raw);
+      const invariants = extractInvariants(ir);
+      pages.push({ path: pagePath, invariants, ...(raw.tokens ? { tokens: raw.tokens } : {}) });
+      console.error(`  extracted: ${pagePath} (${ir.nodes.length} nodes)`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`  skipped: ${pagePath} — ${msg}`);
+    }
+  }
+
+  if (pages.length < 2) {
+    console.error('fewer than 2 pages extracted successfully — cannot compare');
+    process.exit(1);
+  }
+
+  const violations = checkSite(pages);
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(violations));
+  } else {
+    for (const v of violations) {
+      console.log(`[${v.severity}] ${v.id}: ${v.message}`);
+    }
+    if (violations.length === 0) console.log('ok — no cross-page drift detected');
+  }
+
+  process.exit(violations.length > 0 ? 1 : 0);
+}
+
 async function cmdCheck(opts: Opts): Promise<never> {
+  // Route to site-wide consistency check when --site is present or ≥2 positional args given.
+  if (opts.site || opts._.length >= 2) return cmdCheckSite(opts);
+
   const { normalize } = await import('../core/ir/normalize.ts');
   const { loadRules, check } = await import('../core/rules/engine.ts');
 
@@ -473,6 +560,8 @@ function usage(): never {
     + '  render <page> -o shot.png [--viewport WxH]  headless screenshot\n'
     + '  render <page> --filmstrip -o f.html [--viewport WxH]  load-time filmstrip\n'
     + '  check [<page>|--ir f] [--json] [--category slop] [--no-log]\n'
+    + '  check --site <dir>                          cross-page consistency (SITE-*)\n'
+    + '  check <page1> <page2> ...                   same, multi-page positional\n'
     + '  coach                                        trends across `omd check` history\n'
     + '\n'
     + '  frame show\n'

--- a/core/render/index.ts
+++ b/core/render/index.ts
@@ -6,6 +6,93 @@ import type { MotionMeasurement, RawIr } from '../types.ts';
 
 const MAX_NODES = 4000;
 
+// ── Block detection ─────────────────────────────────────────────────────────
+
+/**
+ * Thrown by extractIr when the page is behind a bot-challenge or is otherwise
+ * unreachable. Callers (CLI, scout) should not retry the same URL — demote to
+ * `--image` or advance to the next candidate.
+ */
+export class BlockedPageError extends Error {
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`blocked page: ${reason}`);
+    this.name = 'BlockedPageError';
+    this.reason = reason;
+  }
+}
+
+/** Challenge-page title patterns that indicate bot/Cloudflare/WAF blocking. */
+const CHALLENGE_TITLE_PATTERNS: RegExp[] = [
+  /^just a moment/i,
+  /^attention required/i,
+  /^access denied/i,
+  /^ddos.{0,20}protection/i,
+  /^please (verify|wait)/i,
+  /^security check/i,
+  /^cloudflare/i,
+  /^are you (a )?human/i,
+  /^checking your browser/i,
+  /^one more step/i,
+  /^403\b/,
+  /^error\s+403\b/i,
+  /^(503|502|500)\b/,
+];
+
+/**
+ * Pure heuristic, fully testable without a browser.
+ *
+ * Returns the block reason string when the signals indicate a bot-challenge or
+ * hollow page; returns null when the page looks valid.
+ *
+ * Rules, in order:
+ *   1. HTTP 403 or any 5xx → explicitly blocked or server error
+ *   2. Challenge-page title → Cloudflare / WAF interstitial
+ *   3. Near-empty body (< 200 visible chars) → hollow IR — nothing to measure
+ */
+export function detectBlockReason(
+  title: string,
+  bodyTextLength: number,
+  httpStatus: number | null,
+): string | null {
+  if (httpStatus !== null && (httpStatus === 403 || httpStatus >= 500)) {
+    return `HTTP ${httpStatus}`;
+  }
+  for (const pattern of CHALLENGE_TITLE_PATTERNS) {
+    if (pattern.test(title.trim())) {
+      return `challenge page: "${title.trim()}"`;
+    }
+  }
+  if (bodyTextLength < 200) {
+    return `near-empty body (${bodyTextLength} visible chars)`;
+  }
+  return null;
+}
+
+/**
+ * Evaluates the loaded page inside Playwright and throws BlockedPageError when
+ * blocked. Called inside withPage after navigation; never throws for probe
+ * failures (those are caught locally so capture can continue best-effort).
+ *
+ * Block detection is only meaningful for live HTTP/HTTPS targets. A file://
+ * URL cannot be challenged by Cloudflare and may have minimal body text by
+ * design (a fixture page is often all CSS, no prose). Skip all checks for
+ * local files so test fixtures are never falsely flagged.
+ */
+async function assertNotBlocked(
+  page: import('playwright').Page,
+  httpStatus: number | null,
+  resolvedUrl: string,
+): Promise<void> {
+  if (resolvedUrl.startsWith('file:')) return; // local files are never bot-challenged
+  const title = await page.title().catch(() => '');
+  const bodyTextLength = await page
+    .evaluate(() => (document.body?.innerText?.trim() ?? '').length)
+    .catch(() => 999); // can't measure → assume valid so capture still runs
+  const reason = detectBlockReason(title, bodyTextLength, httpStatus);
+  if (reason !== null) throw new BlockedPageError(reason);
+}
+
 export interface Viewport { width: number; height: number }
 
 function toUrl(target: string): string {
@@ -15,13 +102,19 @@ function toUrl(target: string): string {
   return pathToFileURL(path).href;
 }
 
-async function withPage<T>(target: string, viewport: Viewport, fn: (page: import('playwright').Page) => Promise<T>): Promise<T> {
+async function withPage<T>(
+  target: string,
+  viewport: Viewport,
+  fn: (page: import('playwright').Page, httpStatus: number | null, resolvedUrl: string) => Promise<T>,
+): Promise<T> {
   const { chromium } = await import('playwright');
   const browser = await chromium.launch();
   try {
     const page = await browser.newPage({ viewport });
-    await page.goto(toUrl(target), { waitUntil: 'networkidle' });
-    return await fn(page);
+    const resolvedUrl = toUrl(target);
+    const response = await page.goto(resolvedUrl, { waitUntil: 'networkidle' });
+    const httpStatus = response?.status() ?? null;
+    return await fn(page, httpStatus, resolvedUrl);
   } finally {
     await browser.close();
   }
@@ -34,7 +127,7 @@ export function parseViewport(s = '390x844'): Viewport {
 }
 
 export function renderPage(target: string, opts: { viewport: Viewport; out: string }): Promise<string> {
-  return withPage(target, opts.viewport, async (page) => {
+  return withPage(target, opts.viewport, async (page, _httpStatus, _resolvedUrl) => {
     await page.screenshot({ path: opts.out, fullPage: true });
     return opts.out;
   });
@@ -281,7 +374,7 @@ export async function renderFilmstrip(
   const dir = dirname(resolve(base));
   const name = basename(base);
 
-  return withPage(target, opts.viewport, async (page) => {
+  return withPage(target, opts.viewport, async (page, _httpStatus, _resolvedUrl) => {
     mkdirSync(dir, { recursive: true });
     const framePaths: string[] = [];
 
@@ -319,7 +412,13 @@ export async function renderFilmstrip(
 }
 
 export function extractIr(target: string, opts: { viewport: Viewport; selector?: string | null }): Promise<RawIr> {
-  return withPage(target, opts.viewport, async (page) => {
+  return withPage(target, opts.viewport, async (page, httpStatus, resolvedUrl) => {
+    // Fail fast on blocked/challenge pages before attempting DOM extraction.
+    // A blocked page produces a hollow IR (no tokens, near-empty nodes) that
+    // silently scores low signal — the tool reports the wrong cause. Better to
+    // name it here and let the caller (scout, CLI) choose the fallback.
+    await assertNotBlocked(page, httpStatus, resolvedUrl);
+
     // Node strips the types, so toString() yields runnable JS for the browser.
     const raw = await page.evaluate(
       `(${extractInPage.toString()})(${MAX_NODES}, ${JSON.stringify(opts.selector ?? null)})`,

--- a/core/site/index.ts
+++ b/core/site/index.ts
@@ -1,0 +1,100 @@
+import type { Invariants } from '../types.ts';
+
+/**
+ * A cross-page consistency finding. Not a per-node violation — these have no
+ * single node to anchor to. The `pages` array names every page involved.
+ */
+export interface SiteViolation {
+  id: 'SITE-TOKEN-DRIFT' | 'SITE-LADDER-DRIFT';
+  severity: 'warn';
+  /** All page paths involved in the comparison. */
+  pages: string[];
+  message: string;
+}
+
+/**
+ * One page's extracted data for site-level comparison.
+ *
+ * `invariants` must already be extracted (via extractInvariants in
+ * core/ref/invariants.ts). Keeping the comparison logic pure — no Ir, no
+ * browser — lets it be tested against synthetic fixtures without Playwright.
+ *
+ * `tokens` is the raw token map from RawIr.tokens (CSS custom property names
+ * → values). Absent for pages loaded from pre-computed IR files that pre-date
+ * the tokens field; treated as an empty set in that case.
+ */
+export interface SitePage {
+  path: string;
+  invariants: Invariants;
+  tokens?: Record<string, string>;
+}
+
+/**
+ * Cross-page consistency check. Pure function: no filesystem, no browser.
+ *
+ * SITE-LADDER-DRIFT fires when any of the three design ladders (type scale,
+ * spacing, radius) has a step count that differs by more than one across pages.
+ * A difference of one step is tolerated — a detail page may legitimately use
+ * one fewer text size than the index. A difference of two or more means the
+ * pages were built from different scales.
+ *
+ * SITE-TOKEN-DRIFT fires when token coverage varies by more than 0.3 across
+ * pages. Token coverage is the fraction of tokenable nodes (fill, radius) that
+ * cite a CSS custom property rather than an inline value. A page at 0.9 and
+ * another at 0.1 were built from different design-system disciplines.
+ *
+ * Returns an empty array for a single page — a site has no cross-page
+ * comparison to make.
+ */
+export function checkSite(pages: SitePage[]): SiteViolation[] {
+  if (pages.length < 2) return [];
+
+  const violations: SiteViolation[] = [];
+  const allPaths = pages.map((p) => p.path);
+
+  // ── Ladder drift ────────────────────────────────────────────────────────────
+
+  const ladderChecks: Array<{ name: string; get: (inv: Invariants) => number[] }> = [
+    { name: 'type scale', get: (inv) => inv.typeScale },
+    { name: 'spacing ladder', get: (inv) => inv.spacingLadder },
+    { name: 'radius ladder', get: (inv) => inv.radiusLadder },
+  ];
+
+  for (const { name, get } of ladderChecks) {
+    const entries = pages.map((p) => ({ path: p.path, steps: get(p.invariants).length }));
+    const stepCounts = entries.map((e) => e.steps);
+    const min = Math.min(...stepCounts);
+    const max = Math.max(...stepCounts);
+
+    if (max - min > 1) {
+      const detail = entries.map((e) => `${e.path}: ${e.steps}`).join(', ');
+      violations.push({
+        id: 'SITE-LADDER-DRIFT',
+        severity: 'warn',
+        pages: allPaths,
+        message: `${name} step count disagrees across pages (${detail})`,
+      });
+    }
+  }
+
+  // ── Token-coverage drift ────────────────────────────────────────────────────
+
+  const coverages = pages.map((p) => p.invariants.tokenCoverage);
+  const minCoverage = Math.min(...coverages);
+  const maxCoverage = Math.max(...coverages);
+
+  // Round to 4dp before comparing to avoid 0.9 - 0.6 = 0.30000000000000004 false-positives.
+  if (Math.round((maxCoverage - minCoverage) * 10000) / 10000 > 0.3) {
+    const detail = pages
+      .map((p) => `${p.path}: ${p.invariants.tokenCoverage.toFixed(2)}`)
+      .join(', ');
+    violations.push({
+      id: 'SITE-TOKEN-DRIFT',
+      severity: 'warn',
+      pages: allPaths,
+      message: `token coverage varies by ${(maxCoverage - minCoverage).toFixed(2)} across pages (${detail})`,
+    });
+  }
+
+  return violations;
+}

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -57,6 +57,19 @@ for `.omd/attribution.md`: the hand traces each token decision back to a named c
 without this line, the attribution table has no origin to cite. `omd ref add` prints a
 design-signal score; a page under 0.4 does not count toward the floor.
 
+**Rejection obligates replacement.** When a capture is rejected — for slop (2+ findings),
+for low signal, for kinship, for a blocked-page error — it does not leave a hole. The
+board is made of what passed, not of what was available. Every rejected capture triggers a
+replacement search: a different query from a different angle, a source tier at least one
+step higher in the trust hierarchy. The scout does not stop until every slot in the
+composition contract is filled with a capture that passed. Anti-references — captures kept
+to document what to avoid — do not count toward the floor: their value is in the warning
+they carry, not the slot they occupy.
+
+When `omd ref add` throws a blocked-page error, the URL is not retried. Demote to
+`--image` if you can construct honest reasoning from public discourse about the site; if
+not, discard and run the replacement search.
+
 **Never describe how a reference looks** (Jansson & Smith: shown an example, designers
 reproduce its features even after the flaws are flagged; a model is worse). Numbers and
 reasons only. The board lands in `.omd/refs/` and any later `omd:ultradesign` run picks it

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -452,6 +452,20 @@ step 4.**
 
 ## 8. Ship, then explain
 
+**When the build produced more than one page**, run `omd check --site <dir>` on the
+output directory before shipping. A blog and its index, a landing page and its docs page,
+a dashboard and its empty state — pages built together should read as one design system.
+`SITE-LADDER-DRIFT` fires when one page carries a 4-step type scale and another a 6-step
+one; `SITE-TOKEN-DRIFT` fires when one page uses design tokens throughout and another
+falls back to inline values. Either finding means the pages were not built from the same
+set of decisions, and the user will feel that drift before they can name it.
+
+```bash
+omd check --site ./dist   # or pass the pages explicitly: omd check index.html post.html
+```
+
+If violations appear, fix the drifting page before shipping.
+
 Deliver the working site. Then, in a short paragraph — not a report — tell the user:
 
 - what you decided the problem actually was, and what evidence pointed there

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -176,6 +176,62 @@ instructions: |
   Every reference gets one line: why it is here, against the concept. If you cannot
   justify it, drop it.
 
+  ## Blocked sites: demote, don't retry
+
+  `omd ref add` throws a blocked-page error when it detects a Cloudflare interstitial,
+  HTTP 403/5xx, or near-empty body (< 200 visible chars). When this happens:
+
+  - Do **not** retry the same URL. A site that blocks headless browsers once will block
+    again, and a retry loop is how the scout stalls without making progress.
+  - Demote the URL to `--image` if you can construct useful reasoning from what you know
+    about the site's reputation and design choices without capturing its DOM. An `--image`
+    capture that honestly notes "blocked; principles from public discourse only" is more
+    honest than a hollow IR.
+  - If you cannot construct useful reasoning — the site is unknown or too generic to
+    reason about without seeing it — discard it and advance to the next candidate.
+  - A blocked site does not leave a slot empty. Either the `--image` demoted capture fills
+    the slot, or the replacement obligation (see below) requires a new search.
+
+  ## Rejection obligates replacement
+
+  Every rejected capture — whether rejected for slop contamination, low signal, kinship,
+  blocked access, or inadequate principles — leaves a gap in the board's composition
+  contract. **That gap must be filled.** The board is made of what passed, not of what was
+  available.
+
+  When you reject a capture, the next action is a replacement search, not a note that the
+  slot is empty. The replacement search must differ in two ways:
+
+  1. **Different query.** The original query found a problematic candidate; a variant of
+     the same query will likely find the same pool. Search from a different angle: if the
+     first query was a craft query, try a domain query; if it was a competitor query, try
+     a theory query.
+  2. **Different source tier.** If the rejected capture came from tier 4 (anonymous search
+     result), search tier 3 (personal portfolios) or higher. If it came from tier 3, try
+     tier 2 (live product pages) or tier 1 (human-juried curation). Moving up the trust
+     hierarchy is not optional — the rejection signal is evidence that the tier you were
+     searching was producing contaminated results.
+
+  The scout does not stop until every slot in the composition contract is filled with a
+  capture that passed:
+
+  - **Whole pages (3–4)**: all `slopCount < 2`, all from tier 2 or above, or tier 3/4
+    with `slopCount = 0` and a named, specific design decision.
+  - **Components (one per inventory item)**: clean capture with a tight selector.
+  - **Typography studies (minimum 2)**: from different registers; principles name why the
+    pairing works.
+  - **Motion studies (minimum 2, 4 when the brief implies animation)**: from different
+    domains; motionDurations and easingVocab were actually read.
+  - **Voice study (minimum 1)**: a real product, not a template. Copy checked against
+    SLOP-COPY / SLOP-COPY-KO before the study is considered collected.
+  - **Community references (minimum 2)**: `--image`, unmeasurable, from real discourse —
+    not listicles.
+
+  Anti-references — captures kept explicitly to document what to avoid — do **not** count
+  toward this floor. A board of eighteen anti-references is a board of zero references.
+  The composition contract is satisfied only by captures that passed, and the scout does
+  not stop until the slots are filled.
+
   ## Slop-contaminated captures do not go on the board
 
   `omd ref add` now prints two quality checks: a design-signal score and a slop finding
@@ -188,6 +244,8 @@ instructions: |
   uses the indigo-violet gradient and triple feature cards — both patterns to reject" is
   a legitimate anti-reference. Dropping it entirely is also correct. Treating it as a
   positive reference is not: you would be training the build on the mean.
+
+  Rejection for slop triggers the replacement obligation above.
 
   ## Low-signal pages do not count
 

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -57,6 +57,19 @@ for `.omd/attribution.md`: the hand traces each token decision back to a named c
 without this line, the attribution table has no origin to cite. `omd ref add` prints a
 design-signal score; a page under 0.4 does not count toward the floor.
 
+**Rejection obligates replacement.** When a capture is rejected — for slop (2+ findings),
+for low signal, for kinship, for a blocked-page error — it does not leave a hole. The
+board is made of what passed, not of what was available. Every rejected capture triggers a
+replacement search: a different query from a different angle, a source tier at least one
+step higher in the trust hierarchy. The scout does not stop until every slot in the
+composition contract is filled with a capture that passed. Anti-references — captures kept
+to document what to avoid — do not count toward the floor: their value is in the warning
+they carry, not the slot they occupy.
+
+When `omd ref add` throws a blocked-page error, the URL is not retried. Demote to
+`--image` if you can construct honest reasoning from public discourse about the site; if
+not, discard and run the replacement search.
+
 **Never describe how a reference looks** (Jansson & Smith: shown an example, designers
 reproduce its features even after the flaws are flagged; a model is worse). Numbers and
 reasons only. The board lands in `.omd/refs/` and any later `omd-ultradesign` run picks it

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -452,6 +452,20 @@ step 4.**
 
 ## 8. Ship, then explain
 
+**When the build produced more than one page**, run `omd check --site <dir>` on the
+output directory before shipping. A blog and its index, a landing page and its docs page,
+a dashboard and its empty state — pages built together should read as one design system.
+`SITE-LADDER-DRIFT` fires when one page carries a 4-step type scale and another a 6-step
+one; `SITE-TOKEN-DRIFT` fires when one page uses design tokens throughout and another
+falls back to inline values. Either finding means the pages were not built from the same
+set of decisions, and the user will feel that drift before they can name it.
+
+```bash
+omd check --site ./dist   # or pass the pages explicitly: omd check index.html post.html
+```
+
+If violations appear, fix the drifting page before shipping.
+
 Deliver the working site. Then, in a short paragraph — not a report — tell the user:
 
 - what you decided the problem actually was, and what evidence pointed there

--- a/test/capture-resilience.test.ts
+++ b/test/capture-resilience.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the block-page heuristic in core/render/index.ts.
+ *
+ * All tests exercise detectBlockReason — the pure function that inspects a
+ * page title, visible body-text length, and HTTP status, and returns either a
+ * block-reason string or null. No browser is required.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectBlockReason } from '../core/render/index.ts';
+
+// ── HTTP status signals ──────────────────────────────────────────────────────
+
+test('HTTP 403 is a block signal', () => {
+  const reason = detectBlockReason('', 5000, 403);
+  assert.ok(reason !== null, 'should detect block');
+  assert.ok(reason!.includes('403'));
+});
+
+test('HTTP 500 is a block signal', () => {
+  const reason = detectBlockReason('My Site', 5000, 500);
+  assert.ok(reason !== null);
+  assert.ok(reason!.includes('500'));
+});
+
+test('HTTP 502 is a block signal', () => {
+  assert.ok(detectBlockReason('', 5000, 502) !== null);
+});
+
+test('HTTP 200 is not a block signal on its own', () => {
+  assert.equal(detectBlockReason('My Site', 5000, 200), null);
+});
+
+test('null HTTP status (file URL or unknown) does not trigger status check', () => {
+  // Should not block on status alone — fall through to other checks.
+  const reason = detectBlockReason('My Site', 5000, null);
+  assert.equal(reason, null);
+});
+
+// ── Challenge-title signals ──────────────────────────────────────────────────
+
+test('"Just a moment..." (Cloudflare) is a block signal', () => {
+  const reason = detectBlockReason('Just a moment...', 1200, 200);
+  assert.ok(reason !== null);
+  assert.ok(reason!.includes('challenge page'));
+});
+
+test('"Attention Required!" is a block signal', () => {
+  assert.ok(detectBlockReason('Attention Required!', 1200, 200) !== null);
+});
+
+test('"Access Denied" is a block signal', () => {
+  assert.ok(detectBlockReason('Access Denied', 1200, 200) !== null);
+});
+
+test('"Checking your browser" is a block signal', () => {
+  assert.ok(detectBlockReason('Checking your browser', 1200, 200) !== null);
+});
+
+test('"Are you human?" is a block signal', () => {
+  assert.ok(detectBlockReason('Are you human? Please verify', 1200, 200) !== null);
+});
+
+test('"One more step" is a block signal', () => {
+  assert.ok(detectBlockReason('One more step', 1200, 200) !== null);
+});
+
+test('Pattern matching is case-insensitive', () => {
+  assert.ok(detectBlockReason('JUST A MOMENT', 1200, 200) !== null);
+  assert.ok(detectBlockReason('just a moment...', 1200, 200) !== null);
+});
+
+test('A normal page title is not a block signal', () => {
+  assert.equal(detectBlockReason('Linear — Project Management', 5000, 200), null);
+});
+
+test('A title mentioning "moment" mid-sentence is not flagged', () => {
+  // "Just a moment" pattern requires the phrase to start the title.
+  assert.equal(detectBlockReason('This moment changed everything', 5000, 200), null);
+});
+
+// ── Near-empty body signal ───────────────────────────────────────────────────
+
+test('body text < 200 chars is a block signal', () => {
+  const reason = detectBlockReason('My Site', 50, 200);
+  assert.ok(reason !== null);
+  assert.ok(reason!.includes('near-empty body'));
+  assert.ok(reason!.includes('50'));
+});
+
+test('body text exactly 199 chars is a block signal', () => {
+  assert.ok(detectBlockReason('My Site', 199, 200) !== null);
+});
+
+test('body text exactly 200 chars is NOT a block signal', () => {
+  assert.equal(detectBlockReason('My Site', 200, 200), null);
+});
+
+test('body text 0 chars is a block signal', () => {
+  assert.ok(detectBlockReason('', 0, 200) !== null);
+});
+
+// ── Priority: HTTP status beats title beats body ─────────────────────────────
+
+test('HTTP 403 is reported even when title and body also look blocked', () => {
+  const reason = detectBlockReason('Just a moment...', 10, 403);
+  assert.ok(reason !== null);
+  assert.ok(reason!.includes('HTTP 403'), 'HTTP status should be the reported reason');
+});
+
+test('challenge title is reported when status is OK but body is also short', () => {
+  // Title check runs before body check, so the challenge-title reason wins.
+  const reason = detectBlockReason('Just a moment...', 10, 200);
+  assert.ok(reason !== null);
+  assert.ok(reason!.includes('challenge page'), 'challenge-title reason should be reported');
+});
+
+// ── Valid pages pass all checks ───────────────────────────────────────────────
+
+test('a normal well-populated page produces no block reason', () => {
+  const longBody = 'x'.repeat(1500);
+  assert.equal(detectBlockReason('Linear — Project Management', longBody.length, 200), null);
+});

--- a/test/site.test.ts
+++ b/test/site.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the cross-page site consistency check in core/site/index.ts.
+ *
+ * All tests are pure: they construct synthetic Invariants and call checkSite
+ * directly without a browser or filesystem. The assertions verify the exact
+ * conditions documented on checkSite: SITE-LADDER-DRIFT fires when any ladder's
+ * step count differs by more than 1, SITE-TOKEN-DRIFT fires when token coverage
+ * varies by more than 0.3.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkSite } from '../core/site/index.ts';
+import type { Invariants } from '../core/types.ts';
+
+/** A fully-populated Invariants fixture: consistent 4-step type scale, healthy token coverage. */
+const base: Invariants = {
+  spacingLadder: [4, 8, 16, 24],
+  radiusLadder: [4, 8, 12],
+  elevationLevels: 2,
+  centeredRatio: 0.1,
+  tokenCoverage: 0.9,
+  paddingWeight: 16,
+  typeScale: [13, 14, 16, 21],       // 4 steps
+  fontFamilies: ['inter'],
+  weightLadder: [400, 600],
+  motionDurations: [120, 200],
+  easingVocab: ['ease-out'],
+  animatedShare: 0.05,
+  hoverCoverage: 0.8,
+  focusCoverage: 0.6,
+  animatedProperties: ['opacity', 'transform'],
+  hasReducedMotion: true,
+  scrollChoreography: [],
+};
+
+// ── No violations ─────────────────────────────────────────────────────────────
+
+test('returns empty array for a single page', () => {
+  const result = checkSite([{ path: 'index.html', invariants: base }]);
+  assert.deepEqual(result, []);
+});
+
+test('no violations when two identical pages are compared', () => {
+  const result = checkSite([
+    { path: 'index.html', invariants: base },
+    { path: 'post.html', invariants: base },
+  ]);
+  assert.deepEqual(result, []);
+});
+
+test('no violations when three pages agree on all ladders and token coverage', () => {
+  const result = checkSite([
+    { path: 'index.html', invariants: base },
+    { path: 'about.html', invariants: base },
+    { path: 'contact.html', invariants: base },
+  ]);
+  assert.deepEqual(result, []);
+});
+
+// ── Type scale drift ──────────────────────────────────────────────────────────
+
+test('SITE-LADDER-DRIFT fires when type scale length differs by 2 (4 vs 6)', () => {
+  const sixStep = { ...base, typeScale: [12, 13, 14, 16, 21, 32] }; // 6 steps
+  const result = checkSite([
+    { path: 'index.html', invariants: base },       // 4 steps
+    { path: 'post.html', invariants: sixStep },
+  ]);
+  const drift = result.filter((v) => v.id === 'SITE-LADDER-DRIFT');
+  assert.ok(drift.length > 0, 'SITE-LADDER-DRIFT should fire');
+  assert.ok(drift.some((v) => v.message.includes('type scale')));
+});
+
+test('SITE-LADDER-DRIFT does not fire when type scale differs by exactly 1 step', () => {
+  const fiveStep = { ...base, typeScale: [13, 14, 16, 21, 32] }; // 5 steps (diff = 1)
+  const result = checkSite([
+    { path: 'index.html', invariants: base },       // 4 steps
+    { path: 'post.html', invariants: fiveStep },
+  ]);
+  assert.ok(
+    !result.some((v) => v.id === 'SITE-LADDER-DRIFT' && v.message.includes('type scale')),
+    'diff of 1 is tolerated',
+  );
+});
+
+// ── Spacing drift ─────────────────────────────────────────────────────────────
+
+test('SITE-LADDER-DRIFT fires when spacing ladder length differs by 2', () => {
+  const twoStepSpacing = { ...base, spacingLadder: [8, 16] }; // 2 steps vs 4
+  const result = checkSite([
+    { path: 'a.html', invariants: base },
+    { path: 'b.html', invariants: twoStepSpacing },
+  ]);
+  const drift = result.filter((v) => v.id === 'SITE-LADDER-DRIFT');
+  assert.ok(drift.some((v) => v.message.includes('spacing')));
+});
+
+test('SITE-LADDER-DRIFT does not fire when spacing ladder differs by 1', () => {
+  const threeStepSpacing = { ...base, spacingLadder: [8, 16, 24] }; // 3 steps vs 4
+  const result = checkSite([
+    { path: 'a.html', invariants: base },           // 4 steps
+    { path: 'b.html', invariants: threeStepSpacing },
+  ]);
+  assert.ok(
+    !result.some((v) => v.id === 'SITE-LADDER-DRIFT' && v.message.includes('spacing')),
+    'diff of 1 is tolerated',
+  );
+});
+
+// ── Radius drift ──────────────────────────────────────────────────────────────
+
+test('SITE-LADDER-DRIFT fires when radius ladder length differs by 2', () => {
+  const fiveStepRadius = { ...base, radiusLadder: [2, 4, 8, 12, 16] }; // 5 steps vs 3
+  const result = checkSite([
+    { path: 'a.html', invariants: base },
+    { path: 'b.html', invariants: fiveStepRadius },
+  ]);
+  assert.ok(result.some((v) => v.id === 'SITE-LADDER-DRIFT' && v.message.includes('radius')));
+});
+
+// ── Token coverage drift ──────────────────────────────────────────────────────
+
+test('SITE-TOKEN-DRIFT fires when token coverage range exceeds 0.3', () => {
+  const lowCoverage = { ...base, tokenCoverage: 0.5 }; // 0.9 - 0.5 = 0.4 > 0.3
+  const result = checkSite([
+    { path: 'index.html', invariants: base },           // 0.9
+    { path: 'post.html', invariants: lowCoverage },     // 0.5
+  ]);
+  assert.ok(result.some((v) => v.id === 'SITE-TOKEN-DRIFT'), 'SITE-TOKEN-DRIFT should fire');
+});
+
+test('SITE-TOKEN-DRIFT does not fire when token coverage range is exactly 0.3', () => {
+  const slightlyLower = { ...base, tokenCoverage: 0.6 }; // 0.9 - 0.6 = 0.3 (threshold is > 0.3)
+  const result = checkSite([
+    { path: 'index.html', invariants: base },
+    { path: 'post.html', invariants: slightlyLower },
+  ]);
+  assert.ok(
+    !result.some((v) => v.id === 'SITE-TOKEN-DRIFT'),
+    'range of exactly 0.3 is tolerated',
+  );
+});
+
+test('SITE-TOKEN-DRIFT fires for 0.9 vs 0.1 (extreme drift)', () => {
+  const noCoverage = { ...base, tokenCoverage: 0.1 };
+  const result = checkSite([
+    { path: 'a.html', invariants: base },
+    { path: 'b.html', invariants: noCoverage },
+  ]);
+  const drift = result.filter((v) => v.id === 'SITE-TOKEN-DRIFT');
+  assert.ok(drift.length > 0);
+  // Message should include the per-page breakdown
+  assert.ok(drift[0]!.message.includes('0.90') || drift[0]!.message.includes('0.9'));
+});
+
+// ── Multi-page comparisons ────────────────────────────────────────────────────
+
+test('three-page comparison catches drift on the odd-one-out page', () => {
+  const drifted = { ...base, typeScale: [12, 13, 14, 16, 21, 32] }; // 6 steps vs 4
+  const result = checkSite([
+    { path: 'a.html', invariants: base },
+    { path: 'b.html', invariants: base },
+    { path: 'c.html', invariants: drifted },
+  ]);
+  assert.ok(result.some((v) => v.id === 'SITE-LADDER-DRIFT'));
+});
+
+test('all pages listed in violation.pages', () => {
+  const drifted = { ...base, typeScale: [12, 13, 14, 16, 21, 32] };
+  const result = checkSite([
+    { path: 'a.html', invariants: base },
+    { path: 'b.html', invariants: drifted },
+  ]);
+  const ldrViolation = result.find((v) => v.id === 'SITE-LADDER-DRIFT');
+  assert.ok(ldrViolation !== undefined);
+  assert.ok(ldrViolation!.pages.includes('a.html'));
+  assert.ok(ldrViolation!.pages.includes('b.html'));
+});
+
+test('violations have severity warn', () => {
+  const drifted = { ...base, typeScale: [12, 13, 14, 16, 21, 32] };
+  const result = checkSite([
+    { path: 'a.html', invariants: base },
+    { path: 'b.html', invariants: drifted },
+  ]);
+  for (const v of result) {
+    assert.equal(v.severity, 'warn');
+  }
+});
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+test('empty token object does not cause token drift', () => {
+  // No tokens field → treated as no token set → token drift still uses tokenCoverage
+  const result = checkSite([
+    { path: 'a.html', invariants: base, tokens: {} },
+    { path: 'b.html', invariants: base, tokens: {} },
+  ]);
+  assert.deepEqual(result, []);
+});
+
+test('pages with empty ladders on both sides produce no drift', () => {
+  const noLadders = { ...base, typeScale: [], spacingLadder: [], radiusLadder: [] };
+  const result = checkSite([
+    { path: 'a.html', invariants: noLadders },
+    { path: 'b.html', invariants: noLadders },
+  ]);
+  assert.deepEqual(result, []);
+});


### PR DESCRIPTION
Plan.md items #6, #9 + user amendment (rejection obliges replacement). 240→277 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)