### PR TITLE
Batch F — plugin evals, release workflow, bump script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2   # need HEAD~1 to detect the version change
+
+      - name: Detect version bump
+        id: ver
+        run: |
+          prev=$(git show HEAD~1:.claude-plugin/plugin.json 2>/dev/null | jq -r '.version // empty' || echo "")
+          curr=$(jq -r .version .claude-plugin/plugin.json)
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+          echo "curr=$curr"  >> "$GITHUB_OUTPUT"
+          if [ "$prev" != "$curr" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and create GitHub release
+        if: steps.ver.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ steps.ver.outputs.curr }}"
+
+          # Use the merge-commit body as release notes; fall back to tag name.
+          notes=$(git log -1 --format="%b" | sed '/^$/d' | head -80)
+          notes="${notes:-Release $tag}"
+
+          git tag "$tag"
+          git push origin "$tag"
+
+          gh release create "$tag" \
+            --title "$tag" \
+            --notes "$notes" \
+            --latest

--- a/evals/korean-showpiece/graders/artifacts-in-english.md
+++ b/evals/korean-showpiece/graders/artifacts-in-english.md
@@ -1,0 +1,19 @@
+# Grader: .omd/ Artifacts in English
+
+Check that all engineering artifacts written under `.omd/` are in English, regardless of the brief's language.
+
+## Pass criteria
+
+- `.omd/frame.md`, `.omd/decisions.md`, `.omd/attribution.md`, and any files under `.omd/refs/` are written in English.
+- The voice study / register notes may contain Korean quoted examples (e.g., example copy), but the analytical commentary and field labels surrounding them must be in English.
+- `.omd/motion-spec.md` (if it exists) is in English.
+
+## Fail criteria
+
+- Any `.omd/` file (other than the user-supplied brief) is primarily written in Korean — prose sections, headings, or structured data fields.
+- The frame problem/reframe statement is in Korean.
+- Attribution rows or decision rationale are in Korean.
+
+## Why this matters
+
+`.omd/` artifacts are engineering records that survive the design run and are read by future agents, reviewers, and CI pipelines. They must be in the same language as the codebase (English) regardless of what language the end-user page targets.

--- a/evals/korean-showpiece/graders/no-pink-elephant.md
+++ b/evals/korean-showpiece/graders/no-pink-elephant.md
@@ -1,0 +1,22 @@
+# Grader: No Pink-Elephant Copy
+
+Check that the Korean copy does not contain AI-prose clichés that `omd:humanize` and the SLOP-COPY-KO rules are designed to eliminate.
+
+## Pass criteria
+
+- The rendered HTML (or the copy written in the transcript) contains none of the following patterns:
+  - Connective-comma openers: "그러나, " / "하지만, " / "또한, " / "따라서, " at the start of a sentence
+  - Structural openers: "첫째," / "둘째," / "셋째," used as enumeration scaffold without narrative need
+  - Abstract value nouns stacked without a concrete subject: "혁신", "신뢰", "편리함", "간편한" appearing in the hero headline without a specific claim attached
+  - The double-postposition pattern "에서의" / "에로의" (retain only if the sentence genuinely requires it and no simpler form exists)
+- The copy reads like a Korean product — not a translated marketing brief.
+
+## Fail criteria
+
+- Any connective-comma opener appears in the body copy.
+- The hero or subheadline stacks ≥ 2 abstract value nouns (e.g., "편리하고 혁신적인 금융 서비스") without a concrete grounding clause.
+- The transcript shows the agent wrote copy then ran humanize and then reverted the humanize output.
+
+## Note
+
+These are the S1-level patterns from SLOP-COPY-KO. A single occurrence that slipped through is a FAIL — the point of the grader is to catch the regression before it becomes the baseline.

--- a/evals/korean-showpiece/graders/showpiece-register.md
+++ b/evals/korean-showpiece/graders/showpiece-register.md
@@ -1,0 +1,19 @@
+# Grader: Showpiece Register Committed
+
+Check that the design explicitly committed to the showpiece register before building — not just incidentally produced something expressive.
+
+## Pass criteria
+
+- `.omd/frame.md` or the run transcript shows the agent explicitly named the register: "showpiece", "expressive", or an equivalent Korean term ("쇼피스", "표현적") before writing code.
+- The rendered page uses at least one of the canonical showpiece techniques: display-scale typography (font-size ≥ 72px on a heading), deliberate negative space (padding or margin ≥ 80px on a section), or a scroll-triggered entrance animation.
+- If `.omd/motion-spec.md` exists, it references the register decision with a cited reference or theory file.
+
+## Fail criteria
+
+- The page looks like a standard landing page template (equal-width cards, centered hero with medium-size text, generic gradient).
+- No evidence in the transcript or `.omd/` that the showpiece register was a deliberate choice versus the default output.
+- The agent described the tone as "modern" or "clean" without committing to the expressive vocabulary of the showpiece register.
+
+## Severity
+
+FAIL if the output is indistinguishable from a default `omd:ultradesign` quiet run.

--- a/evals/korean-showpiece/graders/voice-study.md
+++ b/evals/korean-showpiece/graders/voice-study.md
@@ -1,0 +1,18 @@
+# Grader: Voice Study on Board
+
+Check that a voice study was captured and committed to the reference board before copy was written.
+
+## Pass criteria
+
+- `.omd/theory/voice.md` (or a voice-study file under `.omd/`) exists in the run's working directory AND contains at least one cited source sentence — a direct quote or paraphrase attributed to a real product, person, or document.
+- The `.omd/board.md` or `.omd/refs/` directory references at least one entry tagged as a voice or copy reference (look for `voice`, `copy`, or `register` in the ref metadata or filename).
+
+## Fail criteria
+
+- No `.omd/` voice/copy study file exists.
+- Copy was written without any attributed register example (the agent invented a "warm trustworthy" tone from scratch rather than measuring it from references).
+- The voice study file exists but contains only the agent's own description of the desired tone, with no cited external evidence.
+
+## Severity
+
+FAIL on any single criterion above — the voice study is a prerequisite gate, not a polish step.

--- a/evals/korean-showpiece/prompt.md
+++ b/evals/korean-showpiece/prompt.md
@@ -1,0 +1,1 @@
+Design a Korean-language showpiece landing page for a fintech savings app called "모아" (Moa). The brand voice is trustworthy but warm — not corporate, not cute. Use omd:ultradesign.

--- a/evals/quiet-dashboard/graders/no-showpiece-leak.md
+++ b/evals/quiet-dashboard/graders/no-showpiece-leak.md
@@ -1,0 +1,23 @@
+# Grader: No Showpiece Techniques in a Quiet Dashboard
+
+Check that expressive / showpiece techniques did not leak into a functional dashboard that explicitly requested a quiet register.
+
+## Pass criteria
+
+- No entrance animations triggered on page load (no `@keyframes`, no `animation:`, no `transition` on opacity/transform at the root component level on first paint).
+- No display-scale typography: all text sizes ≤ 48px; the dominant heading size is ≤ 32px.
+- No full-bleed hero section — the layout goes directly to data.
+- Color usage is utilitarian: ≤ 3 distinct hues used for data (e.g., status colors), no decorative gradients.
+- If `.omd/motion-spec.md` exists, it either does not exist or explicitly states "no entrance animations — functional state transitions only."
+
+## Fail criteria (any one fails the case)
+
+- A hero or billboard section with oversized headline occupies the first viewport.
+- CSS contains `@keyframes` that animate elements on initial load.
+- More than 3 non-neutral hues appear as decoration (not as data encoding).
+- The transcript shows the agent invoking showpiece reference principles (expressive.md, motion pacing for drama) for a dashboard brief.
+- `omd check` output includes `MOTION-EVERYTHING-MOVES` or `MOTION-UNIFORM` warnings.
+
+## Why this matters
+
+Register containment is as important as register execution. The showpiece and quiet registers must be distinct — a pipeline that bleeds showpiece techniques into every output has not learned to read the brief.

--- a/evals/quiet-dashboard/prompt.md
+++ b/evals/quiet-dashboard/prompt.md
@@ -1,0 +1,1 @@
+Build a data dashboard for a logistics SaaS — shipment volume, delivery status, and regional breakdown. Keep it functional and quiet. Use omd:ultradesign.

--- a/evals/scout-only/graders/board-composition.md
+++ b/evals/scout-only/graders/board-composition.md
@@ -1,0 +1,24 @@
+# Grader: Board Composition Contract
+
+Check that the scout's reference board meets the minimum composition contract defined in the omd:scout agent spec.
+
+## Pass criteria
+
+- At least 18 captures are recorded in `.omd/refs/` (the scout's stated minimum; target is 25).
+- Captures span at least three granularities:
+  1. **Whole-page** feel captures (full-page IR or screenshot of the entire page)
+  2. **Component-level** captures (a pricing card, a feature table, a CTA row — one component isolated)
+  3. **Typography or motion** captures (a type specimen, a heading treatment, or a motion invariant reading)
+- The board includes at least one capture from a curated/juried source (Awwwards Site of the Day, Godly, SiteInspire, GDWEB — look for these domain names or explicit attribution in the ref metadata).
+- `.omd/board.md` (or equivalent board summary) exists and lists the captures with their signal scores.
+
+## Fail criteria
+
+- Fewer than 18 captures in `.omd/refs/`.
+- All captures are the same granularity (all whole-page, or all component snippets).
+- No capture from a curated source — the entire board came from undifferentiated search results.
+- `.omd/board.md` is missing or empty.
+
+## Why this matters
+
+The board composition contract exists because a 5-reference board teaches the same lessons as a 1-reference board: the mean of a small sample. 18+ captures at mixed granularity is what turns "inspiration" into measurement.

--- a/evals/scout-only/graders/clean-captures.md
+++ b/evals/scout-only/graders/clean-captures.md
@@ -1,0 +1,21 @@
+# Grader: Clean Captures Only (No Slop-Contaminated References)
+
+Check that the reference board contains no captures that would be barred by the contamination-defense rules: slop-flagged pages may not sit on the board as positive references.
+
+## Pass criteria
+
+- No capture in `.omd/refs/` has a slop score indicating ≥ 2 SLOP rule violations (SLOP-GRADIENT, TRIPLE-CARD, EVERYTHING-CENTERED, or equivalent).
+- Any page that triggered ≥ 2 slop rules was either:
+  - Excluded from the board entirely, OR
+  - Explicitly downgraded to `anti-reference` status with a note in `.omd/board.md` explaining what failure it demonstrates.
+- The transcript shows the scout ran slop detection on captures (look for `omd check`, `slop`, or contamination-defense language) — not just signal scoring.
+
+## Fail criteria
+
+- A capture with ≥ 2 slop violations sits on the board as a positive reference without an `anti-reference` label.
+- The scout ran no slop check at all — signal score was the only filter.
+- More than 3 captures in the board share a pairwise similarity ≥ 0.85 (kinship cluster — indicates AI-generated or template pages slipped through in bulk).
+
+## Why this matters
+
+Slop-contaminated references are the primary vector for AI-average aesthetics re-entering the pipeline. The contamination-defense rules (Plan item #12) require the scout to gate captures at the point of collection, not after. A board that passes this grader cannot easily have trained the pipeline on its own output.

--- a/evals/scout-only/prompt.md
+++ b/evals/scout-only/prompt.md
@@ -1,0 +1,1 @@
+Build a reference board for a B2B SaaS pricing page redesign. Collect references only — no design, no code. Use omd:scout.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "test": "node --test 'test/*.test.ts'",
     "typecheck": "tsc --noEmit",
-    "build": "node adapters/build.ts"
+    "build": "node adapters/build.ts",
+    "release:prep": "node scripts/bump.ts"
   },
   "dependencies": {
     "smol-toml": "^1.3.0",

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * scripts/bump.ts — bump the version in all three manifests atomically.
+ *
+ * Usage:
+ *   node scripts/bump.ts [--dry-run] <new-version>
+ *
+ * Examples:
+ *   node scripts/bump.ts 0.6.0
+ *   node scripts/bump.ts --dry-run 0.6.0
+ *
+ * In dry-run mode, prints what would change to stdout without writing files
+ * or running build/tests.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Rewrite every `"version": "..."` field in a JSON string to `newVersion`.
+ * Covers both single-version files (package.json, plugin.json) and files
+ * with multiple version fields (marketplace.json top-level + plugins[0]).
+ * Preserves all other formatting.
+ */
+export function bumpJson(content: string, newVersion: string): string {
+  return content.replace(/"version"\s*:\s*"[^"]*"/g, `"version": "${newVersion}"`);
+}
+
+const MANIFESTS = [
+  'package.json',
+  '.claude-plugin/plugin.json',
+  '.claude-plugin/marketplace.json',
+] as const;
+
+function run(args: string[]): void {
+  const dryRun = args.includes('--dry-run');
+  const version = args.filter((a) => !a.startsWith('--')).at(-1);
+
+  if (!version || !/^\d+\.\d+\.\d+/.test(version)) {
+    process.stderr.write('Usage: node scripts/bump.ts [--dry-run] <new-version>\n');
+    process.stderr.write('Example: node scripts/bump.ts --dry-run 0.6.0\n');
+    process.exit(1);
+  }
+
+  const changes: Array<{ path: string; before: string; after: string }> = [];
+
+  for (const rel of MANIFESTS) {
+    const abs = join(root, rel);
+    const before = readFileSync(abs, 'utf8');
+    const after = bumpJson(before, version);
+    changes.push({ path: rel, before, after });
+  }
+
+  // Report what will change
+  for (const { path, before, after } of changes) {
+    if (before === after) {
+      process.stdout.write(`  ${path}: already at ${version} (no change)\n`);
+    } else {
+      const prevMatch = /"version"\s*:\s*"([^"]*)"/.exec(before);
+      const prev = prevMatch?.[1] ?? '?';
+      process.stdout.write(`  ${path}: ${prev} → ${version}\n`);
+    }
+  }
+
+  if (dryRun) {
+    process.stdout.write('\n[dry-run] no files written\n');
+    return;
+  }
+
+  // Write
+  for (const { path, after } of changes) {
+    writeFileSync(join(root, path), after);
+  }
+  process.stdout.write(`\nwrote ${MANIFESTS.length} manifests\n`);
+
+  // Build
+  process.stdout.write('\nrunning build...\n');
+  const build = spawnSync(process.execPath, ['adapters/build.ts'], {
+    cwd: root,
+    stdio: 'inherit',
+    encoding: 'utf8',
+  });
+  if (build.status !== 0) {
+    process.stderr.write('build failed — manifests were written, build was not.\n');
+    process.exit(build.status ?? 1);
+  }
+
+  // Test
+  process.stdout.write('\nrunning tests...\n');
+  const test = spawnSync(process.execPath, ['--test', 'test/*.test.ts'], {
+    cwd: root,
+    stdio: 'inherit',
+    encoding: 'utf8',
+    shell: true,
+  });
+  if (test.status !== 0) {
+    process.stderr.write('tests failed — version was bumped but tests did not pass.\n');
+    process.exit(test.status ?? 1);
+  }
+
+  process.stdout.write(`\nready: v${version} — commit .claude-plugin/plugin.json, .claude-plugin/marketplace.json, package.json\n`);
+}
+
+import { pathToFileURL } from 'node:url';
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  run(process.argv.slice(2));
+}

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bumpJson } from '../scripts/bump.ts';
+
+test('bumpJson rewrites a single version field', () => {
+  const before = '{\n  "name": "omd",\n  "version": "0.5.0"\n}\n';
+  const after = bumpJson(before, '0.6.0');
+  assert.equal(after, '{\n  "name": "omd",\n  "version": "0.6.0"\n}\n');
+});
+
+test('bumpJson rewrites all version fields — covers marketplace.json shape', () => {
+  const before = JSON.stringify({
+    version: '0.5.0',
+    plugins: [{ name: 'omd', version: '0.5.0' }],
+  });
+  const after = bumpJson(before, '0.6.0');
+  const parsed = JSON.parse(after) as { version: string; plugins: Array<{ version: string }> };
+  assert.equal(parsed.version, '0.6.0');
+  assert.equal(parsed.plugins[0]?.version, '0.6.0');
+});
+
+test('bumpJson does not touch other string fields', () => {
+  const before = '{"name":"omd","version":"0.5.0","description":"test v0.5.0 notes"}';
+  const after = bumpJson(before, '0.6.0');
+  // name and description unchanged
+  assert.match(after, /"name":"omd"/);
+  assert.match(after, /"description":"test v0.5.0 notes"/);
+  // only the version field updated
+  assert.match(after, /"version": "0.6.0"/);
+  assert.doesNotMatch(after, /"version": "0.5.0"/);
+});
+
+test('bumpJson is idempotent — bumping to the same version changes nothing meaningful', () => {
+  const before = '{"version":"0.6.0"}';
+  const after = bumpJson(before, '0.6.0');
+  assert.equal(JSON.parse(after).version, '0.6.0');
+});
+
+test('bumpJson handles compact JSON without spaces around colon', () => {
+  const before = '{"version":"1.0.0","plugins":[{"version":"1.0.0"}]}';
+  const after = bumpJson(before, '1.1.0');
+  assert.doesNotMatch(after, /"version":"1.0.0"/);
+  assert.doesNotMatch(after, /"version": "1.0.0"/);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["bin", "core", "adapters", "test"]
+  "include": ["bin", "core", "adapters", "test", "scripts"]
 }


### PR DESCRIPTION
Plan.md items #7, #8. 277→282 tests. Release workflow tags v{version} when .claude-plugin/plugin.json changes on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)