### PR TITLE
Batch K — finish pass + eval reinforcement

### DIFF
--- a/adapters/build.ts
+++ b/adapters/build.ts
@@ -117,6 +117,15 @@ export function build(): void {
       }
     }
 
+    // Copy craft pack (finish-pass checklist and related craft material) so agents can read it
+    // at ${CLAUDE_PLUGIN_ROOT}/core/craft/
+    const craftDir = join(root, 'core', 'craft');
+    if (existsSync(craftDir)) {
+      for (const f of readdirSync(craftDir).filter((f) => f.endsWith('.md'))) {
+        write(host, `core/craft/${f}`, readFileSync(join(craftDir, f), 'utf8'));
+      }
+    }
+
     console.log(`${host}: ${Object.keys(files).length} files, ${skills.length} skills`);
   }
 

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -347,6 +347,35 @@ capture or a theory file is a decision that must be reconsidered — the table m
 gap visible. The eye reads `.omd/attribution.md` alongside the screenshot; any row that
 reads "I chose this" without a source is a finding.
 
+## Finish pass — the last 5%
+
+After `omd check` returns clean and before handback, walk
+`${CLAUDE_PLUGIN_ROOT}/core/craft/finish-pass.md` (or `core/craft/finish-pass.md` in the
+repo root) top to bottom. Each item is either implemented or skipped with a written reason
+in `omd decision`. The six items are:
+
+1. **`::selection`** — derive the highlight colour from `--color-accent`. Default browser
+   selection blue on a page with a considered colour system announces that someone stopped
+   caring at the boundary of their CSS.
+2. **Focus ring** — `:focus-visible` with a two-layer `box-shadow` ring, never
+   `outline: none` without a replacement. `A11Y-FOCUS-SUPPRESSED` fires on bare suppression.
+   Cite the FOCUS rule in the decision entry.
+3. **Scrollbar** — `scrollbar-color` / `scrollbar-width` (standards-track, Chrome 121+ and
+   Firefox) first; `-webkit-scrollbar` rules as the noted fallback.
+4. **Optical alignment** — icon baseline nudge (`vertical-align: -0.125em` as a starting
+   point), button padding asymmetry (reduce bottom by 1–2px), tabular figures on numeric
+   columns. These are the 1px corrections a linter cannot catch and a person always notices.
+5. **Favicon** — inline SVG data-URI so no asset file is required. A monogram character on
+   the brand background colour. The emoji-favicon variant is acceptable only when the emoji
+   is a deliberate brand choice. A page without a favicon reads as unfinished in a tab row.
+6. **OG and meta** — `<title>`, `<meta name="description">`, `og:title`, `og:description`,
+   `og:image` (only if the designed card file actually exists). OG copy must pass the same
+   rules as page copy: SLOP-COPY, SLOP-PINK-ELEPHANT, no pink-elephant negations. If the
+   brief was in Korean, the OG strings are in Korean.
+
+A page without items 5 and 6 reads as a prototype, not a product, regardless of how well
+the rest was executed.
+
 ## Check yourself before you hand off
 
     omd check <your-page> --json

--- a/core/craft/finish-pass.md
+++ b/core/craft/finish-pass.md
@@ -1,0 +1,254 @@
+# Finish pass — the last 5%
+
+Done is when the build passes checks and the eye approves it. Cared for is when the cursor selects text and the highlight colour is yours, when focus rings look designed rather than browser-default, when the favicon tab reads as the brand in a row of twenty other tabs. Nobody schedules these items because none of them ships features. All of them ship the difference between a page a developer handed off and a page a designer finished.
+
+This checklist runs after `omd check` returns clean and before handback. Walk it top to bottom. Each item is either implemented or skipped with a written reason. A page without a favicon and `::selection` colour reads as unfinished regardless of everything else.
+
+---
+
+## ::selection
+
+The browser's default selection highlight is a system blue. On a page that committed to a considered colour system, the default highlight announces that somebody stopped caring at the boundary of their CSS.
+
+Derive the selection colour from the accent token already declared in `:root`. The background should be a mid-opacity or tinted variant of the accent — not a hardcoded blue, not a generic highlight. The text colour must maintain 4.5:1 contrast against the selection background.
+
+```css
+/* Derive from the accent token already declared in :root.
+   Use a transparent or tinted variant so the selected text remains readable.
+   WCAG minimum: 4.5:1 between --color-selection-text and --color-selection-bg. */
+::selection {
+  background-color: var(--color-selection-bg, oklch(from var(--color-accent) l c h / 0.25));
+  color: var(--color-selection-text, inherit);
+}
+
+/* Declare the tokens in :root alongside the rest of the colour system. */
+:root {
+  --color-selection-bg: oklch(from var(--color-accent) l c h / 0.2);
+  --color-selection-text: var(--color-text-primary);
+}
+```
+
+For browsers without `oklch()` color relative syntax support, declare an explicit fallback:
+
+```css
+:root {
+  --color-selection-bg: color-mix(in oklch, var(--color-accent) 20%, transparent);
+}
+```
+
+Condition for skipping: the brief specifies a monochrome print stylesheet as the only output. Otherwise, this ships.
+
+---
+
+## Focus ring
+
+Suppressing outlines — `outline: none` without a replacement — is an accessibility defect. The FOCUS rule in `omd check` (`A11Y-FOCUS-SUPPRESSED`) fires on any selector that removes the outline without providing a visible `:focus-visible` alternative. Do not suppress; design it.
+
+`:focus-visible` is the correct pseudo-class. `:focus` fires on mouse clicks too, which produces a ring on button-press that most designs do not intend. `:focus-visible` fires only when the keyboard (or a pointing device in sequential-focus mode) is the active input — the ring appears when it is needed and disappears when it is not.
+
+```css
+/* Remove the default only where you are replacing it. Never remove without replacing. */
+:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--color-bg-primary, #fff),
+    0 0 0 4px var(--color-focus-ring, var(--color-accent));
+}
+
+/* Declare the focus ring token in :root. */
+:root {
+  --color-focus-ring: var(--color-accent);
+}
+```
+
+The two-layer shadow creates a ring with a gap between the element edge and the visible ring — the gap is the inner shadow matching the page background. This technique works on any background colour as long as the inner shadow is updated. For dark-background sections, override locally:
+
+```css
+.section--inverted :focus-visible {
+  box-shadow:
+    0 0 0 2px var(--color-bg-inverted),
+    0 0 0 4px var(--color-focus-ring-on-dark, #fff);
+}
+```
+
+Minimum ring visibility: 3:1 contrast between the ring colour and the adjacent background (WCAG 2.2 §2.4.11). Run `omd check --category a11y` after setting these values — the checker measures contrast, not intent.
+
+---
+
+## Scrollbar
+
+The browser default scrollbar is a grey rectangle. It is legible and functional; it is not designed. On a page that committed to a colour system, the scrollbar is the one surface the browser owns that does not match.
+
+Use the standards-track properties first. `scrollbar-color` and `scrollbar-width` are in the CSS Scrollbars Specification (Candidate Recommendation) and are supported in Firefox and Chrome 121+.
+
+```css
+/* Standards-track. Thumb colour, then track colour. */
+:root {
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+  scrollbar-width: thin;
+
+  --color-scrollbar-thumb: color-mix(in oklch, var(--color-text-primary) 30%, transparent);
+  --color-scrollbar-track: transparent;
+}
+```
+
+Follow with the `-webkit-` prefixed properties as the noted fallback for Safari and older browsers. These properties do not compose with `inherit` correctly — set explicit values:
+
+```css
+/* -webkit- fallback (Safari, older Chromium). Note: these are not in any standard.
+   They are widely supported but their future is not guaranteed; the standards-track
+   properties above take precedence wherever both are supported. */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: var(--color-scrollbar-track, transparent);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-scrollbar-thumb);
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--color-scrollbar-thumb) 140%, transparent);
+}
+```
+
+Condition for skipping: the page is a web application that deliberately defers to the OS scrollbar for platform-native feel. Record the reason.
+
+---
+
+## Optical alignment
+
+Pixel-perfect alignment is not optical alignment. A 16px icon inside a 16px × 16px bounding box sits 1px high relative to adjacent text — its visual weight lands above the centre. A button whose padding is `12px 16px` produces more apparent top weight than bottom because the ascender height of the glyph does not fill the cap-height. These are the corrections that make the difference between type that looks placed and type that looks set.
+
+**Icon baseline nudge.** Icons whose bounding box touches the cap line rather than the baseline need a fractional downward shift. The correction is 1–2px for most icon sets at 16–20px; the correct value is measured, not assumed.
+
+```css
+/* Inline icons adjacent to text: nudge down by half the difference between
+   the icon's optical centre and the text baseline. Start with 1px; adjust by eye. */
+.icon-inline {
+  vertical-align: -0.125em; /* ≈ 2px at 16px font-size — tune to match the type */
+}
+```
+
+**Button padding asymmetry.** Most typefaces have a slightly higher optical midpoint than the mathematical midpoint. Equal vertical padding reads as too much bottom space on most Latin type. Subtract 1–2px from the bottom padding to correct.
+
+```css
+/* Start with equal padding, then reduce bottom by 1–2px until the label reads centred.
+   The correction varies by typeface — Inter and Geist need less, older serif faces more. */
+.button {
+  padding: 11px 20px 9px; /* or: padding-top: 11px; padding-bottom: 9px */
+}
+```
+
+**Number alignment in tables.** Tabular figures (`font-variant-numeric: tabular-nums`) align decimal points. Without this, proportional numerals produce ragged columns.
+
+```css
+.data-cell {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+```
+
+These corrections are small and cumulative. None of them will survive a linter check; they pass `omd check` before and after. They register when a human looks at the finished page and notices it is not quite right — or when they look and notice it is exactly right, without being able to say why.
+
+---
+
+## Favicon
+
+A favicon delivered as a separate asset file creates a dependency and an HTTP request. The inline SVG data-URI pattern delivers the icon with the HTML, requires no build step, and works across every browser that renders the page.
+
+**SVG data-URI (recommended):** Build the icon as an SVG element, then encode it as a data URI. For a typographic favicon, this means a single `<text>` element with a carefully chosen character and fill colour.
+
+```html
+<!-- Inline SVG favicon: no asset file, no HTTP request, works in every browser.
+     The SVG viewBox is 32×32; the font-size and y offset must be tuned to keep
+     the glyph centred — exact values depend on the typeface. -->
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%23111'/><text x='16' y='22' font-size='18' text-anchor='middle' fill='%23fff' font-family='system-ui,sans-serif' font-weight='700'>M</text></svg>">
+```
+
+Replace `%23111` with the URL-encoded hex of the brand background colour and `%23fff` with the glyph colour. The `rx='6'` rounds the favicon square — most platform launchers clip to this shape anyway; making it explicit ensures the corner doesn't read as a sharp artefact.
+
+**Emoji favicon (minimal variant):** When the brand has no monogram but an associated emoji is genuinely appropriate, the single-character SVG is the minimal implementation:
+
+```html
+<!-- Emoji favicon: one character, no colour management needed.
+     The emoji renders in its platform colour — no fill attribute required.
+     Use only when the emoji is a deliberate brand choice, not a fallback decoration. -->
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌱</text></svg>">
+```
+
+Both variants require no external asset. The inline SVG approach gives more control over the appearance at 16×16 and 32×32 display sizes; the emoji variant is correct only when the emoji reads well at small sizes (simple pictograms work; detailed emoji do not).
+
+Provide a `<title>` with the brand name — the favicon without a page title still reads as generic in the tab.
+
+---
+
+## OG and meta
+
+Open Graph and meta tags are copy. They are read by every person who sees the link shared in a chat, a feed, or a notification. They are the page's first impression in contexts where the design cannot speak — and they are where the same model that wrote "Unlock the power of" will try again, unchecked, if nobody explicitly closes that door.
+
+The copy rules that apply to the page apply here without exception.
+
+**Required tags:**
+
+```html
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Page title: brand name + one-line position, not a tagline.
+       "Moa — 목표를 위한 저축" not "Moa | Save smarter. Live better." -->
+  <title>Brand — specific position</title>
+
+  <!-- Description: one or two concrete sentences. What does it do, for whom.
+       No "powerful", "seamless", "next-level". No pink-elephant negations.
+       omd check --category slop applies to this string exactly as it applies to body copy. -->
+  <meta name="description" content="Specific, concrete description. One thing the product does.">
+
+  <!-- OG title: same rule as <title>. Match or slightly adapt — do not write a new tagline. -->
+  <meta property="og:title" content="Brand — specific position">
+  <meta property="og:description" content="Same concrete description.">
+
+  <!-- og:image policy: if a designed card image exists, use it.
+       If one does not exist, omit og:image rather than setting a broken path —
+       platforms render the URL card without an image more gracefully than they render
+       a 404. Do not set og:image to a screenshot of the page unless it was designed
+       as a social card at 1200×630. -->
+  <meta property="og:image" content="https://example.com/og-card.png"> <!-- only if the file exists -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/">
+
+  <!-- Twitter/X card — summary_large_image if og:image is designed, summary if not -->
+  <meta name="twitter:card" content="summary_large_image">
+</head>
+```
+
+**OG copy rules:**
+1. The OG title must pass SLOP-COPY: it must say something specific about this product, not any product. "모아 — 목표까지 함께하는 저축" is specific; "모아 | 더 스마트하게 저축하세요" is a placeholder with the brand name prepended.
+2. The description must not be the tagline repeated. If the title already communicates the position, the description adds a second concrete fact — who it is for, what it costs, what the first action is.
+3. SLOP-PINK-ELEPHANT and SLOP-COPY rules apply. Run `omd check <page> --category slop` — the checker reads meta tags. A description that passes the page body but fails the OG string is the same failure.
+4. If the brief was in Korean, the OG strings should be in Korean.
+
+---
+
+## Applying the checklist
+
+Walk each item in order. For each one, write the decision into `.omd/decisions.md`:
+
+```bash
+omd decision "::selection bg: oklch from --color-accent at 20%" \
+  --why "accent-derived highlight; 4.5:1 verified by omd check"
+
+omd decision "Scrollbar: standards-track scrollbar-color/scrollbar-width with webkit fallback" \
+  --why "thin scrollbar matches quiet register; track transparent"
+
+omd decision "Favicon: inline SVG data-URI, monogram M on brand-dark background" \
+  --why "no asset file dependency; legible at 16x16"
+
+omd decision "OG title: '모아 — 목표까지 함께하는 저축'" \
+  --why "specific claim, passes SLOP-COPY; mirrors page hero"
+```
+
+An item that is genuinely not applicable — `::selection` on a non-interactive data terminal, scrollbar styling on a page that disables scrolling by design — still gets a decision entry with the reason. The absence of a record is not the same as a decision not to implement.

--- a/evals/blog-multipage/graders/cross-page-ladders.md
+++ b/evals/blog-multipage/graders/cross-page-ladders.md
@@ -1,0 +1,25 @@
+# Grader: Cross-Page Design Ladders Consistent
+
+Check that the type scale, spacing ladder, and radius ladder are consistent across both the landing index and the article page — measured from the built output, not from intent.
+
+## Pass criteria
+
+- The landing page and the article page share the same CSS custom properties for type scale tokens (`--text-*`, `--font-*`), spacing tokens (`--space-*`), and radius tokens (`--radius-*`).
+- Both pages reference a shared stylesheet, or each page's `:root` block declares the same token set with the same values.
+- If the article page intentionally uses a wider measure or a different leading for reading comfort, that decision is recorded in `.omd/decisions.md` — the variation is intentional, not drift.
+- `omd check --site` (or equivalent) confirms no `SITE-LADDER-DRIFT` finding.
+
+## Fail criteria
+
+- The landing page uses a 4-step type scale and the article page uses a different number of distinct sizes with no recorded reason.
+- One page declares `--radius-card: 8px` and the other uses `border-radius: 12px` inline — the ladder is inconsistent and untokenised.
+- The font families differ between pages without a recorded decision (e.g., the landing uses a display serif for headings and the article page defaults to system-ui).
+- Spacing tokens are present on the landing page but absent or overridden on the article page.
+
+## Why this matters
+
+A design system that applies to only one of two pages is not a design system. Cross-page ladder consistency is the minimum bar for "built together" — the user reads both pages in one session and the seam between them is what they remember.
+
+## Severity
+
+FAIL on any single criterion above.

--- a/evals/blog-multipage/graders/finish-pass-items.md
+++ b/evals/blog-multipage/graders/finish-pass-items.md
@@ -1,0 +1,26 @@
+# Grader: Finish Pass Items Present
+
+Check that the finish-pass checklist was applied to the built pages — specifically the items that are most visible in a personal blog context: favicon, `::selection` colour, and OG meta tags.
+
+## Pass criteria
+
+- **Favicon**: at least one `<link rel="icon">` tag is present in the `<head>` of both pages, using an inline SVG data-URI (no separate asset file dependency). A missing favicon is a FAIL — a personal blog without one reads as a template, not a publication.
+- **`::selection`**: the page CSS contains a `::selection` rule that sets `background-color` to a value other than the browser default (`Highlight` keyword or bare system blue). The colour should be derived from or consistent with the page's accent token.
+- **OG meta tags**: both pages contain `<meta property="og:title">` and `<meta property="og:description">`. The OG title is specific to each page — the article page's OG title is the article title, not the blog name. The OG description is a concrete sentence, not a tagline.
+- **`omd decision` entries**: `.omd/decisions.md` contains at least one entry related to the finish pass (favicon, ::selection, scrollbar, OG, or optical alignment). The finish pass was walked, not assumed.
+
+## Fail criteria
+
+- No `<link rel="icon">` tag in either page — the build shipped without a favicon.
+- `::selection` is absent from the CSS — the default browser highlight colour was left in place.
+- `og:title` is identical on both pages — the article page does not have its own OG title.
+- `og:description` contains AI stock phrases ("powerful", "seamless", "next-level", "도움이 됩니다") that would fail SLOP-COPY.
+- No finish-pass decisions recorded in `.omd/decisions.md`.
+
+## Why this matters
+
+A blog is a publication. Publications have favicons, branded highlights, and sharing metadata because real people share them. The finish-pass checklist is what separates a build that passes `omd check` from a build that reads as published.
+
+## Severity
+
+FAIL if favicon is absent. FAIL if OG tags are absent. WARN if `::selection` is missing or OG copy is generic.

--- a/evals/blog-multipage/graders/site-check-clean.md
+++ b/evals/blog-multipage/graders/site-check-clean.md
@@ -1,0 +1,23 @@
+# Grader: omd check --site Ran and Returned Clean
+
+Check that the cross-page site check was run on the output directory and produced no SITE-* findings, or that any firing site-level finding has a recorded decision overrule.
+
+## Pass criteria
+
+- The transcript or `.omd/` records show `omd check --site <dir>` (or `omd check index.html post.html` with both pages explicit) was executed after the build completed.
+- The command returned no `SITE-LADDER-DRIFT` or `SITE-TOKEN-DRIFT` findings, OR every finding has a corresponding entry in `.omd/decisions.md` naming the rule ID and the reason it was overruled (not "it looked fine").
+
+## Fail criteria
+
+- `omd check --site` was not run — the build produced multiple pages and only a per-page check was run.
+- `SITE-LADDER-DRIFT` fires and is not overruled — one page uses a 4-step type scale and another uses a different number of steps with no recorded reason.
+- `SITE-TOKEN-DRIFT` fires and is not overruled — one page uses design tokens throughout and another falls back to inline values.
+- The two pages visibly belong to different design systems (different font families, different radius vocabulary, different spacing ladder) with no recorded intent.
+
+## Why this matters
+
+A blog and its article page were designed together. The user will feel the drift between them before they can name it. `omd check --site` is what makes cross-page consistency measurable rather than approximate. The step 8 gate in `omd:ultradesign` exists for exactly this case.
+
+## Severity
+
+FAIL if `omd check --site` was skipped entirely. WARN if it ran and findings were not addressed.

--- a/evals/blog-multipage/graders/voice-study-korean.md
+++ b/evals/blog-multipage/graders/voice-study-korean.md
@@ -1,0 +1,27 @@
+# Grader: Voice Study on Board, Korean Copy Follows It
+
+Check that a voice study was captured before copy was written, and that the Korean copy on both pages follows the measured register rather than translated marketing.
+
+## Pass criteria
+
+- `.omd/theory/voice.md` (or a voice-study file under `.omd/`) exists and contains at least one cited source sentence — a direct quote or paraphrase attributed to a real product, person, or publication.
+- The `.omd/board.md` or `.omd/refs/` directory includes at least one entry tagged as a voice, copy, or register reference.
+- The Korean copy on both the landing and article page reads like a Korean writer wrote it first — not like an English template translated into Korean.
+- No connective-comma openers appear in the body copy: "그러나, " / "하지만, " / "또한, " / "따라서, " at the start of a sentence.
+- The hero or post-title subheadline does not stack ≥ 2 abstract value nouns ("편리한", "혁신적인", "스마트한") without a concrete subject attached.
+- `omd check --category slop` returns no SLOP-COPY-KO findings, or any finding is overruled with a written reason.
+
+## Fail criteria
+
+- No voice study file exists under `.omd/` — the copy register was invented rather than measured.
+- The voice study exists but contains only the agent's own description of the desired tone with no cited external evidence.
+- The article body copy contains connective-comma patterns that `SLOP-COPY-KO` is designed to catch.
+- The landing hero headline reads as a translated marketing brief: "매일의 생각을 기록하고 성장하세요" (enumerated imperative) rather than a direct personal statement.
+
+## Why this matters
+
+A Korean blog by a product designer should read the way that designer writes — not the way an international SaaS platform translated its tagline. The voice study is the measurement that makes this possible. Without it, the register defaults to the mean of all Korean web copy, which is translated marketing copy.
+
+## Severity
+
+FAIL if no voice study exists. WARN if it exists but Korean copy contains SLOP-COPY-KO patterns.

--- a/evals/blog-multipage/prompt.md
+++ b/evals/blog-multipage/prompt.md
@@ -1,0 +1,1 @@
+Design a Korean personal blog with two pages: a landing index that surfaces the five most recent posts, and a single article page. The blog belongs to a product designer who writes about systems thinking and everyday observation. The tone is personal and unhurried — not a portfolio, not a media site. Use omd:ultradesign.

--- a/evals/docs-site/graders/density-spectrum-cited.md
+++ b/evals/docs-site/graders/density-spectrum-cited.md
@@ -1,0 +1,25 @@
+# Grader: Information Density Decision Cited from layout.md
+
+Check that the layout density decisions for the documentation site were made with explicit reference to the density spectrum in `core/theory/layout.md`, rather than applied as defaults.
+
+## Pass criteria
+
+- `.omd/decisions.md` contains at least one entry that cites `layout.md` (or `core/theory/layout.md`) in the context of density, information hierarchy, or line length.
+- The transcript or decisions file shows the agent consulted the density spectrum and made an explicit choice: dense (more content per viewport) vs. airy (reading comfort over information density) — with a reason tied to the documentation use case.
+- The committed line length for body text falls within the readable range (60–80 characters, `45ch`–`75ch`). Documentation is read in long sessions; line length is a fatigue variable.
+- The vertical rhythm and spacing between sections serves information scanning — headings are visually distinguishable from body, code blocks are clearly separated, the reading flow is unambiguous.
+
+## Fail criteria
+
+- No `layout.md` citation in any decision entry related to density or line length.
+- Body text line length is unconstrained (full-width on 1280px viewport) — a long line of prose documentation is a reading fatigue defect.
+- The spacing between sections is uniform: every section has the same gap regardless of the conceptual relationship between them (a navigation heading and a body paragraph have the same spacing as two unrelated sections).
+- `.omd/decisions.md` does not exist or contains no citation of the theory pack for layout decisions.
+
+## Why this matters
+
+`core/theory/layout.md` exists precisely because density is a decision, not a default. A documentation site with unconstrained line width and uniform spacing was not designed — it was generated. The density spectrum gives the builder a condition → choice → reason table to work from; citing it in decisions.md is how the choice becomes traceable.
+
+## Severity
+
+FAIL if line length is unconstrained at 1280px. WARN if layout.md was not cited in any decision.

--- a/evals/docs-site/graders/navigation-from-components.md
+++ b/evals/docs-site/graders/navigation-from-components.md
@@ -1,0 +1,27 @@
+# Grader: Navigation Pattern From components.md
+
+Check that the navigation structure of the documentation site was chosen with reference to `core/theory/components.md` rather than applied as a default pattern.
+
+## Pass criteria
+
+- `.omd/decisions.md` contains at least one entry citing `components.md` (or `core/theory/components.md`) for the navigation decision.
+- The navigation pattern chosen (top bar, left sidebar, or breadcrumb trail) matches the type of content and user task: a multi-page CLI reference warrants a persistent left sidebar for cross-page scanning; a single-page guide does not require one.
+- The navigation provides the user with orientation — current page is highlighted, top-level structure is visible, depth is legible.
+- Interactive targets in the navigation meet the 44×44px minimum hit area (`omd check` A11Y-HIT-AREA must not fire on navigation items).
+- The navigation structure is consistent across all three pages (home, Getting Started, Commands reference).
+
+## Fail criteria
+
+- No `components.md` citation for the navigation decision in `.omd/decisions.md`.
+- The navigation pattern is the same on a single-page guide as it would be for a 200-page API reference — the pattern was applied as a default rather than chosen for the content.
+- Current page is not indicated in the navigation — the user cannot tell where they are.
+- Navigation items fail the 44×44px hit area check on mobile (375px viewport).
+- The Commands reference page omits a navigation element that would allow the user to return to the Getting Started guide — the pages are isolated rather than connected.
+
+## Why this matters
+
+Navigation is infrastructure. When it fails, everything else becomes harder — the user cannot orient, cannot cross-reference, cannot tell where they are in a larger structure. `components.md` provides the condition → choice → reason reasoning for navigation patterns: why a sidebar belongs in multi-section documentation, why a breadcrumb trail matters for depth > 2. Citing it means the decision was made, not assumed.
+
+## Severity
+
+FAIL if current page is not indicated in navigation. FAIL if navigation targets fail hit-area checks on mobile. WARN if components.md was not cited.

--- a/evals/docs-site/graders/no-showpiece-techniques.md
+++ b/evals/docs-site/graders/no-showpiece-techniques.md
@@ -1,0 +1,28 @@
+# Grader: No Showpiece Techniques in a Documentation Site
+
+Check that expressive or showpiece techniques did not appear in a documentation site that explicitly requested a quiet, technical register.
+
+## Pass criteria
+
+- No split-text or stagger entrance animations on headings.
+- No sticky scroll-stage transitions between sections.
+- No section colour inversion (the section-inversion composition recipe is a showpiece technique; documentation pages do not invert).
+- Navigation is functional and conventionally placed — top navigation bar or left sidebar. No experimental navigation patterns.
+- Code blocks and command references are given more visual weight than decorative elements — the hierarchy serves the reader's task, not the brand's expressiveness.
+- If `.omd/motion-spec.md` exists, it either does not exist or explicitly states "no entrance animations".
+
+## Fail criteria (any one fails the case)
+
+- A section of the home page uses full-bleed colour inversion as a visual device.
+- A heading uses split-text letter-by-letter entrance animation.
+- The navigation uses a custom interaction pattern (magnetic hover, scroll-driven reveal) that interferes with reading flow.
+- The transcript shows `omd-hand` citing `expressive.md` to justify a visual technique on a documentation page.
+- `omd check` returns `MOTION-EVERYTHING-MOVES` or `MOTION-UNIFORM` — the motion rules that flag showpiece excess.
+
+## Why this matters
+
+The quiet register is not a diminished register — it is a different one. Documentation that performs for its own sake loses on the dimension that matters most to its users: speed to information. A pipeline that applies showpiece technique to every output has not learned to read what the brief asked for. Register containment is as important as register execution.
+
+## Severity
+
+FAIL on any criterion above.

--- a/evals/docs-site/graders/quiet-register.md
+++ b/evals/docs-site/graders/quiet-register.md
@@ -1,0 +1,28 @@
+# Grader: Quiet Register Committed
+
+Check that the design explicitly committed to the quiet register before building — and that the committed register is visible in the output.
+
+## Pass criteria
+
+- `.omd/frame.md` or the run transcript shows the agent explicitly named the register as "quiet", "functional", "tool-oriented", or an equivalent phrase before writing code.
+- The rendered pages do not contain entrance animations on page load — no `@keyframes`, no `animation:` triggered on first paint.
+- Typography is utilitarian: a body type scale with no display-scale headings (font-size ≤ 48px on all headings).
+- Color usage encodes information: status indicators, syntax highlighting, navigation state. No decorative gradients, no hero overlays, no color for atmosphere.
+- If `.omd/motion-spec.md` exists, it explicitly states that the register is quiet and that entrance animations were rejected.
+- `omd check --category slop` returns no SLOP-GRADIENT or SLOP-EVERYTHING-CENTERED findings on a documentation page.
+
+## Fail criteria
+
+- A hero or billboard section with oversized headline (> 48px) occupies the first viewport of the home page.
+- CSS contains `@keyframes` that animate elements on initial page load.
+- More than 3 non-neutral hues appear as decoration (not as syntax highlighting or status encoding).
+- The transcript shows the agent consulting `expressive.md` or motion recipes for the documentation brief — the wrong register was applied.
+- `MOTION-UNIFORM` or `MOTION-EVERYTHING-MOVES` fires on a documentation page.
+
+## Why this matters
+
+Documentation is read for information, not for experience. A documentation site that applies showpiece technique to the home page signals that the register detection failed — the pipeline defaulted to the mean output rather than reading the brief. The separation between quiet and showpiece registers is a correctness property, not a preference.
+
+## Severity
+
+FAIL if a hero with oversized type occupies the first viewport. FAIL if entrance animations fire on a documentation page. WARN for decorative colour use.

--- a/evals/docs-site/prompt.md
+++ b/evals/docs-site/prompt.md
@@ -1,0 +1,1 @@
+Build a documentation site for an open-source CLI tool called "vessel" — a container orchestration utility. The site needs a home page that explains what vessel does, a Getting Started guide, and a Commands reference page. The register is technical and quiet — the user came to read, not to be impressed. Use omd:ultradesign.

--- a/evals/korean-showpiece/graders/composition-recipe-cited.md
+++ b/evals/korean-showpiece/graders/composition-recipe-cited.md
@@ -1,0 +1,25 @@
+# Grader: Composition Recipe Cited for Page Structure
+
+Check that the page structure was committed using at least one named recipe from the composition cookbook (`core/composition/`), rather than applied as a default grid layout.
+
+## Pass criteria
+
+- `.omd/decisions.md` contains at least one entry that names a composition recipe by file name — for example, `typographic-hero.md`, `section-inversion.md`, `asymmetric-diagonal-grid.md`, `bento-grid.md`, or another recipe from `core/composition/`.
+- The named recipe's conditions are met: for example, if `typographic-hero.md` is cited, the hero heading is actually display-scale (`clamp()` sizing, filling the viewport), not a standard-size centred headline.
+- The page-level structure (hero zone, feature zone, CTA zone) maps to one or more recognisable composition recipes — the layout has a committed structure, not a default stack of equal sections.
+- If `section-inversion.md` was used, it appears at most once — the recipe's own constraint.
+
+## Fail criteria
+
+- No composition recipe is named in `.omd/decisions.md` — the structure was applied without reference to the cookbook.
+- A recipe is named but its conditions are not met: `typographic-hero.md` is cited but the hero uses a moderate-scale centred headline that would not fill the viewport.
+- All sections have equal visual weight and equal span — `SLOP-TRIPLE-CARD` at page scale, with no recorded decision to use a recipe that permits equal treatment.
+- The layout is a standard landing page stack (hero → three-column cards → footer) with no committed composition decision.
+
+## Why this matters
+
+The composition cookbook exists because structure is a decision, not a default. A showpiece page that uses the default landing page structure — regardless of how expressive the typography or motion is — has not committed to a concept at the layout level. The recipe citation is what makes the structure traceable: it names the condition that was met, and the condition being met is what separates a recipe application from a coincidence.
+
+## Severity
+
+FAIL if no composition recipe is cited. WARN if cited but conditions are not clearly met.

--- a/evals/korean-showpiece/graders/finish-pass.md
+++ b/evals/korean-showpiece/graders/finish-pass.md
@@ -1,0 +1,25 @@
+# Grader: Finish Pass Applied
+
+Check that the finish-pass checklist was walked after the build, and that at minimum the favicon and `::selection` colour were implemented — the two items that are most visible on a showpiece page.
+
+## Pass criteria
+
+- **Favicon**: a `<link rel="icon">` tag is present in the `<head>` using an inline SVG data-URI. The favicon is not a broken path, not a missing asset, and not absent. A showpiece landing page without a favicon reads as a prototype in the browser tab.
+- **`::selection`**: the page CSS contains a `::selection` rule that sets `background-color` to a value consistent with the page's colour system — not the default browser-blue highlight. On a brand-forward Korean fintech landing page, the selection colour is a design decision.
+- **`omd decision` entries**: `.omd/decisions.md` contains at least one entry related to the finish pass. The checklist was walked and each item was either implemented or explicitly skipped with a reason.
+- **OG meta tags**: `<meta property="og:title">` and `<meta property="og:description">` are present. The OG description is in Korean (matching the brief language) and does not contain SLOP-COPY-KO patterns.
+
+## Fail criteria
+
+- No `<link rel="icon">` tag in the page — the build shipped without a favicon.
+- `::selection` is absent from the CSS — the default browser highlight was left in place.
+- No finish-pass entries in `.omd/decisions.md` — the checklist was skipped entirely.
+- OG tags are absent or the OG description is a placeholder, a tagline, or contains AI-prose patterns that would fail the copy rules.
+
+## Why this matters
+
+A showpiece page is built to impress. The favicon appears in the browser tab before the user has scrolled once. The `::selection` colour appears the moment the user highlights text. These are the surfaces that announce whether the page was finished or abandoned at "checks pass." The finish-pass checklist is what closes the gap between "the eye approved it" and "a person could publish this."
+
+## Severity
+
+FAIL if favicon is absent. FAIL if finish-pass was not walked (no decisions). WARN if `::selection` is missing.

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -382,6 +382,18 @@ If the build reveals the structure was wrong — and sometimes it will — that 
 reframe step is for. Rebuilding once is cheaper than generating alternatives every time on
 the chance it might be.
 
+**Before handing off to the eye, the build is only done when the finish pass is done.**
+The finish-pass checklist lives at `${CLAUDE_PLUGIN_ROOT}/core/craft/finish-pass.md` (or
+`core/craft/finish-pass.md` in the repo root). `omd:hand` walks it after `omd check` returns
+clean: `::selection` colour derived from the accent token, focus ring via `:focus-visible`
+(not outline suppression — `A11Y-FOCUS-SUPPRESSED` fires on bare suppression), scrollbar
+styling with `scrollbar-color`/`scrollbar-width` first and `-webkit-` as the noted fallback,
+optical alignment corrections (icon baseline nudge, button padding asymmetry), inline SVG
+favicon (no asset file required — the emoji-favicon trick is the minimal variant), and OG
+meta tags whose copy passes the same SLOP-COPY rules as the page body. Each item is
+implemented or skipped with a written reason in `.omd/decisions.md`. A page without a
+favicon and `::selection` colour reads as unfinished regardless of everything else.
+
 ---
 
 ## 6. SEE — look at what actually rendered

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -349,6 +349,35 @@ instructions: |
   gap visible. The eye reads `.omd/attribution.md` alongside the screenshot; any row that
   reads "I chose this" without a source is a finding.
 
+  ## Finish pass — the last 5%
+
+  After `omd check` returns clean and before handback, walk
+  `${CLAUDE_PLUGIN_ROOT}/core/craft/finish-pass.md` (or `core/craft/finish-pass.md` in the
+  repo root) top to bottom. Each item is either implemented or skipped with a written reason
+  in `omd decision`. The six items are:
+
+  1. **`::selection`** — derive the highlight colour from `--color-accent`. Default browser
+     selection blue on a page with a considered colour system announces that someone stopped
+     caring at the boundary of their CSS.
+  2. **Focus ring** — `:focus-visible` with a two-layer `box-shadow` ring, never
+     `outline: none` without a replacement. `A11Y-FOCUS-SUPPRESSED` fires on bare suppression.
+     Cite the FOCUS rule in the decision entry.
+  3. **Scrollbar** — `scrollbar-color` / `scrollbar-width` (standards-track, Chrome 121+ and
+     Firefox) first; `-webkit-scrollbar` rules as the noted fallback.
+  4. **Optical alignment** — icon baseline nudge (`vertical-align: -0.125em` as a starting
+     point), button padding asymmetry (reduce bottom by 1–2px), tabular figures on numeric
+     columns. These are the 1px corrections a linter cannot catch and a person always notices.
+  5. **Favicon** — inline SVG data-URI so no asset file is required. A monogram character on
+     the brand background colour. The emoji-favicon variant is acceptable only when the emoji
+     is a deliberate brand choice. A page without a favicon reads as unfinished in a tab row.
+  6. **OG and meta** — `<title>`, `<meta name="description">`, `og:title`, `og:description`,
+     `og:image` (only if the designed card file actually exists). OG copy must pass the same
+     rules as page copy: SLOP-COPY, SLOP-PINK-ELEPHANT, no pink-elephant negations. If the
+     brief was in Korean, the OG strings are in Korean.
+
+  A page without items 5 and 6 reads as a prototype, not a product, regardless of how well
+  the rest was executed.
+
   ## Check yourself before you hand off
 
       omd check <your-page> --json

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -382,6 +382,18 @@ If the build reveals the structure was wrong — and sometimes it will — that 
 reframe step is for. Rebuilding once is cheaper than generating alternatives every time on
 the chance it might be.
 
+**Before handing off to the eye, the build is only done when the finish pass is done.**
+The finish-pass checklist lives at `${CLAUDE_PLUGIN_ROOT}/core/craft/finish-pass.md` (or
+`core/craft/finish-pass.md` in the repo root). `omd-hand` walks it after `omd check` returns
+clean: `::selection` colour derived from the accent token, focus ring via `:focus-visible`
+(not outline suppression — `A11Y-FOCUS-SUPPRESSED` fires on bare suppression), scrollbar
+styling with `scrollbar-color`/`scrollbar-width` first and `-webkit-` as the noted fallback,
+optical alignment corrections (icon baseline nudge, button padding asymmetry), inline SVG
+favicon (no asset file required — the emoji-favicon trick is the minimal variant), and OG
+meta tags whose copy passes the same SLOP-COPY rules as the page body. Each item is
+implemented or skipped with a written reason in `.omd/decisions.md`. A page without a
+favicon and `::selection` colour reads as unfinished regardless of everything else.
+
 ---
 
 ## 6. SEE — look at what actually rendered

--- a/test/finish-pass.test.ts
+++ b/test/finish-pass.test.ts
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const craftDir = join(root, 'core', 'craft');
+const finishPassFile = join(craftDir, 'finish-pass.md');
+
+// ── Required section headings ────────────────────────────────────────────────
+// Each heading corresponds to one finish-pass checklist item.
+const REQUIRED_HEADINGS = [
+  '## ::selection',
+  '## Focus ring',
+  '## Scrollbar',
+  '## Optical alignment',
+  '## Favicon',
+  '## OG and meta',
+];
+
+// ── Presence checks ──────────────────────────────────────────────────────────
+
+test('core/craft/ directory exists', () => {
+  assert.ok(existsSync(craftDir), `craft directory not found at ${craftDir}`);
+});
+
+test('core/craft/finish-pass.md exists', () => {
+  assert.ok(existsSync(finishPassFile), `finish-pass.md not found at ${finishPassFile}`);
+});
+
+test('core/craft/ contains exactly 1 .md file', () => {
+  const files = readdirSync(craftDir).filter((f) => f.endsWith('.md'));
+  assert.equal(
+    files.length,
+    1,
+    `expected 1 file in core/craft/, found ${files.length}: ${files.join(', ')}`
+  );
+});
+
+// ── Section structure ────────────────────────────────────────────────────────
+
+for (const heading of REQUIRED_HEADINGS) {
+  test(`finish-pass.md contains section "${heading}"`, () => {
+    if (!existsSync(finishPassFile)) assert.fail('finish-pass.md not found');
+    const content = readFileSync(finishPassFile, 'utf8');
+    assert.ok(
+      content.includes(heading),
+      `finish-pass.md: missing section heading "${heading}"`
+    );
+  });
+}
+
+// ── Content requirements ─────────────────────────────────────────────────────
+
+test('finish-pass.md mentions :focus-visible (not bare outline suppression)', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  assert.ok(
+    content.includes(':focus-visible'),
+    'finish-pass.md: missing :focus-visible — must cite the correct pseudo-class'
+  );
+});
+
+test('finish-pass.md cites A11Y-FOCUS-SUPPRESSED or FOCUS rule', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  assert.ok(
+    content.includes('A11Y-FOCUS-SUPPRESSED') || content.includes('FOCUS'),
+    'finish-pass.md: must cite the FOCUS rule (A11Y-FOCUS-SUPPRESSED)'
+  );
+});
+
+test('finish-pass.md mentions scrollbar-color and scrollbar-width (standards-track)', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  assert.ok(
+    content.includes('scrollbar-color'),
+    'finish-pass.md: missing scrollbar-color (standards-track property)'
+  );
+  assert.ok(
+    content.includes('scrollbar-width'),
+    'finish-pass.md: missing scrollbar-width (standards-track property)'
+  );
+});
+
+test('finish-pass.md mentions -webkit-scrollbar as fallback', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  assert.ok(
+    content.includes('-webkit-scrollbar'),
+    'finish-pass.md: missing -webkit-scrollbar fallback'
+  );
+});
+
+test('finish-pass.md favicon section contains inline SVG data-URI example', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  const faviconSection = /## Favicon([\s\S]*?)(?=\n## |\n# |$)/.exec(content)?.[1] ?? '';
+  assert.ok(
+    faviconSection.includes('data:image/svg+xml'),
+    'finish-pass.md Favicon section: missing inline SVG data-URI example'
+  );
+});
+
+test('finish-pass.md ::selection section derives colour from accent token', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  const selectionSection = /## ::selection([\s\S]*?)(?=\n## |\n# |$)/.exec(content)?.[1] ?? '';
+  assert.ok(
+    selectionSection.includes('--color-accent') || selectionSection.includes('accent'),
+    'finish-pass.md ::selection section: must derive colour from the accent token'
+  );
+});
+
+test('finish-pass.md OG section requires copy to pass slop rules', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  const ogSection = /## OG and meta([\s\S]*?)(?=\n## |\n# |$)/.exec(content)?.[1] ?? '';
+  assert.ok(
+    ogSection.includes('SLOP-COPY') || ogSection.includes('slop'),
+    'finish-pass.md OG section: must state that OG copy passes slop rules'
+  );
+});
+
+test('finish-pass.md has substantive intro prose (not just headers)', () => {
+  const content = readFileSync(finishPassFile, 'utf8');
+  // The file must start with a paragraph before the first ## heading.
+  const beforeFirstHeading = content.split('\n## ')[0] ?? '';
+  assert.ok(
+    beforeFirstHeading.length > 200,
+    'finish-pass.md: intro prose is too short — the file must open with essayistic rationale'
+  );
+});
+
+// ── Build dist check ─────────────────────────────────────────────────────────
+
+test('dist/claude/core/craft/finish-pass.md exists after build', () => {
+  const distPath = join(root, 'dist', 'claude', 'core', 'craft', 'finish-pass.md');
+  assert.ok(
+    existsSync(distPath),
+    `dist/claude/core/craft/finish-pass.md not found — run npm run build`
+  );
+});
+
+test('dist/codex/core/craft/finish-pass.md exists after build', () => {
+  const distPath = join(root, 'dist', 'codex', 'core', 'craft', 'finish-pass.md');
+  assert.ok(
+    existsSync(distPath),
+    `dist/codex/core/craft/finish-pass.md not found — run npm run build`
+  );
+});


### PR DESCRIPTION
Plan v2 items D3, D4. 373→392 tests. Six eval cases now cover showpiece, quiet, scout-only, motion, multipage blog, and docs registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)