### PR TITLE
Batch I — motion energy curve, spec-vs-measured rules, eye motion rubric

### DIFF
--- a/agents/eye.md
+++ b/agents/eye.md
@@ -67,3 +67,30 @@ showpiece context.
 expectations (calling the entrance animation "distracting") or a quiet build with
 showpiece expectations ("this landing page needs more visual interest"). The register was
 committed before you were spawned; it is not yours to overrule.
+
+## Filmstrip and motion-spec
+
+When a filmstrip is provided alongside the static render, use it — never judge motion
+quality from the static screenshot alone when frames exist.
+
+The filmstrip shows what appeared when, in temporal order. A static render cannot tell
+you whether an entrance animation fired, whether a scroll reveal is visible mid-page, or
+whether the "one memorable moment" committed in the concept actually materialised. The
+frames can.
+
+When `.omd/motion-spec.md` is also provided:
+
+1. Read the spec's scene list **before** examining the frames.
+2. For each scene: identify the frame(s) where that scene should be visible; judge whether
+   the scene reads — is the motion perceptible, or does the frame look like the one before it?
+3. A spec scene that is invisible across all frames is a finding: name the scene, note
+   which frames you checked, and state that no visible change was detected.
+4. Do not judge motion quality from a single static screenshot when a filmstrip exists.
+   "The page looks dynamic" from one frame is not evidence; "Frame 1 and Frame 2 are
+   identical in the hero region where the entrance scene should fire" is.
+
+**The motion-spec boundary**: `.omd/motion-spec.md` is a build artifact written by
+omd:hand before the code was written. It records what the build was contracted to contain.
+You are not given the reasoning that produced the spec — not the framing, not the concept,
+not the reference board. You see the spec and you see the frames. Your only question is:
+did the spec materialise? You are not defending or critiquing the spec's decisions.

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -9,7 +9,8 @@ import { logRun, readHistory } from '../core/history/index.ts';
 import { analyse } from '../core/coach/index.ts';
 import { findLeakedRationale } from '../core/rules/leakage.ts';
 import { checkAttribution } from '../core/rules/attribution.ts';
-import type { Category, Layer, RawIr, Violation } from '../core/types.ts';
+import { checkMotionSpec } from '../core/rules/motion-spec.ts';
+import type { Category, EnergyCurve, Layer, RawIr, Violation } from '../core/types.ts';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -229,9 +230,41 @@ async function cmdCheck(opts: Opts): Promise<never> {
     );
   }
 
+  // Motion-spec audit: only active when .omd/motion-spec.md exists. Compares the scene
+  // inventory written by omd-hand (what was planned) against the live probe data (what ran)
+  // and the filmstrip energy curve (pixel-level confirmation that catches GSAP/rAF too).
+  //
+  // Contract: check reads the most recent energy curve from .omd/.cache/ if present.
+  // The ultradesign skill runs `omd render --filmstrip` before `omd check`, which writes
+  // `<base>-energy.json` alongside the filmstrip HTML. If that file is present, it is
+  // used as a supplementary signal; if absent, probe data alone is used.
+  const motionSpecViolations: Violation[] = [];
+  const motionSpecPath = join(process.cwd(), '.omd', 'motion-spec.md');
+  if (existsSync(motionSpecPath)) {
+    const motionSpecMd = readFileSync(motionSpecPath, 'utf8');
+    const framePath = join(process.cwd(), '.omd', 'frame.md');
+    const frameMd = existsSync(framePath) ? readFileSync(framePath, 'utf8') : null;
+
+    let energyCurve: EnergyCurve | null = null;
+    const cacheDir = join(process.cwd(), '.omd', '.cache');
+    if (existsSync(cacheDir)) {
+      const energyFiles = readdirSync(cacheDir).filter((f) => f.endsWith('-energy.json'));
+      if (energyFiles.length > 0) {
+        try {
+          energyCurve = JSON.parse(readFileSync(join(cacheDir, energyFiles[0]!), 'utf8')) as EnergyCurve;
+        } catch { /* corrupt or unreadable: skip */ }
+      }
+    }
+
+    motionSpecViolations.push(
+      ...checkMotionSpec(ir, motionSpecMd, frameMd, energyCurve)
+        .filter((v) => (!categories || categories.includes(v.category)) && (!layers || layers.includes(v.layer))),
+    );
+  }
+
   // Code-unit order, not localeCompare — same determinism guarantee as check() itself.
   const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
-  const combined: Violation[] = [...violations, ...leaks, ...attrViolations].sort((a, b) => cmp(a.path, b.path) || cmp(a.id, b.id));
+  const combined: Violation[] = [...violations, ...leaks, ...attrViolations, ...motionSpecViolations].sort((a, b) => cmp(a.path, b.path) || cmp(a.id, b.id));
 
   if (opts.json) process.stdout.write(JSON.stringify(combined));
   else for (const v of combined) console.log(`[${v.severity}] ${v.id} ${v.path}: ${v.message}`);
@@ -350,6 +383,14 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
   const slopCount = slopViolations.length;
   const slopIds = [...new Set(slopViolations.map((v) => v.id))];
 
+  // Energy curve: capture pixel-diff motion energy for the reference. Uses a second
+  // Playwright session so the cost is one extra browser launch per `omd ref add`.
+  // Sees ALL motion including GSAP/rAF — closing the getAnimations() blind spot.
+  // Failure is silently ignored: a blocked page or unsupported format must not prevent
+  // the reference from being saved.
+  const { captureEnergy, parseViewport } = await import('../core/render/index.ts');
+  const energyCurve = await captureEnergy(target, { viewport: parseViewport(opts.viewport) });
+
   const path = saveRef(process.cwd(), {
     source: target,
     component: opts.as,
@@ -360,6 +401,7 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
     principles: [],
     slopCount,
     ...(opts.fromUser ? { origin: 'user' as const } : {}),
+    ...(energyCurve !== null ? { energyCurve } : {}),
   });
   console.log(path);
   console.log(JSON.stringify(invariants, null, 2));

--- a/core/motion/energy.ts
+++ b/core/motion/energy.ts
@@ -1,0 +1,188 @@
+import { inflateSync } from 'node:zlib';
+import type { EnergyCurve, FrameEnergy } from '../types.ts';
+
+// ── Minimal PNG decoder ──────────────────────────────────────────────────────
+//
+// Playwright viewport screenshots are always non-interlaced 8-bit RGB (color type 2)
+// or RGBA (color type 6). This narrow scope — four filter equations plus zlib inflate —
+// handles that exact case in ~80 lines without a pngjs dependency.
+//
+// Interlaced PNGs, palette PNGs, and bit depths other than 8 throw immediately.
+// Those formats never appear in Playwright output; if one did, the caller's try/catch
+// turns the failure into a null result rather than breaking capture.
+
+const PNG_SIG = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function paethPredictor(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}
+
+/**
+ * Decode an 8-bit RGB or RGBA PNG buffer into a flat pixel array.
+ *
+ * Supports color types 2 (RGB) and 6 (RGBA), bit depth 8, non-interlaced only —
+ * exactly what Playwright viewport screenshots produce.
+ */
+export function decodePng(data: Buffer): {
+  width: number;
+  height: number;
+  pixels: Uint8Array;
+  channels: number;
+} {
+  for (let i = 0; i < 8; i++) {
+    if (data[i] !== PNG_SIG[i]) throw new Error('not a PNG: bad signature');
+  }
+
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let channels = 0;
+  const idatChunks: Buffer[] = [];
+
+  while (offset + 12 <= data.length) {
+    const chunkLen = data.readUInt32BE(offset);
+    const type = data.subarray(offset + 4, offset + 8).toString('ascii');
+    const chunk = data.subarray(offset + 8, offset + 8 + chunkLen);
+    offset += 12 + chunkLen; // length(4) + type(4) + data(N) + crc(4)
+
+    if (type === 'IHDR') {
+      width = chunk.readUInt32BE(0);
+      height = chunk.readUInt32BE(4);
+      const bitDepth = chunk[8]!;
+      const colorType = chunk[9]!;
+      const interlace = chunk[12]!;
+      if (bitDepth !== 8) throw new Error(`unsupported PNG bit depth: ${bitDepth} (only 8 supported)`);
+      if (colorType === 2) channels = 3;
+      else if (colorType === 6) channels = 4;
+      else throw new Error(`unsupported PNG color type: ${colorType} (only RGB=2 and RGBA=6 supported)`);
+      if (interlace !== 0) throw new Error('interlaced PNG not supported');
+    } else if (type === 'IDAT') {
+      idatChunks.push(chunk);
+    } else if (type === 'IEND') {
+      break;
+    }
+  }
+
+  if (width === 0 || height === 0 || channels === 0) {
+    throw new Error('PNG IHDR not found or has zero dimensions');
+  }
+
+  const stride = width * channels;
+  const raw = inflateSync(Buffer.concat(idatChunks));
+  const pixels = new Uint8Array(width * height * channels);
+  let srcOff = 0;
+
+  for (let y = 0; y < height; y++) {
+    const filterType = raw[srcOff++]!;
+    const dstRow = y * stride;
+
+    for (let x = 0; x < stride; x++) {
+      const rawVal = raw[srcOff + x]! & 0xff;
+      const a = x >= channels ? pixels[dstRow + x - channels]! : 0;
+      const b = y > 0 ? pixels[dstRow - stride + x]! : 0;
+      const c = (x >= channels && y > 0) ? pixels[dstRow - stride + x - channels]! : 0;
+
+      let val: number;
+      switch (filterType) {
+        case 0: val = rawVal; break;                                            // None
+        case 1: val = (rawVal + a) & 0xff; break;                              // Sub
+        case 2: val = (rawVal + b) & 0xff; break;                              // Up
+        case 3: val = (rawVal + Math.floor((a + b) / 2)) & 0xff; break;        // Average
+        case 4: val = (rawVal + paethPredictor(a, b, c)) & 0xff; break;        // Paeth
+        default: throw new Error(`unknown PNG filter type: ${filterType}`);
+      }
+      pixels[dstRow + x] = val;
+    }
+    srcOff += stride;
+  }
+
+  return { width, height, pixels, channels };
+}
+
+const round4 = (v: number): number => Math.round(v * 10000) / 10000;
+
+/**
+ * Compute per-interval pixel-difference energy from a sequence of PNG frame buffers.
+ *
+ * Energy = fraction of pixels whose max per-channel RGB difference exceeds
+ * `diffThreshold` (default 10, scale 0–255). Alpha is ignored — only the visible RGB
+ * signal is compared.
+ *
+ * Region summary: the frame is split into three equal vertical thirds (top / mid / bottom).
+ * `regionFractions[i]` is the fraction of that third's pixels that changed — answering
+ * "where did the motion happen" without requiring layout data.
+ *
+ * IMPORTANT: this function sees ALL pixel-level motion, including GSAP and rAF-driven
+ * libraries that `document.getAnimations()` cannot detect. Where
+ * `ir.meta.motion.animatedProperties` may read as [] for a GSAP-only page, a non-zero
+ * energy curve confirms motion occurred — closing the getAnimations() blind spot documented
+ * on MotionMeasurement and Invariants.animatedProperties.
+ *
+ * Pure and deterministic: given the same PNG buffers and threshold it always returns the
+ * same result. Safe to call in unit tests with synthetic buffers.
+ *
+ * @param buffers   Ordered PNG buffers, earliest frame first. Fewer than 2 → empty pairs.
+ * @param diffThreshold  Per-channel difference threshold (0–255, default 10).
+ */
+export function computeEnergy(buffers: Buffer[], diffThreshold = 10): EnergyCurve {
+  const frames = buffers.map((b) => decodePng(b));
+  const pairs: FrameEnergy[] = [];
+
+  for (let i = 0; i + 1 < frames.length; i++) {
+    const a = frames[i]!;
+    const b = frames[i + 1]!;
+
+    // Dimension mismatch: treat as fully changed (conservative, not a normal case).
+    if (a.width !== b.width || a.height !== b.height) {
+      pairs.push({ pairIndex: i, changedFraction: 1, regionFractions: [1, 1, 1] });
+      continue;
+    }
+
+    const { width, height, channels } = a;
+    const totalPixels = width * height;
+    const thirdH = Math.floor(height / 3);
+    // Bottom region absorbs any remainder from the floor.
+    const regionTotal = [thirdH * width, thirdH * width, (height - 2 * thirdH) * width];
+    const regionChanged = [0, 0, 0];
+    let totalChanged = 0;
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = (y * width + x) * channels;
+        let maxDiff = 0;
+        // Compare RGB channels only — ignore alpha (channel index 3) even if present.
+        const rgbChannels = Math.min(3, channels);
+        for (let ch = 0; ch < rgbChannels; ch++) {
+          const diff = Math.abs((a.pixels[idx + ch]! & 0xff) - (b.pixels[idx + ch]! & 0xff));
+          if (diff > maxDiff) maxDiff = diff;
+        }
+        if (maxDiff > diffThreshold) {
+          totalChanged++;
+          const region = y < thirdH ? 0 : y < thirdH * 2 ? 1 : 2;
+          regionChanged[region]!++;
+        }
+      }
+    }
+
+    const changedFraction = round4(totalChanged / Math.max(totalPixels, 1));
+    const regionFractions: [number, number, number] = [
+      round4(regionChanged[0]! / Math.max(regionTotal[0]!, 1)),
+      round4(regionChanged[1]! / Math.max(regionTotal[1]!, 1)),
+      round4(regionChanged[2]! / Math.max(regionTotal[2]!, 1)),
+    ];
+
+    pairs.push({ pairIndex: i, changedFraction, regionFractions });
+  }
+
+  const peakEnergy = pairs.length > 0
+    ? round4(Math.max(...pairs.map((p) => p.changedFraction)))
+    : 0;
+
+  return { frames: buffers.length, pairs, peakEnergy };
+}

--- a/core/ref/store.ts
+++ b/core/ref/store.ts
@@ -80,6 +80,9 @@ export function loadRefs(cwd: string): Reference[] {
           principles: parsed.principles ?? [],
           ...(parsed.slopCount !== undefined ? { slopCount: parsed.slopCount } : {}),
           ...(parsed.origin !== undefined ? { origin: parsed.origin } : {}),
+          // energyCurve is absent on references captured before energy measurement was
+          // added — omit the key so downstream code can use `?? null` to detect absence.
+          ...(parsed.energyCurve !== undefined ? { energyCurve: parsed.energyCurve } : {}),
         });
       }
     } catch {

--- a/core/render/index.ts
+++ b/core/render/index.ts
@@ -1,8 +1,9 @@
 import { pathToFileURL } from 'node:url';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { resolve, dirname, basename, join } from 'node:path';
 import { extractInPage } from '../ir/dom.ts';
-import type { MotionMeasurement, RawIr } from '../types.ts';
+import { computeEnergy } from '../motion/energy.ts';
+import type { EnergyCurve, MotionMeasurement, RawIr } from '../types.ts';
 
 const MAX_NODES = 4000;
 
@@ -407,8 +408,54 @@ export async function renderFilmstrip(
     ].join('\n');
     writeFileSync(indexPath, html);
 
+    // Energy curve: compute pixel-diff scores between adjacent frames and write alongside
+    // the HTML index. This measurement sees ALL motion including GSAP/rAF — closing the
+    // getAnimations() blind spot documented on MotionMeasurement. Any decode failure is
+    // caught silently so a non-standard PNG format never breaks the filmstrip capture.
+    try {
+      const frameBuffers = framePaths.map((p) => readFileSync(p));
+      const energyCurve = computeEnergy(frameBuffers);
+      const energyPath = join(dir, `${name}-energy.json`);
+      writeFileSync(energyPath, `${JSON.stringify(energyCurve, null, 2)}\n`);
+    } catch {
+      // Best-effort: energy is a bonus measurement; a failure must not break capture.
+    }
+
     return framePaths;
   });
+}
+
+/**
+ * Capture a pixel-diff motion energy curve by taking frames in a live browser session.
+ *
+ * Unlike renderFilmstrip, this does not write any files — it returns the EnergyCurve
+ * directly for embedding in reference records (`omd ref add`). Uses the same
+ * Playwright capture path as renderFilmstrip but in a fresh session.
+ *
+ * Returns null on any failure: a blocked page, unsupported PNG format, or Playwright
+ * error must never prevent a reference from being saved.
+ *
+ * PROBE NOTE: like renderFilmstrip, this sees ALL pixel-level motion including GSAP/rAF,
+ * complementing the getAnimations() probe in extractIr which cannot see rAF-driven libs.
+ */
+export async function captureEnergy(
+  target: string,
+  opts: { viewport: Viewport; frames?: number; interval?: number },
+): Promise<EnergyCurve | null> {
+  const frameCount = Math.min(Math.max(opts.frames ?? 4, 2), 6);
+  const interval = opts.interval ?? 300;
+  try {
+    return await withPage(target, opts.viewport, async (page) => {
+      const buffers: Buffer[] = [];
+      for (let i = 0; i < frameCount; i++) {
+        if (i > 0) await new Promise<void>((r) => setTimeout(r, interval));
+        buffers.push(await page.screenshot({ fullPage: false }));
+      }
+      return computeEnergy(buffers);
+    });
+  } catch {
+    return null;
+  }
 }
 
 export function extractIr(target: string, opts: { viewport: Viewport; selector?: string | null }): Promise<RawIr> {

--- a/core/rules/builtin/motion.yaml
+++ b/core/rules/builtin/motion.yaml
@@ -17,6 +17,12 @@
 # exists and has the expected fields) before asserting. They skip gracefully when the
 # probe was not run or returned null.
 #
+# BLIND SPOT CLOSURE: core/motion/energy.ts (computeEnergy) closes this gap. It
+# computes pixel-diff scores between filmstrip frames and sees ALL motion including
+# GSAP/rAF — a non-zero EnergyCurve.peakEnergy confirms motion occurred even when
+# ir.meta.motion.animatedProperties is []. The MOTION-SPEC-DRIFT and MOTION-NO-ENTRANCE
+# rules in core/rules/motion-spec.ts use the energy curve as a supplementary signal.
+#
 # MOTION-SLOW-HOVER was studied and dropped: node.motion.durations lists ALL transition
 # durations (entrance animations + hover transitions) without distinguishing between them.
 # A rule firing on any interactive node with duration > 200ms would have false positives

--- a/core/rules/motion-spec.ts
+++ b/core/rules/motion-spec.ts
@@ -1,0 +1,204 @@
+import type { EnergyCurve, Ir, Violation } from '../types.ts';
+
+// ── Motion spec parser ───────────────────────────────────────────────────────
+//
+// motion-spec.md format (written by omd-hand before the build):
+//
+//   ## Scene name
+//   - trigger: load | scroll | hover
+//   - target: .selector
+//   - properties: opacity, transform
+//   - duration: 400ms (ref: motion-study-1)
+//   - easing: cubic-bezier(0.2,0,0,1)
+//   - stagger: 40ms between .card siblings   ← optional
+//
+// The parser splits on ## headers, then looks for `trigger:` in each section.
+
+type Trigger = 'load' | 'scroll' | 'hover' | 'unknown';
+
+interface SpecScene {
+  name: string;
+  trigger: Trigger;
+  hasStagger: boolean;
+}
+
+function parseMotionSpec(md: string): SpecScene[] {
+  // Split on h2 headers; slice(1) discards any preamble before the first ##.
+  const sections = md.split(/^##\s+/m).slice(1);
+  const scenes: SpecScene[] = [];
+
+  for (const section of sections) {
+    const lines = section.split('\n');
+    const name = lines[0]?.trim() ?? '';
+    if (!name) continue;
+
+    let trigger: Trigger = 'unknown';
+    const m = /(?:^|\s)trigger\s*:\s*(load|scroll|hover)/im.exec(section);
+    if (m) trigger = m[1]!.toLowerCase() as 'load' | 'scroll' | 'hover';
+
+    const hasStagger = /stagger/i.test(section);
+    scenes.push({ name, trigger, hasStagger });
+  }
+
+  return scenes;
+}
+
+function isShowpiece(frameMd: string | null): boolean {
+  if (!frameMd) return false;
+  return /showpiece/i.test(frameMd);
+}
+
+// ── Rule implementations ─────────────────────────────────────────────────────
+//
+// MOTION-SPEC-DRIFT
+//   Fires when the spec and the live probe disagree about whether motion exists:
+//   (a) spec describes load/scroll scenes → probe detected nothing, OR
+//   (b) probe detected animations → spec has no scenes.
+//   Rationale: the spec is a contract ("build will contain exactly these animations");
+//   a gap between spec and reality means either an unimplemented scene or an
+//   undocumented animation.
+//
+//   GSAP note: getAnimations() cannot see rAF-driven motion (GSAP, Anime.js). A
+//   GSAP-only page may legitimately appear as "probe detected nothing" even when the
+//   filmstrip energy curve shows motion. When energyCurve is present and peakEnergy > 0,
+//   it is used as a fallback signal for probe detection.
+//
+// MOTION-NO-ENTRANCE
+//   Fires only when: (1) frame.md commits to showpiece register, AND (2) motion-spec
+//   has at least one load-triggered scene, AND (3) neither the probe nor the energy
+//   curve detected any entrance animation. Rationale: a showpiece page that promised
+//   an entrance scene and delivered nothing is a broken contract between spec and build.
+//
+// MOTION-NO-STAGGER (dropped — unmeasurable with current probe data)
+//   Plan v2 M5 specified: fires when spec names a stagger but probe start-times of
+//   the scene's siblings are identical. DROPPED: the motion snapshots (t=0/500/1500ms)
+//   record animation count, duration, easing, and properties — but NOT per-element start
+//   times or delays. Without individual element start times there is no deterministic path
+//   to distinguish simultaneous-fire from staggered-fire. Implement when per-element
+//   start times become available from the probe.
+
+/**
+ * Compare `.omd/motion-spec.md` against live probe + energy data and return any
+ * MOTION-SPEC-DRIFT or MOTION-NO-ENTRANCE violations.
+ *
+ * Only called when `.omd/motion-spec.md` exists (the caller guards that).
+ *
+ * @param ir           Normalized IR from the current check run, with ir.meta.motion
+ *                     populated when the check ran against a live page target.
+ * @param motionSpecMd Content of .omd/motion-spec.md.
+ * @param frameMd      Content of .omd/frame.md, or null if absent.
+ * @param energyCurve  Energy curve from .omd/.cache/*-energy.json, or null if absent.
+ *                     Used as a fallback signal when getAnimations() cannot see the
+ *                     motion library in use (e.g. GSAP).
+ */
+export function checkMotionSpec(
+  ir: Ir,
+  motionSpecMd: string,
+  frameMd: string | null,
+  energyCurve: EnergyCurve | null,
+): Violation[] {
+  const violations: Violation[] = [];
+  const scenes = parseMotionSpec(motionSpecMd);
+
+  // Probe data may be absent (pre-probe IRs, or check run without a live page target).
+  // Skip all spec-vs-probe comparisons when it is: a ghost probe would produce false
+  // positives against any spec.
+  const motionProbe = ir.meta?.['motion'] as
+    | {
+        snapshots?: Array<{ t: number; animations: unknown[] }>;
+        animatedProperties?: string[];
+        scrollChoreography?: Array<{ step: number; fired: number; entered: number }>;
+      }
+    | null
+    | undefined;
+
+  if (!motionProbe) return violations;
+
+  // ── Whether the probe/energy detected any motion ─────────────────────────
+
+  const hasProbeAnimations = (motionProbe.animatedProperties?.length ?? 0) > 0;
+  const hasScrollFired = (motionProbe.scrollChoreography ?? []).some((s) => s.fired > 0);
+  // Energy > 0.5% pixel change: a negligible anti-alias flicker stays below this floor.
+  const hasEnergyMotion = energyCurve !== null && energyCurve.peakEnergy > 0.005;
+  const probeDetectedMotion = hasProbeAnimations || hasScrollFired || hasEnergyMotion;
+
+  // ── MOTION-SPEC-DRIFT ────────────────────────────────────────────────────
+
+  const loadScrollScenes = scenes.filter((s) => s.trigger === 'load' || s.trigger === 'scroll');
+
+  if (loadScrollScenes.length > 0 && !probeDetectedMotion) {
+    violations.push({
+      id: 'MOTION-SPEC-DRIFT',
+      severity: 'warn',
+      layer: 1,
+      category: 'motion',
+      nodeId: 'page',
+      path: 'motion-spec',
+      value: `spec:${loadScrollScenes.length},probe:0`,
+      message:
+        `motion-spec.md describes ${loadScrollScenes.length} load/scroll scene`
+        + `${loadScrollScenes.length === 1 ? '' : 's'} but the live probe detected no`
+        + ` animations (getAnimations returned nothing; filmstrip energy also absent or zero).`
+        + ` Either the scenes were not implemented, or they use GSAP/rAF which is invisible`
+        + ` to getAnimations() — run \`omd render --filmstrip\` and check the energy curve.`,
+    });
+  }
+
+  if (scenes.length === 0 && probeDetectedMotion) {
+    violations.push({
+      id: 'MOTION-SPEC-DRIFT',
+      severity: 'warn',
+      layer: 1,
+      category: 'motion',
+      nodeId: 'page',
+      path: 'motion-spec',
+      value: 'spec:0,probe:detected',
+      message:
+        'The live probe detected animations but motion-spec.md describes no scenes.'
+        + ' Animations not in the spec were not planned — add a scene entry for every'
+        + ' animation in the build, or remove the unplanned animations.',
+    });
+  }
+
+  // ── MOTION-NO-ENTRANCE ───────────────────────────────────────────────────
+
+  // Only fires when the page committed to showpiece AND the spec promised an entrance.
+  const hasEntranceScene = scenes.some((s) => s.trigger === 'load');
+  const showpiece = isShowpiece(frameMd);
+
+  if (showpiece && hasEntranceScene) {
+    // Probe snapshots at t=0ms and t=500ms cover the entrance window.
+    const snap0Anims = motionProbe.snapshots?.[0]?.animations.length ?? 0;
+    const snap500Anims = motionProbe.snapshots?.[1]?.animations.length ?? 0;
+    const probeEntranceDetected = snap0Anims > 0 || snap500Anims > 0;
+
+    // Energy from the first frame pair (t=0→t+interval) covers the same window.
+    const entranceEnergy = energyCurve !== null && energyCurve.pairs.length > 0
+      ? energyCurve.pairs[0]!.changedFraction
+      : null;
+    const energyEntranceDetected = entranceEnergy !== null && entranceEnergy > 0.005;
+
+    const entranceMeasured = probeEntranceDetected || energyEntranceDetected;
+
+    if (!entranceMeasured) {
+      violations.push({
+        id: 'MOTION-NO-ENTRANCE',
+        severity: 'warn',
+        layer: 1,
+        category: 'motion',
+        nodeId: 'page',
+        path: 'motion-spec',
+        value: 'showpiece+entrance-spec+no-measured-entrance',
+        message:
+          'This page commits to the showpiece register and motion-spec.md describes a'
+          + ' load-triggered entrance scene, but no entrance animation was detected'
+          + ' (getAnimations reported zero at t=0 and t=500ms; filmstrip energy is also'
+          + ' absent or zero). Either the entrance animation is not running, or it uses'
+          + ' GSAP/rAF — in that case run `omd render --filmstrip` to confirm via the'
+          + ' energy curve.',
+      });
+    }
+  }
+
+  return violations;
+}

--- a/core/types.ts
+++ b/core/types.ts
@@ -256,6 +256,42 @@ export interface Invariants {
 }
 
 /**
+ * Energy for a single adjacent-frame pair: how much of the image changed.
+ * Part of EnergyCurve; defined here so Reference (which embeds EnergyCurve) stays
+ * in the same file as all other core record types.
+ */
+export interface FrameEnergy {
+  /** 0-indexed index of the earlier frame in the pair. */
+  pairIndex: number;
+  /**
+   * Fraction of pixels whose max RGB channel difference exceeds the diff threshold.
+   * 0..1, 4dp. 0 = identical frames; 1 = every pixel changed beyond threshold.
+   */
+  changedFraction: number;
+  /**
+   * Fraction of changed pixels per vertical third of the frame: [top, mid, bottom].
+   * Answers "where did the motion happen" without requiring layout data.
+   */
+  regionFractions: [number, number, number];
+}
+
+/**
+ * Pixel-diff motion energy measured from a filmstrip's frame sequence.
+ *
+ * Unlike the getAnimations() probe (MotionMeasurement), this is computed from actual
+ * rendered pixels and therefore captures ALL motion including GSAP/rAF — closing the
+ * getAnimations() blind spot documented on MotionMeasurement and Invariants.animatedProperties.
+ */
+export interface EnergyCurve {
+  /** Number of source frames (pairs.length === frames - 1). */
+  frames: number;
+  /** Per-interval pixel-difference scores, one entry per adjacent frame pair. */
+  pairs: FrameEnergy[];
+  /** Maximum changedFraction across all pairs. 0 when pairs is empty. */
+  peakEnergy: number;
+}
+
+/**
  * Live motion probe data attached to ir.meta.motion by probeMotion() in
  * core/render/index.ts. Absent on IRs captured before this probe was added;
  * all consuming code reads defensively (presence check before access).
@@ -265,6 +301,10 @@ export interface Invariants {
  * probe — a GSAP-only page reports animatedProperties: []. Only CSS animations, CSS
  * transitions exposed via WAAPI, and explicit WAAPI calls (Framer Motion's WAAPI path)
  * are captured. This limit is surfaced in Invariants.animatedProperties.
+ *
+ * To close this blind spot, use the pixel-diff energy curve (EnergyCurve / computeEnergy
+ * in core/motion/energy.ts): it measures frame-to-frame pixel differences and sees all
+ * motion including GSAP/rAF.
  */
 export interface MotionMeasurement {
   /** Animation states sampled at t=0ms, t=500ms, t=1500ms after load. */
@@ -319,6 +359,15 @@ export interface Reference {
    * captured before this field was introduced — treat absence as `'scout'` at usage sites.
    */
   origin?: 'user' | 'scout';
+  /**
+   * Pixel-diff motion energy curve measured during reference capture. Absent when the
+   * reference was captured before energy measurement was introduced, or when kind is
+   * `'image'` (no rendered page to film). Treat absence as null at usage sites.
+   *
+   * Unlike `ir.meta.motion` (which only sees getAnimations()), this curve captures ALL
+   * pixel-level motion including GSAP/rAF — closing the getAnimations() blind spot.
+   */
+  energyCurve?: EnergyCurve | null;
 }
 
 /** How close a page sits to a reference. 1 is identical; the warning threshold is 0.6. */

--- a/evals/motion-showpiece/graders/filmstrip-has-energy.md
+++ b/evals/motion-showpiece/graders/filmstrip-has-energy.md
@@ -1,0 +1,23 @@
+# Grader: Filmstrip Frames Differ (Energy > 0)
+
+Check that the filmstrip captured visible motion — at least one frame pair shows pixel-level change, confirming animation actually ran.
+
+## Pass criteria
+
+- `.omd/.cache/filmstrip-energy.json` (or any `*-energy.json` in `.omd/.cache/`) exists.
+- `peakEnergy` in the energy JSON is greater than 0.01 (more than 1% of pixels changed between at least one frame pair).
+- At least one `regionFraction` entry (top/mid/bottom) in any pair is non-zero — the motion is spatially locatable, not a metadata artifact.
+
+## Fail criteria
+
+- No energy file found in `.omd/.cache/`.
+- `peakEnergy` is 0 or below 0.01 — the filmstrip frames are identical, meaning no animation fired during capture.
+- The frames file count is fewer than 2 (only one frame captured, no pairs to compare).
+
+## Severity
+
+FAIL — a showpiece page with zero measured motion is not a showpiece page. The one memorable moment must produce a pixel-level signal in the filmstrip.
+
+## Note on GSAP
+
+If the page uses GSAP/rAF exclusively, `getAnimations()` will report zero animations (a known probe limit), but the energy curve will still show non-zero `peakEnergy` as long as the animation actually ran during the filmstrip capture window. A GSAP-only page with peakEnergy > 0.01 passes this grader.

--- a/evals/motion-showpiece/graders/motion-rules-clean.md
+++ b/evals/motion-showpiece/graders/motion-rules-clean.md
@@ -1,0 +1,27 @@
+# Grader: MOTION-* Findings Clean (or Overruled)
+
+Check that the deterministic motion rules in `omd check --category motion` pass, or that any firing rule has a recorded decision overrule.
+
+## Pass criteria
+
+- `omd check <page> --category motion` exits 0 (no findings), OR
+- Every finding that fires has a corresponding `omd decision` entry in `.omd/decisions.md` that names the rule ID and gives a reason (not "it looked fine").
+
+Rules checked:
+- `MOTION-NO-REDUCED` — animations without prefers-reduced-motion (see reduced-motion grader)
+- `MOTION-LAYOUT-THRASH` — transitioning width/height/top/left instead of transform
+- `MOTION-UNIFORM` — 3+ animated nodes sharing one duration with only CSS default easings
+
+If `.omd/motion-spec.md` exists, also check:
+- `MOTION-SPEC-DRIFT` — spec scenes with no measured motion, or measured motion with no spec scene
+- `MOTION-NO-ENTRANCE` — showpiece register + entrance spec scene + no measured entrance
+
+## Fail criteria
+
+- Any of the above rules fires and there is no decision entry overruling it.
+- `MOTION-UNIFORM` fires — uniform 500ms ease-in-out is the generated-work signature and is never acceptable for a showpiece page without an explicit overrule.
+- `MOTION-SPEC-DRIFT` fires — a broken contract between spec and build.
+
+## Severity
+
+FAIL for `MOTION-UNIFORM` (the signature of an unexamined build) and `MOTION-SPEC-DRIFT` (spec-build contract broken). WARN for others without an overrule.

--- a/evals/motion-showpiece/graders/motion-spec-exists.md
+++ b/evals/motion-showpiece/graders/motion-spec-exists.md
@@ -1,0 +1,21 @@
+# Grader: motion-spec.md Exists and Cites Cookbook Recipes
+
+Check that the build produced a motion spec before writing animation code, and that each scene cites a recipe from the cookbook.
+
+## Pass criteria
+
+- `.omd/motion-spec.md` exists and has at least one `## Scene` header.
+- Each scene entry includes a `trigger:` field (load, scroll, or hover).
+- At least one scene cites a recipe from `core/motion/recipes/` by file name (e.g. `split-text-entrance.md`, `scroll-reveal.md`, `stagger-orchestrator.md`) or explicitly names the cookbook as the source.
+- At least one scene cites a `duration` and `easing` drawn from a motion study reference (not from recipe illustrative defaults — the value should match or reference a measured invariant from the board's motion studies).
+
+## Fail criteria
+
+- `.omd/motion-spec.md` does not exist.
+- The spec exists but has no `##` scene headers (empty or preamble-only).
+- No scene cites a cookbook recipe — animations were improvised without the spec-as-contract.
+- Duration/easing values are purely default (e.g. `500ms ease-in-out` with no study citation) across all scenes.
+
+## Severity
+
+FAIL if the spec is absent or entirely uncited. WARN if scenes exist but recipe citations are thin.

--- a/evals/motion-showpiece/graders/reduced-motion.md
+++ b/evals/motion-showpiece/graders/reduced-motion.md
@@ -1,0 +1,17 @@
+# Grader: Reduced-Motion Block Present
+
+Check that the build includes a `@media (prefers-reduced-motion)` block wrapping the motion layer.
+
+## Pass criteria
+
+- `omd check <page> --category motion` returns no `MOTION-NO-REDUCED` finding.
+- OR: the page source (HTML/CSS) contains at least one `prefers-reduced-motion` media query that suppresses or substantially reduces the animations.
+
+## Fail criteria
+
+- `MOTION-NO-REDUCED` fires and no `omd decision` overrule of that finding exists in `.omd/decisions.md`.
+- The page has live animations but no `prefers-reduced-motion` handling at all.
+
+## Severity
+
+FAIL — a showpiece page with striking animation that ignores the user's accessibility preference is a correctness defect, not a style choice.

--- a/evals/motion-showpiece/prompt.md
+++ b/evals/motion-showpiece/prompt.md
@@ -1,0 +1,3 @@
+Design a showpiece landing page for a Korean independent music label called "새벽 레코즈" (Saebyeok Records — "Dawn Records"). The label's aesthetic: raw, alive, post-midnight energy. Not corporate, not cute, not generic. Use omd:ultradesign.
+
+The page must have striking animation. The designer should choose one memorable orchestrated moment — not a list of techniques, one moment.

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -436,11 +436,21 @@ omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come 
 
 Only when the copy is clean does the eye see the page.
 
-Finally spawn `omd:eye` on the built page. Hand it the desktop screenshot, the mobile
-screenshot, the filmstrip, and the combined findings from all viewport runs (including
-motion). The filmstrip tells the eye what appeared when during load — information that a
-static render cannot carry. It sees the renders and the findings and nothing about why you
-built it that way. It cannot defend your reasoning because it does not have it.
+Finally spawn `omd:eye` on the built page. Hand it:
+- The desktop screenshot and the mobile screenshot.
+- The filmstrip HTML (`.omd/.cache/filmstrip.html`).
+- If `.omd/motion-spec.md` exists, its content — the eye reads it as a checklist of
+  intended scenes to locate in the frames, never as reasoning to defend. The spec is a
+  build artifact: it was written by omd:hand before the code, and the eye was not in
+  the room when that decision was made. That boundary is the point — the eye judges the
+  gap between spec and frames without access to why the spec says what it says.
+- The combined findings from all viewport runs (including motion).
+
+The filmstrip tells the eye what appeared when during load — information that a static
+render cannot carry. When a filmstrip exists, the eye must not judge motion quality from
+the static screenshot alone. It sees the renders, the filmstrip, the spec checklist, and
+the findings. It does not see the frame, the concept, the reference board, or any other
+reasoning. It cannot defend what it was never shown.
 
 ---
 

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -75,3 +75,30 @@ instructions: |
   expectations (calling the entrance animation "distracting") or a quiet build with
   showpiece expectations ("this landing page needs more visual interest"). The register was
   committed before you were spawned; it is not yours to overrule.
+
+  ## Filmstrip and motion-spec
+
+  When a filmstrip is provided alongside the static render, use it — never judge motion
+  quality from the static screenshot alone when frames exist.
+
+  The filmstrip shows what appeared when, in temporal order. A static render cannot tell
+  you whether an entrance animation fired, whether a scroll reveal is visible mid-page, or
+  whether the "one memorable moment" committed in the concept actually materialised. The
+  frames can.
+
+  When `.omd/motion-spec.md` is also provided:
+
+  1. Read the spec's scene list **before** examining the frames.
+  2. For each scene: identify the frame(s) where that scene should be visible; judge whether
+     the scene reads — is the motion perceptible, or does the frame look like the one before it?
+  3. A spec scene that is invisible across all frames is a finding: name the scene, note
+     which frames you checked, and state that no visible change was detected.
+  4. Do not judge motion quality from a single static screenshot when a filmstrip exists.
+     "The page looks dynamic" from one frame is not evidence; "Frame 1 and Frame 2 are
+     identical in the hero region where the entrance scene should fire" is.
+
+  **The motion-spec boundary**: `.omd/motion-spec.md` is a build artifact written by
+  omd-hand before the code was written. It records what the build was contracted to contain.
+  You are not given the reasoning that produced the spec — not the framing, not the concept,
+  not the reference board. You see the spec and you see the frames. Your only question is:
+  did the spec materialise? You are not defending or critiquing the spec's decisions.

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -436,11 +436,21 @@ omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come 
 
 Only when the copy is clean does the eye see the page.
 
-Finally spawn `omd-eye` on the built page. Hand it the desktop screenshot, the mobile
-screenshot, the filmstrip, and the combined findings from all viewport runs (including
-motion). The filmstrip tells the eye what appeared when during load — information that a
-static render cannot carry. It sees the renders and the findings and nothing about why you
-built it that way. It cannot defend your reasoning because it does not have it.
+Finally spawn `omd-eye` on the built page. Hand it:
+- The desktop screenshot and the mobile screenshot.
+- The filmstrip HTML (`.omd/.cache/filmstrip.html`).
+- If `.omd/motion-spec.md` exists, its content — the eye reads it as a checklist of
+  intended scenes to locate in the frames, never as reasoning to defend. The spec is a
+  build artifact: it was written by omd-hand before the code, and the eye was not in
+  the room when that decision was made. That boundary is the point — the eye judges the
+  gap between spec and frames without access to why the spec says what it says.
+- The combined findings from all viewport runs (including motion).
+
+The filmstrip tells the eye what appeared when during load — information that a static
+render cannot carry. When a filmstrip exists, the eye must not judge motion quality from
+the static screenshot alone. It sees the renders, the filmstrip, the spec checklist, and
+the findings. It does not see the frame, the concept, the reference board, or any other
+reasoning. It cannot defend what it was never shown.
 
 ---
 

--- a/test/motion-energy.test.ts
+++ b/test/motion-energy.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for core/motion/energy.ts — M4 pixel-diff motion energy.
+ *
+ * All tests use synthetic PNG buffers created with Node's built-in deflate + CRC32.
+ * No browser is required. The test helpers (makePng, uniformRgb) build minimal valid
+ * PNGs with filter type 0 (None), which is the simplest case for decodePng.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deflateSync, crc32 } from 'node:zlib';
+import { decodePng, computeEnergy } from '../core/motion/energy.ts';
+
+// ── PNG creation helpers ──────────────────────────────────────────────────────
+
+function uint32BE(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(n >>> 0, 0);
+  return b;
+}
+
+function makePngChunk(type: string, data: Buffer): Buffer {
+  const typeBytes = Buffer.from(type, 'ascii');
+  const checksum = crc32(Buffer.concat([typeBytes, data]));
+  return Buffer.concat([uint32BE(data.length), typeBytes, data, uint32BE(checksum >>> 0)]);
+}
+
+/**
+ * Build a minimal valid PNG from raw RGB pixels.
+ * Uses filter type 0 (None) for every scanline — simplest for testing purposes.
+ */
+function makePng(width: number, height: number, rgb: Uint8Array): Buffer {
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;  // bit depth
+  ihdr[9] = 2;  // color type: RGB
+  ihdr[10] = 0; ihdr[11] = 0; ihdr[12] = 0; // compression, filter, interlace
+
+  const stride = width * 3;
+  // Build raw data: one filter byte (0 = None) per scanline, then the pixel data.
+  const rawRows = Buffer.alloc((stride + 1) * height);
+  for (let y = 0; y < height; y++) {
+    rawRows[y * (stride + 1)] = 0; // filter: None
+    for (let x = 0; x < stride; x++) {
+      rawRows[y * (stride + 1) + 1 + x] = rgb[y * stride + x]!;
+    }
+  }
+
+  return Buffer.concat([
+    signature,
+    makePngChunk('IHDR', ihdr),
+    makePngChunk('IDAT', deflateSync(rawRows)),
+    makePngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+/** Create a width×height RGB image where every pixel has the given [r,g,b] value. */
+function uniformRgb(width: number, height: number, r: number, g: number, b: number): Buffer {
+  const pixels = new Uint8Array(width * height * 3);
+  for (let i = 0; i < width * height; i++) {
+    pixels[i * 3] = r;
+    pixels[i * 3 + 1] = g;
+    pixels[i * 3 + 2] = b;
+  }
+  return makePng(width, height, pixels);
+}
+
+// ── decodePng ────────────────────────────────────────────────────────────────
+
+test('decodePng: decodes a 2×2 RGB PNG with known pixel values', () => {
+  // 2×2 image: top-left=red, top-right=green, bottom-left=blue, bottom-right=white
+  const pixels = new Uint8Array([
+    255, 0, 0,    // top-left: red
+    0, 255, 0,    // top-right: green
+    0, 0, 255,    // bottom-left: blue
+    255, 255, 255, // bottom-right: white
+  ]);
+  const png = makePng(2, 2, pixels);
+  const { width, height, channels } = decodePng(png);
+  assert.equal(width, 2);
+  assert.equal(height, 2);
+  assert.equal(channels, 3);
+});
+
+test('decodePng: pixel values round-trip correctly', () => {
+  const pixels = new Uint8Array([100, 150, 200, 50, 75, 25, 255, 0, 128, 10, 20, 30]);
+  const png = makePng(4, 1, pixels);
+  const decoded = decodePng(png);
+  assert.equal(decoded.width, 4);
+  assert.equal(decoded.height, 1);
+  for (let i = 0; i < pixels.length; i++) {
+    assert.equal(decoded.pixels[i], pixels[i], `pixel[${i}] mismatch`);
+  }
+});
+
+test('decodePng: rejects a non-PNG buffer', () => {
+  const notPng = Buffer.from('not a png at all');
+  assert.throws(() => decodePng(notPng), /not a PNG/);
+});
+
+test('decodePng: rejects 16-bit depth', () => {
+  // Build a PNG with IHDR claiming 16-bit depth. decodePng should throw before deflate.
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(4, 0); ihdr.writeUInt32BE(4, 4);
+  ihdr[8] = 16; ihdr[9] = 2; // 16-bit RGB
+  const chunk = makePngChunk('IHDR', ihdr);
+  const fake = Buffer.concat([signature, chunk]);
+  assert.throws(() => decodePng(fake), /unsupported PNG bit depth/);
+});
+
+// ── computeEnergy ────────────────────────────────────────────────────────────
+
+test('computeEnergy: identical frames → changedFraction 0 and peakEnergy 0', () => {
+  const frame = uniformRgb(8, 6, 128, 64, 32);
+  const result = computeEnergy([frame, frame]);
+  assert.equal(result.frames, 2);
+  assert.equal(result.pairs.length, 1);
+  assert.equal(result.pairs[0]!.changedFraction, 0);
+  assert.equal(result.peakEnergy, 0);
+});
+
+test('computeEnergy: completely different frames → changedFraction 1 and peakEnergy 1', () => {
+  const black = uniformRgb(4, 4, 0, 0, 0);
+  const white = uniformRgb(4, 4, 255, 255, 255);
+  const result = computeEnergy([black, white]);
+  assert.equal(result.pairs[0]!.changedFraction, 1);
+  assert.equal(result.peakEnergy, 1);
+});
+
+test('computeEnergy: small diff below threshold → changedFraction 0', () => {
+  // Default threshold is 10; diff of 5 should not register as changed.
+  const frame1 = uniformRgb(4, 4, 100, 100, 100);
+  const frame2 = uniformRgb(4, 4, 105, 105, 105); // diff = 5 < threshold 10
+  const result = computeEnergy([frame1, frame2]);
+  assert.equal(result.pairs[0]!.changedFraction, 0);
+});
+
+test('computeEnergy: diff exactly at threshold → not counted (> threshold, not >=)', () => {
+  const frame1 = uniformRgb(4, 4, 100, 100, 100);
+  const frame2 = uniformRgb(4, 4, 110, 100, 100); // diff = 10 = threshold, not >
+  const result = computeEnergy([frame1, frame2]);
+  assert.equal(result.pairs[0]!.changedFraction, 0);
+});
+
+test('computeEnergy: diff just above threshold → changedFraction 1', () => {
+  const frame1 = uniformRgb(4, 4, 100, 100, 100);
+  const frame2 = uniformRgb(4, 4, 111, 100, 100); // diff = 11 > threshold 10
+  const result = computeEnergy([frame1, frame2]);
+  assert.equal(result.pairs[0]!.changedFraction, 1);
+});
+
+test('computeEnergy: top-third motion only → top regionFraction > 0, others 0', () => {
+  // 6 rows: top 2 change (rows 0-1), mid 2 stay (rows 2-3), bottom 2 stay (rows 4-5).
+  const w = 4;
+  const h = 6;
+  const pixels1 = new Uint8Array(w * h * 3).fill(100);
+  const pixels2 = new Uint8Array(w * h * 3).fill(100);
+  // Change top two rows only (rows 0 and 1 = first third with floor(6/3)=2 rows).
+  for (let y = 0; y < 2; y++) {
+    for (let x = 0; x < w; x++) {
+      pixels2[(y * w + x) * 3] = 200; // diff = 100 > threshold 10
+    }
+  }
+  const result = computeEnergy([makePng(w, h, pixels1), makePng(w, h, pixels2)]);
+  const [top, mid, bottom] = result.pairs[0]!.regionFractions;
+  assert.ok(top! > 0, 'top region should have changed pixels');
+  assert.equal(mid, 0, 'mid region should be unchanged');
+  assert.equal(bottom, 0, 'bottom region should be unchanged');
+});
+
+test('computeEnergy: dimension mismatch → changedFraction 1', () => {
+  const small = uniformRgb(4, 4, 0, 0, 0);
+  const large = uniformRgb(8, 8, 255, 255, 255);
+  const result = computeEnergy([small, large]);
+  assert.equal(result.pairs[0]!.changedFraction, 1);
+  assert.deepEqual(result.pairs[0]!.regionFractions, [1, 1, 1]);
+});
+
+test('computeEnergy: three frames → two pairs with correct pairIndex', () => {
+  const f0 = uniformRgb(4, 3, 0, 0, 0);
+  const f1 = uniformRgb(4, 3, 255, 0, 0);  // high diff vs f0
+  const f2 = uniformRgb(4, 3, 255, 0, 0);  // same as f1 → no diff
+  const result = computeEnergy([f0, f1, f2]);
+  assert.equal(result.frames, 3);
+  assert.equal(result.pairs.length, 2);
+  assert.equal(result.pairs[0]!.pairIndex, 0);
+  assert.equal(result.pairs[1]!.pairIndex, 1);
+  assert.ok(result.pairs[0]!.changedFraction > 0, 'pair 0 should show motion');
+  assert.equal(result.pairs[1]!.changedFraction, 0, 'pair 1 should show no motion');
+  assert.equal(result.peakEnergy, result.pairs[0]!.changedFraction);
+});
+
+test('computeEnergy: single frame → no pairs and peakEnergy 0', () => {
+  const frame = uniformRgb(4, 4, 128, 128, 128);
+  const result = computeEnergy([frame]);
+  assert.equal(result.frames, 1);
+  assert.equal(result.pairs.length, 0);
+  assert.equal(result.peakEnergy, 0);
+});
+
+test('computeEnergy: custom diffThreshold respected', () => {
+  // diff = 50; threshold 60 → not counted; threshold 40 → counted.
+  const frame1 = uniformRgb(4, 4, 100, 100, 100);
+  const frame2 = uniformRgb(4, 4, 150, 100, 100); // max diff = 50
+  const notCounted = computeEnergy([frame1, frame2], 60);
+  const counted = computeEnergy([frame1, frame2], 40);
+  assert.equal(notCounted.pairs[0]!.changedFraction, 0, 'threshold 60 should not count diff 50');
+  assert.equal(counted.pairs[0]!.changedFraction, 1, 'threshold 40 should count diff 50');
+});
+
+test('computeEnergy: partial row change produces correct fraction', () => {
+  // 4×4 image; change only 2 of 16 pixels.
+  const w = 4;
+  const h = 4;
+  const px1 = new Uint8Array(w * h * 3).fill(100);
+  const px2 = new Uint8Array(w * h * 3).fill(100);
+  // Change pixels at (0,0) and (1,0) — top row, leftmost two pixels.
+  px2[0] = 255; px2[3] = 255; // pixel 0 and pixel 1, R channel
+  const result = computeEnergy([makePng(w, h, px1), makePng(w, h, px2)]);
+  // 2 out of 16 pixels changed.
+  assert.equal(result.pairs[0]!.changedFraction, 2 / 16);
+});

--- a/test/motion-spec.test.ts
+++ b/test/motion-spec.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for core/rules/motion-spec.ts — M5 spec-vs-measured rules.
+ *
+ * All tests use synthetic IR, synthetic spec markdown, and synthetic energy curves.
+ * No browser required. The probe data shape mirrors what probeMotion() attaches to
+ * ir.meta.motion at check time.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalize } from '../core/ir/normalize.ts';
+import { checkMotionSpec } from '../core/rules/motion-spec.ts';
+import type { EnergyCurve, RawIr } from '../core/types.ts';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeIr(meta?: Record<string, unknown>) {
+  const raw: RawIr = {
+    nodes: [{
+      id: 'n0', name: 'div', type: 'FRAME', path: 'body/div',
+      parent: null, box: { x: 0, y: 0, w: 100, h: 100 }, children: [],
+    }],
+    ...(meta ? { meta } : {}),
+  };
+  return normalize(raw);
+}
+
+function probeWithAnimations(count = 1) {
+  return {
+    animatedProperties: count > 0 ? ['opacity', 'transform'] : [],
+    hasReducedMotion: false,
+    scrollChoreography: [],
+    snapshots: [
+      { t: 0, animations: Array.from({ length: count }, () => ({ duration: 400, easing: 'ease-out', properties: ['opacity'], playState: 'running' })) },
+      { t: 500, animations: [] },
+      { t: 1500, animations: [] },
+    ],
+  };
+}
+
+function probeNoAnimations() {
+  return {
+    animatedProperties: [],
+    hasReducedMotion: false,
+    scrollChoreography: [],
+    snapshots: [
+      { t: 0, animations: [] },
+      { t: 500, animations: [] },
+      { t: 1500, animations: [] },
+    ],
+  };
+}
+
+function probeScrollFired() {
+  return {
+    animatedProperties: [],
+    hasReducedMotion: false,
+    scrollChoreography: [{ step: 2, fired: 3, entered: 5 }],
+    snapshots: [
+      { t: 0, animations: [] },
+      { t: 500, animations: [] },
+      { t: 1500, animations: [] },
+    ],
+  };
+}
+
+function energyCurveWithMotion(peak = 0.15): EnergyCurve {
+  return {
+    frames: 2,
+    pairs: [{ pairIndex: 0, changedFraction: peak, regionFractions: [peak, 0, 0] }],
+    peakEnergy: peak,
+  };
+}
+
+function energyCurveNoMotion(): EnergyCurve {
+  return {
+    frames: 2,
+    pairs: [{ pairIndex: 0, changedFraction: 0, regionFractions: [0, 0, 0] }],
+    peakEnergy: 0,
+  };
+}
+
+const SPEC_WITH_LOAD_SCENE = `
+## Hero entrance
+- trigger: load
+- target: .hero-heading
+- properties: opacity, transform
+- duration: 400ms
+- easing: cubic-bezier(0.2,0,0,1)
+`.trim();
+
+const SPEC_WITH_SCROLL_SCENE = `
+## Card reveal
+- trigger: scroll
+- target: .card
+- properties: opacity, transform
+- duration: 300ms
+`.trim();
+
+const SPEC_WITH_STAGGER = `
+## Cards stagger entrance
+- trigger: scroll
+- target: .card
+- stagger: 40ms between .card siblings
+- duration: 300ms
+`.trim();
+
+const SPEC_EMPTY_NO_SCENES = '# Motion Spec\n\nNo scenes defined yet.\n';
+
+const FRAME_SHOWPIECE = `
+---
+generator: "a bold agency site"
+---
+
+## Frame
+
+This page commits to the **showpiece** register...
+`.trim();
+
+const FRAME_QUIET = `
+## Frame
+
+This page uses a quiet, confident register. Restraint is the correct choice here.
+`.trim();
+
+// ── MOTION-SPEC-DRIFT: spec has scenes, probe has nothing ─────────────────────
+
+test('MOTION-SPEC-DRIFT fires when spec has a load scene but probe detected nothing', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, null);
+  assert.ok(v.some((x) => x.id === 'MOTION-SPEC-DRIFT'), 'should fire MOTION-SPEC-DRIFT');
+});
+
+test('MOTION-SPEC-DRIFT fires when spec has a scroll scene but probe detected nothing', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_SCROLL_SCENE, null, null);
+  assert.ok(v.some((x) => x.id === 'MOTION-SPEC-DRIFT'));
+});
+
+test('MOTION-SPEC-DRIFT does not fire when probe has animatedProperties', () => {
+  const ir = makeIr({ motion: probeWithAnimations(2) });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-SPEC-DRIFT'));
+});
+
+test('MOTION-SPEC-DRIFT does not fire when scrollChoreography shows fired > 0', () => {
+  const ir = makeIr({ motion: probeScrollFired() });
+  const v = checkMotionSpec(ir, SPEC_WITH_SCROLL_SCENE, null, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-SPEC-DRIFT'));
+});
+
+test('MOTION-SPEC-DRIFT does not fire when energy curve has non-zero peak', () => {
+  // probe shows nothing BUT energy curve shows motion (GSAP scenario)
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, energyCurveWithMotion(0.1));
+  assert.ok(!v.some((x) => x.id === 'MOTION-SPEC-DRIFT'), 'energy should be enough to silence the rule');
+});
+
+test('MOTION-SPEC-DRIFT does not fire when energy peak is below the noise floor (0.005)', () => {
+  // Anti-alias noise: 0.001 < 0.005 threshold should not count as motion
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const noise: EnergyCurve = { frames: 2, pairs: [{ pairIndex: 0, changedFraction: 0.001, regionFractions: [0.001, 0, 0] }], peakEnergy: 0.001 };
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, noise);
+  assert.ok(v.some((x) => x.id === 'MOTION-SPEC-DRIFT'), 'noise below floor should still trigger drift');
+});
+
+// ── MOTION-SPEC-DRIFT: probe has animations, spec has no scenes ───────────────
+
+test('MOTION-SPEC-DRIFT fires when probe detected animations but spec has no scenes', () => {
+  const ir = makeIr({ motion: probeWithAnimations(3) });
+  const v = checkMotionSpec(ir, SPEC_EMPTY_NO_SCENES, null, null);
+  assert.ok(v.some((x) => x.id === 'MOTION-SPEC-DRIFT'));
+});
+
+test('MOTION-SPEC-DRIFT does not fire when both spec and probe have nothing', () => {
+  // No spec scenes AND no probe motion → nothing to compare, no violation.
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_EMPTY_NO_SCENES, null, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-SPEC-DRIFT'));
+});
+
+// ── No probe data → skip all rules ───────────────────────────────────────────
+
+test('No violations when ir.meta.motion is absent (pre-probe IR)', () => {
+  const ir = makeIr(); // no meta at all
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, null);
+  assert.equal(v.length, 0, 'pre-probe IR must not produce false positives');
+});
+
+test('No violations when ir.meta.motion is null', () => {
+  const ir = makeIr({ motion: null });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, null);
+  assert.equal(v.length, 0);
+});
+
+// ── MOTION-NO-ENTRANCE ────────────────────────────────────────────────────────
+
+test('MOTION-NO-ENTRANCE fires when showpiece + entrance spec + no probe/energy', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, FRAME_SHOWPIECE, null);
+  assert.ok(v.some((x) => x.id === 'MOTION-NO-ENTRANCE'));
+});
+
+test('MOTION-NO-ENTRANCE does not fire when probe has entrance animations (snap0 > 0)', () => {
+  const ir = makeIr({ motion: probeWithAnimations(2) });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, FRAME_SHOWPIECE, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-ENTRANCE'));
+});
+
+test('MOTION-NO-ENTRANCE does not fire when energy curve shows entrance motion', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, FRAME_SHOWPIECE, energyCurveWithMotion(0.2));
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-ENTRANCE'));
+});
+
+test('MOTION-NO-ENTRANCE does not fire when register is not showpiece', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, FRAME_QUIET, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-ENTRANCE'), 'quiet register should not trigger MOTION-NO-ENTRANCE');
+});
+
+test('MOTION-NO-ENTRANCE does not fire when frame.md is null', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-ENTRANCE'));
+});
+
+test('MOTION-NO-ENTRANCE does not fire when spec has no load scene (scroll only)', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_SCROLL_SCENE, FRAME_SHOWPIECE, null);
+  assert.ok(!v.some((x) => x.id === 'MOTION-NO-ENTRANCE'));
+});
+
+// ── Stagger-only spec does not generate false MOTION-SPEC-DRIFT ──────────────
+
+test('MOTION-SPEC-DRIFT fires on scroll-stagger spec with no probe motion (trigger is scroll)', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_STAGGER, null, null);
+  // SPEC_WITH_STAGGER has trigger: scroll → should fire drift when nothing measured
+  assert.ok(v.some((x) => x.id === 'MOTION-SPEC-DRIFT'));
+});
+
+// ── Violation shape ───────────────────────────────────────────────────────────
+
+test('MOTION-SPEC-DRIFT violation has correct shape (category, layer, severity)', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, null, null);
+  const drift = v.find((x) => x.id === 'MOTION-SPEC-DRIFT');
+  assert.ok(drift);
+  assert.equal(drift.category, 'motion');
+  assert.equal(drift.layer, 1);
+  assert.equal(drift.severity, 'warn');
+  assert.equal(drift.nodeId, 'page');
+  assert.equal(drift.path, 'motion-spec');
+});
+
+test('MOTION-NO-ENTRANCE violation has correct shape', () => {
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, SPEC_WITH_LOAD_SCENE, FRAME_SHOWPIECE, energyCurveNoMotion());
+  const noEnt = v.find((x) => x.id === 'MOTION-NO-ENTRANCE');
+  assert.ok(noEnt);
+  assert.equal(noEnt.category, 'motion');
+  assert.equal(noEnt.layer, 1);
+  assert.equal(noEnt.severity, 'warn');
+});
+
+// ── Multiple scenes: only load/scroll count for drift ────────────────────────
+
+test('hover-only spec does not trigger MOTION-SPEC-DRIFT when probe is empty', () => {
+  const hoverOnlySpec = `
+## Button hover glow
+- trigger: hover
+- target: button
+- duration: 150ms
+`.trim();
+  const ir = makeIr({ motion: probeNoAnimations() });
+  const v = checkMotionSpec(ir, hoverOnlySpec, null, null);
+  // Hover scenes don't count for drift check (hover is interactive, not measured by probe)
+  assert.ok(!v.some((x) => x.id === 'MOTION-SPEC-DRIFT'), 'hover-only spec should not produce drift finding');
+});


### PR DESCRIPTION
Plan v2 items M4, M5, M6. 307→342 tests. Zero new dependencies (built-in PNG decode for Playwright's fixed format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)