### PR TITLE
feat: slop redefinition + research-grounded voice theory

### DIFF
--- a/agents/eye.md
+++ b/agents/eye.md
@@ -44,6 +44,22 @@ You have no reasoning here to defend.
   `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,motion,components,craft,expressive}.md`.
   Theory citations are evidence. Taste is not.
 
+## Korean copy critique
+
+When the page contains Korean copy, run two additional checks as part of the critique
+— these are not covered by `omd check` when the IR has already collapsed the markup:
+
+1. **Register consistency** — pick any two sentences in the same paragraph and compare
+   their endings. 해요체 (아요/어요/에요) and 합니다체 (습니다/ㅂ니다) must not alternate
+   inside one block. `SLOP-KO-REGISTER-MIX` fires at the text-node level; what that rule
+   cannot see is whether the *same speech level was chosen and held across the whole page*.
+   Name the level the voice study committed to; flag any block that deviates.
+
+2. **Dash usage** — spaced em-dash ( — ) and en-dash ( – ) inside Korean sentences read
+   as translation artifacts. `SLOP-KO-EMDASH` fires on these; confirm no instance reached
+   the render. If one did, name the specific sentence and the rewrite (comma, colon, or
+   new sentence).
+
 ## Register-aware critique
 
 You will be given the committed register (quiet / confident / showpiece) alongside the

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -159,6 +159,34 @@ the im-not-ai taxonomy — avoid all of them:
 - connective abuse: consecutive sentences opening with 또한/따라서/즉/Also/Moreover
 - decoration: bold everywhere, em-dash chains, emoji in headings
 
+Four additional tells that are deterministically AI-flavoured in Korean copy — `omd check`
+flags the first two; the second two are yours to police before the page ships:
+
+**No spaced em-dash or en-dash in Korean sentences.** " — " and " – " inside Hangul-bearing
+sentences are a direct transfer from English typography and appear in Korean AI output as a
+translation artifact. Rewrite as a comma, a colon, or a new sentence. "빠릅니다 — 정확합니다"
+→ "빠르고 정확합니다." `SLOP-KO-EMDASH` fires on this pattern.
+
+**One speech level, chosen from the voice study, held for the whole page.** 해요체 (아요/어요/
+에요) and 합니다체 (습니다/ㅂ니다) must not alternate within the same paragraph or across
+paragraphs on the same page. The voice study in `.omd/` names which level this product uses;
+every sentence conforms to it. `SLOP-KO-REGISTER-MIX` fires when both endings appear in one
+text node.
+
+**No `<br>` or hard newlines mid-sentence.** Line wrapping is the CSS's job. A sentence broken
+with `<br>` reads as AI-formatted text (the model inserting visual line breaks to match its
+training data's layout conventions) and breaks reflow at every other viewport width. Write
+continuous prose; let `max-width` and `line-height` control the line length. This tell cannot
+be detected by `omd check` — the IR collapses `<br>` before the linter runs — so it is your
+responsibility to catch it in the source HTML before handoff.
+
+**No self-explainer copy.** The page sells outcomes; it does not describe its own mechanism
+in README cadence. "X는 Y를 잡아내는 Claude Code 플러그인이에요" is documentation, not a hero
+line. Write what the reader gets, what changes after they use the product, what happens next
+— not what the tool is or how it works. If you catch yourself writing "X는/은 ~하는 ~이에요/
+입니다" as the first sentence of a section, that is the self-explainer tell; delete it and
+write the outcome instead.
+
 Placeholder copy is a defect. "Lorem ipsum" and "Your content here" never ship.
 
 ## Unmeasured decisions require a citation
@@ -177,8 +205,12 @@ and no third:
 **Arbitrary decision is not a third option.** "I chose 1.333 because it felt right" is
 not a decision — it is a guess. The theory pack exists precisely to resolve the gaps the
 board leaves. Use it. Path: `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,
-motion,components,craft,expressive}.md`. Read whichever file covers the gap, pull the
-relevant condition→choice→reason entry, and record it in `omd decision`.
+motion,components,craft,expressive,voice}.md`. Read whichever file covers the gap, pull
+the relevant condition→choice→reason entry, and record it in `omd decision`. For copy
+decisions — sentence rhythm, vocabulary temperature, register — cite `voice.md`
+specifically: it maps the burstiness finding to practical sentence construction, the
+Oppenheimer result to vocabulary choice, and the Toss/Mailchimp standards to the positive
+form of each Korean and English tell.
 
 ## Write the motion spec before building anything
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -100,6 +100,15 @@ The composition contract:
   SLOP-COPY / SLOP-COPY-KO rules target — its voice is not collectible: those patterns
   trace the model's training data, not a human writer's choices.
 
+  When writing the voice study principles, name which moves from `core/theory/voice.md`
+  the studied site exemplifies. The framework: does the site front-load information
+  (voice.md § scanning research)? Does it vary sentence length — short after long
+  (voice.md § statistical signature)? Does it use concrete nouns over nominalisations
+  (voice.md § plain language)? For Korean sites: which speech level, and does the
+  vocabulary temperature favour native 고유어 over Sino-Korean (voice.md § Korean copy)?
+  A principle that names the voice.md move gives the hand a citation to cite in
+  attribution.md; a principle that says "sentences are short and direct" gives nothing.
+
 ## Source trust hierarchy
 
 Not every source is equally trustworthy, and the slop problem is specifically a search

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -597,7 +597,7 @@ async function cmdDoctor(): Promise<never> {
   }
 
   // Theory-pack files — resolved relative to the CLI's own root
-  const theoryFiles = ['color.md', 'typography.md', 'layout.md', 'motion.md', 'expressive.md', 'components.md', 'craft.md'];
+  const theoryFiles = ['color.md', 'typography.md', 'layout.md', 'motion.md', 'expressive.md', 'components.md', 'craft.md', 'voice.md'];
   for (const f of theoryFiles) {
     const path = join(root, 'core', 'theory', f);
     report(`theory/${f}`, existsSync(path));

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -1,6 +1,18 @@
-# Nothing in this file describes a defect. Every rule here describes a design that has
-# converged on the mean of everything a model has ever seen — correct, competent, and
-# indistinguishable from ten thousand others. That is the failure this tool exists for.
+# Nothing in this file describes a defect. Every rule here describes work that a model
+# produced from pattern alone, without the position of an author who built the thing and
+# speaks the language. Two families live here:
+#
+# 1. Visual convergence-to-the-mean — the gradient band, the identical radius, the triple
+#    card grid. Correct, competent, indistinguishable from ten thousand others. That is the
+#    failure this tool was first built for.
+#
+# 2. Prose that could not have been written by a person who speaks the language natively
+#    and owns the product — register drift, translation punctuation (spaced em-dash inside
+#    Korean copy), speech-level mixing within a paragraph, explainer cadence on a product
+#    page. These are not grammar errors. A fluent reader knows, immediately, that no native
+#    speaker wrote them. The IR cannot always see layout-level signals (a hard <br> inside
+#    a sentence is invisible once the DOM collapses text nodes), but it can see the text
+#    itself — and the text is where generated work gives itself away first.
 #
 # Each is a heuristic and each can be wrong about a deliberate choice. So they warn, they
 # never error, and every message says what to do instead rather than merely what is wrong.
@@ -119,6 +131,53 @@
   value: "node.text"
   assert: "!/(?:그러나|하지만|또한|따라서|즉),[ \\t]|살펴보겠습니다|알아보겠습니다|둘째[,，]|셋째[,，]/u.test(value)"
   message: "Korean AI writing pattern: \"{value}\". A connective followed by a comma (그러나,/또한,), a structural 살펴보겠습니다/알아보겠습니다opener, or a 둘째/셋째 enumeration all trace the model's essay skeleton, not the product's actual claim. Write the specific fact this sentence was hiding."
+
+# Korean translation-punctuation tell: a spaced em-dash ( — ) or en-dash ( – ) inside a
+# sentence that contains Hangul. The spaced em-dash is standard English typography and is
+# legitimate in English copy; it is not standard in Korean product writing. It appears in
+# Korean AI output because the model learned the pattern from English text and transfers it
+# directly. A native Korean copywriter uses a comma, a colon, a dash without surrounding
+# spaces, or starts a new sentence — never the spaced European em-dash construction.
+#
+# Gated on Hangul presence in the same node so English copy is never touched.
+- id: SLOP-KO-EMDASH
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.text) && node.text.length > 8 && /[가-힣]/u.test(node.text)"
+  value: "node.text"
+  assert: "!/ [—–] /.test(value)"
+  message: "Spaced em-dash or en-dash inside Korean copy: \"{value}\". The spaced em-dash ( — ) is an English typography convention; it appears in Korean AI output as a direct transfer from English training data. Rewrite as a comma, colon, or a new sentence — the construction Korean product copy actually uses."
+
+# Korean speech-level mixing within a single text block. Korean has two formal registers
+# that must not alternate in the same paragraph outside of quoted dialogue:
+#
+#   해요체 — ALL forms end in 요 followed by sentence-final punctuation (. ! ?):
+#             아요, 어요, 예요, 에요, 해요, 봐요, 줘요, 쉬워요, and every other contracted form.
+#   합니다체 — ALL forms end in 니다 followed by sentence-final punctuation (. ! ?):
+#              습니다, and the ㅂ-absorbed forms 합니다, 됩니다, 만듭니다, 갑니다, etc.
+#              (In Unicode, the ㅂ attaches to the preceding syllable as a 받침 —
+#              "만듭니다" is 만+듭+니+다, not 만+들+ㅂ+니+다. The text "ㅂ니다" never
+#              appears; 니다[.!?] is the correct detector for the full family.)
+#
+# A native speaker writing product copy commits to one level and holds it. A model assembles
+# sentences across registers because each sentence is generated independently. The result
+# reads immediately as machine-made to any fluent reader — not as a grammar error but as
+# a sign that no single human voice was present.
+#
+# False positive guard: if the node contains quotation marks (straight or curly, Korean
+# angle brackets), stay silent — dialogue attribution legitimately mixes registers.
+#
+# Positive test: "모델은 정답을 만들지 않아요. 훈련 데이터의 평균을 만듭니다." (해요체 + 합니다체)
+# Negatives: all-해요체 block, all-합니다체 block, any block containing 따옴표.
+- id: SLOP-KO-REGISTER-MIX
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.text) && node.text.length > 8 && /[가-힣]/u.test(node.text)"
+  value: "node.text"
+  assert: "!(/요[.!?]/.test(value) && /니다[.!?]/.test(value)) || /[\"'\\u201C\\u201D\\u2018\\u2019\\u300C\\u300D]/.test(value)"
+  message: "Mixed speech levels in one text block: \"{value}\". 해요체 endings (요.) and 합니다체 endings (니다.) alternate inside one paragraph — a sign that sentences were assembled across generation passes rather than written by one voice. Choose one level, held for the whole page, and state which in the voice study."
 
 - id: SLOP-TRIPLE-CARD
   layer: 1

--- a/core/theory/voice.md
+++ b/core/theory/voice.md
@@ -1,0 +1,293 @@
+# Voice — decision material
+
+Copy gives away its origin before a pixel does. A line break mid-sentence, three consecutive
+sentences of the same length, a hedge that adds no information — any one of these signals
+that a model wrote this faster than a person could have. The tells are measurable. The
+repairs are learnable. This file records both.
+
+---
+
+## The statistical signature of generated prose
+
+Research into detecting AI-generated text consistently identifies two statistical
+properties that separate human writing from model output: perplexity and burstiness.
+Perplexity measures how predictable each word choice is — models select high-probability
+tokens by construction, producing text that is smoother than any human writer's. Burstiness
+measures how much sentence length and complexity vary across a document — humans interrupt
+long sequences with short ones, shift register unexpectedly, and write sentences that range
+widely in structure; models produce text at a more uniform cadence because they optimise the
+same way at every position.
+
+A 2025 feature-based detection study in *AI and Ethics* (Springer) confirmed that human
+writers demonstrate greater variability in sentence length — wider distribution, higher
+standard deviation — while model-generated text concentrates around a narrower range. A PMC
+study on academic writing achieved over 99% detection accuracy using four feature categories,
+with sentence-level diversity in length and paragraph complexity as primary signals.
+An arXiv analysis (2408.04647) found that GPT-generated sentences are typically longer on
+average while human-written sentences have a wider range — meaning human writing is not
+consistently shorter, just consistently more varied.
+
+The practical instruction is not "write shorter sentences." It is: vary deliberately. After
+two long sentences, write a short one. After a clause-heavy paragraph, write a paragraph of
+one sentence. The variation is the signal of a person.
+
+Condition → choice → reason: when copy reads flat or rhythmically identical across
+paragraphs, it is not a style problem — it is a burstiness deficit. Introduce one
+dramatically short sentence in every three to four long ones. Not as ornament, but as a
+factual break: the claim that deserves the white space gets it.
+
+---
+
+## How people actually read on the web
+
+The finding that shaped modern web writing came from Jakob Nielsen and John Morkes in 1997.
+In their study of how users approached web pages, 79 percent of test users always scanned
+any new page — only 16 percent read word by word. Twenty-three years later, Nielsen's 2020
+follow-up confirmed the proportion had not moved. Scanning is not a failure mode; it is the
+default mode of a reader whose attention is distributed across millions of competing pages.
+
+The same pair published the implications in "Concise, SCANNABLE, and Objective: How to Write
+for the Web" (Morkes and Nielsen, 1997). Testing five writing styles against a control, they
+found the concise version scored 58% higher in measured usability, the scannable version 47%
+higher, and the objective version (no promotional language) 27% higher. A site that was all
+three simultaneously scored 124% higher. A follow-up rewriting Sun.com pages produced 159%
+improvement. These are not marginal effects; they are the largest usability gains in the
+literature for a single intervention class.
+
+Nielsen's 2006 eye-tracking study of 232 users across thousands of pages documented the
+F-pattern: a full sweep of the first line, a shorter sweep of a second line, then a vertical
+scan down the left edge. The pattern is a failure state — it emerges when content lacks
+visual hierarchy and the reader falls back to a heuristic. The design response is not to
+format text to fit the F; it is to give the reader entry points that break the fallback.
+
+What these studies mean for sentence construction:
+
+**Front-load information.** The first sentence of a paragraph and the first clause of a
+sentence carry disproportionate weight. If the important claim is buried after a preamble,
+the scanner never sees it. The inverted pyramid — conclusion first, support after — is not
+a newspaper convention; it is the writing shape that matches how web users extract value.
+
+**One idea per paragraph.** A paragraph that opens with claim A and closes with claim B is
+two paragraphs. Splitting them is not padding; it is giving each claim the surface area to
+be scanned and absorbed independently.
+
+**Concrete nouns over abstract nominalizations.** "The facilitation of user onboarding" and
+"helping people get started" convey the same claim. The second is scannable; the first
+requires parsing. Abstract nouns — facilitation, optimisation, utilisation — slow processing
+and carry no additional precision. Every nominalization is a candidate for replacement with
+a verb or a specific noun.
+
+---
+
+## Plain language is not dumbing down
+
+Daniel Oppenheimer's 2006 study "Consequences of Erudite Vernacular Utilized Irrespective
+of Necessity" (*Applied Cognitive Psychology*, 20(2), 139–156) ran five experiments with
+Stanford students, manipulating the vocabulary complexity of texts and measuring the authors'
+perceived intelligence. The result reversed the folk assumption: as complexity increased,
+estimated author intelligence decreased. The mechanism is processing fluency — difficult
+text feels effortful to read, and the reader attributes that effort to the writer's
+unclear thinking rather than to the word choice. The effect held regardless of essay quality
+and regardless of readers' prior expectations.
+
+Plain language is the confident register. It is the register of a person who understands
+the subject well enough to explain it without armour. Mailchimp's public content style guide
+(styleguide.mailchimp.com) names this "plainspoken" and defines it as stripping away the
+hyperbolic language, upsells, and over-promises that the reader has learned to distrust —
+not because simplicity is good in itself, but because clarity is what trust is built on.
+
+37signals states the same principle in their communication guide: "If your words can be
+perceived in different ways, they'll be understood in the way which does the most harm."
+Plain writing reduces the number of ways a sentence can be understood. That reduction is a
+quality, not a constraint.
+
+Condition → choice → reason: when a sentence contains a long Latinate noun where a
+shorter verb would serve — "provide an indication of" → "indicate", "make a determination"
+→ "decide", "in the event that" → "if" — replace it. The test is not whether the long form
+is correct but whether the short form loses any precision. In the overwhelming majority of
+cases, it does not.
+
+---
+
+## The voice chart: writing from product principles
+
+Torrey Podmajersky's *Strategic Writing for UX* (O'Reilly, 2019) introduces the voice chart
+as the instrument that connects product principles to copy decisions. The chart holds rows
+for vocabulary, verbosity, grammar, and concepts — filled in for each dimension by asking
+what the product principle demands of the words, not what sounds nice. A financial product
+whose principle is "trustworthy" chooses precise vocabulary over colloquial; a product whose
+principle is "approachable" accepts shorter sentences and native vocabulary over formal
+constructions. Podmajersky's formulation: "These principles define what the experience is
+trying to be to the people who use it. Then, the voice can do its job of conveying those
+product principles with every word."
+
+The voice chart makes copy decisions auditable. Without it, every copy choice is a taste
+decision — and taste decisions are re-litigated on every page, by every person who touches
+the product. With it, the question becomes: does this sentence match the registered
+voice dimensions? That is a question with a testable answer.
+
+Condition → choice → reason: before writing a word of copy, name the product principle
+each section is serving. When no principle can be named, the copy is decoration; decoration
+is the first thing the scanner skips.
+
+---
+
+## The review-mining move
+
+Joanna Wiebe at Copyhackers documented what she calls the voice-of-customer method: instead
+of writing copy on a blank page, mine the language that real users have already written —
+in reviews, support tickets, forum threads, comment sections — and use their phrasing
+directly. The argument is that the customer names the value of the product more precisely
+than the copywriter can, because the customer experienced the problem before the solution
+existed and reaches for the words that match that experience.
+
+The method is a search operation. Identify the exact problem your product solves. Find
+online communities — reviews, subreddits, Help forum threads — where people describe that
+problem in their own words. The phrases that appear repeatedly, with emotional precision,
+are the phrases the copy should use or echo. The user who writes "I used to spend three
+hours a week reconciling this manually" has handed you a sentence. The copy that quotes
+their situation back to them is the copy that converts.
+
+This connects directly to the scout's community captures. A Reddit thread where users argue
+about exactly this product category, a Hacker News comment naming why a redesign failed —
+these are not sentiment data. They are voice data. The scout captures them; the hand uses
+them. A voice study that records how a site writes is the positive model; the community
+captures record the phrases the audience already uses for the problem.
+
+---
+
+## Korean copy: 한국어 카피의 목소리
+
+Korean product copy has a distinct set of decisions that have no equivalent in English
+writing advice. Applying English-language principles to Korean prose — even translated ones
+— produces copy that reads as translated, which is among the loudest tells.
+
+### Speech-level commitment: choose one and hold it
+
+The two dominant written registers in Korean product copy are 해요체 (하다 → 해요, 됩니다
+→ 돼요) and 합니다체 (하다 → 합니다, 됩니다 → 됩니다). These are not style choices on a
+spectrum; they make categorically different claims about the relationship between the
+product and the user. 합니다체 signals institutional formality — the bank teller, the
+government notice, the press release. 해요체 signals a person speaking to a person —
+warmer, more accessible, without the distance formal endings create.
+
+Toss committed to 해요체 across every string in its product and published the rule
+explicitly: all copy uses 해요체, without exception, regardless of context or screen.
+Their stated reason is consistency of experience — 합니다체 anywhere breaks the register
+the rest of the product has established. The rule also extends to avoiding over-polite forms
+(~시겠어요?, ~께) that amplify formality past what the relationship calls for.
+
+What the `SLOP-KO-REGISTER-MIX` rule detects — 해요체 and 합니다체 alternating within the
+same text node — is not stylistic inconsistency. It is an absence of commitment. The product
+has not decided what its relationship with the user is, and the mixed endings make that
+indecision visible.
+
+Condition → choice → reason: before writing a single string in Korean, record the speech
+level in the voice study. Then hold it for every string, including error messages, empty
+states, and button labels. A button that reads "확인합니다" on a screen where the hero reads
+"지금 시작해요" is two products, not one.
+
+### Vocabulary temperature: 고유어 over 한자어 where precision allows
+
+Korean has two vocabulary strata available for almost any concept: native Korean (고유어)
+and Sino-Korean (한자어). Most product copy defaults to Sino-Korean because it feels
+professional and precise. This instinct produces text that is correct, stiff, and forgettable.
+
+Toss's 8 writing principles include "Easy to speak" — their test is whether the sentence
+sounds wrong when said aloud, not whether it looks wrong in print. They cite 한자어 and
+literary 문어체 constructions as the primary cause of copy that passes a proofreading
+read but sounds like documentation. Examples from their practice: 송금이 완료되었습니다
+becomes 5000원을 보냈어요 — "송금" (Sino-Korean for remittance) replaced by "보내다" (native
+verb for send), "완료되었습니다" (formal Sino-Korean completion) replaced by "보냈어요"
+(native past tense in 해요체). The semantic content is identical; the temperature is
+completely different.
+
+The working vocabulary test: say the sentence aloud. Does it sound like something a person
+would say to a friend explaining what just happened? If not, identify the Sino-Korean
+construction and replace it with the native equivalent. "결제 진행" → "결제 중". "이용
+가능합니다" → "쓸 수 있어요". "확인 후 진행하세요" → "확인하고 다음으로 가세요". Each
+substitution costs no precision and removes the institutional chill that Sino-Korean carries.
+
+### One sentence, one idea
+
+Toss's principle 4 — Focus on key message — is a sentence construction rule as much as an
+editing rule: one sentence carries one message, read in a single breath. Korean's
+agglutinative structure tempts long sentences because each extension costs only a morpheme,
+and the grammatical seams are invisible in a way that English subordination is not. The
+sentence that says three things when read carefully says nothing when scanned.
+
+The test is breath, not grammar: if the sentence runs past one breath when read aloud at
+normal pace, it carries more than one idea. Split at the clause boundary where the idea
+changes. The two shorter sentences will not need connectives (또한, 따라서, 그리고) to join
+them — the natural juxtaposition carries the relationship without naming it.
+
+### What Korean products actually sound like
+
+The native register of successful Korean consumer products — Toss, 당근, Kakao — is not
+informal. It is committed to one register and precise within it. The sentences are short.
+The verbs are native. The formality level is consistent from hero to error message. The copy
+never explains the product's own mechanism; it describes what changes for the user.
+
+배민 (Baemin) operates in a distinct creative register — warm, witty, deliberately playful —
+but the underlying commitment is the same: a consistent voice that was designed and held,
+not allowed to drift. Their UX writing interview at bcut.baemin.com describes the first
+UX writer's mandate as "ensuring the text inside the app communicates clearly with users
+and protecting consistency." The register is brand-specific; the structural commitment is
+universal.
+
+Translated English marketing is the loudest failure mode. The sentence structure of
+English product copy — subject, action verb, object, benefit clause — does not map cleanly
+onto Korean's SOV order or its topic-comment preference. Copy that was conceived in English
+and translated reads as translated: the particle choices are safe rather than native, the
+nominalisations are abundant, and the rhythm is wrong in a way that fluent readers feel
+before they can name it. The correct direction is to write the Korean sentence a Korean
+product would have written first, not to translate the English sentence that would have
+appeared on an English-language version of the same screen.
+
+---
+
+## Sources
+
+- Nielsen, J. (1997). "How Users Read on the Web." Nielsen Norman Group.
+  nngroup.com/articles/how-users-read-on-the-web/ — 79% scan finding; scanning as default
+  web reading behavior, not an aberration
+- Morkes, J. & Nielsen, J. (1997). "Concise, SCANNABLE, and Objective: How to Write for
+  the Web." Nielsen Norman Group. nngroup.com/articles/concise-scannable-and-objective —
+  58% usability gain for concise writing, 47% for scannable, 124% combined
+- Nielsen, J. (2006). "F-Shaped Pattern For Reading Web Content."
+  nngroup.com/articles/f-shaped-pattern-reading-web-content-discovered/ — F-pattern as a
+  fallback behavior, not a design target
+- Oppenheimer, D.M. (2006). "Consequences of Erudite Vernacular Utilized Irrespective of
+  Necessity: Problems with using long words needlessly." *Applied Cognitive Psychology*,
+  20(2), 139–156. doi:10.1002/acp.1178 — plain language increases perceived intelligence
+  via processing fluency; complexity reduces it
+- Feature-based detection of AI-generated text (Springer, *AI and Ethics*, 2025) — human
+  writing has greater sentence-length variance and standard deviation than model-generated
+  text; confirmed across academic, journalistic, and creative domains
+- PMC study on academic science writing (pmc.ncbi.nlm.nih.gov/articles/PMC10328544/) —
+  sentence-level diversity in length and paragraph complexity as primary detection signals;
+  over 99% accuracy using stylometric features alone
+- arXiv 2408.04647, "Distinguishing Chatbot from Human" — GPT sentences longer on average;
+  human writing has wider range and higher variance across sentence lengths
+- Podmajersky, T. (2019). *Strategic Writing for UX.* O'Reilly Media. — voice chart as
+  instrument connecting product principles to copy decisions; voice applied like a spice:
+  too little is flavorless, too much inedible
+- Mailchimp Content Style Guide (styleguide.mailchimp.com) — "plainspoken" as the core
+  voice dimension: strip hyperbolic language, upsells, and over-promises; clarity above
+  entertainment; active voice, positive language, plain English
+- 37signals, "The 37signals Guide to Internal Communication" (37signals.com/how-we-
+  communicate) — "If your words can be perceived in different ways, they'll be understood
+  in the way which does the most harm"; plain writing reduces interpretive surface
+- Wiebe, J. / Copyhackers, "How to do rapid-fire review mining"
+  (copyhackers.com/how-to-do-rapid-fire-review-mining/) — voice-of-customer method:
+  mine real user language from reviews and forums; the customer names the value better
+  than the copywriter
+- Toss Tech. (2022). "토스의 8가지 라이팅 원칙들."
+  toss.tech/article/8-writing-principles-of-toss — eight principles built from A/B test
+  data: Predictable hint, Weed cutting, Remove empty sentences, Focus on key message, Easy
+  to speak (avoid 한자어 and 문어체), Suggest over force, Universal words, Find hidden emotion
+- Toss Developer Center, UX Writing Guide
+  (developers-apps-in-toss.toss.im/design/ux-writing.html) — 해요체 as the product-wide
+  standard; active voice preference; one message per sentence; native Korean over Sino-Korean
+- 배민 UX Writing interview (bcut.baemin.com/6287/) — first UX writer mandate: clear
+  communication and consistency of voice; register as a designed commitment, not a default

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -61,6 +61,12 @@ makes rewrites noisy and trust collapse fast. Three tiers:
 - **Uniform rhythm**: 문장 길이 분산이 없음, 같은 어미 연속(-다/-다/-다, -입니다 3연속)
 - **E-7** (S3): 경어법 레벨 흔들림 — 합쇼체와 해체가 단락 안에서 섞임. 대화문 안의 흔들림은
   예외. 군집(5회+)일 때만 제거.
+- **E-8** (S1): 한국어 문장 안 스페이스드 대시 — " — " 또는 " – "(양옆 공백이 있는 em-dash/
+  en-dash)가 한글이 포함된 문장에 등장하면 즉시 제거. 영문 타이포그래피 관습이 번역 과정에서
+  그대로 옮겨진 패턴이다. 쉼표·콜론·새 문장으로 대체. `SLOP-KO-EMDASH` 규칙과 동일한 패턴.
+- **E-9** (S1): 경어법 혼용 — 해요체(아요/어요/예요/에요)와 합니다체(습니다/ㅂ니다)가 같은
+  단락에서 교차하면 S1으로 처리. 따옴표 안의 대화는 예외. 페이지 전체에서 보이스 스터디가
+  결정한 한 가지 어체만 사용. `SLOP-KO-REGISTER-MIX` 규칙과 동일한 패턴.
 - **Redundant modification**: 매우/정말/아주 습관적 사용, 유의어 쌍(명확하고 분명한),
   -적/-성/-화 접미사 남발
 - **Hedging stacks**: ~할 수 있을 것으로 보인다, ~일 수도 있다고 생각된다
@@ -76,6 +82,22 @@ makes rewrites noisy and trust collapse fast. Three tiers:
 - Hedging: "can potentially", "may possibly", "it could be argued"
 - Bold **key phrases** sprinkled as decoration
 
+## Four tells the linter cannot fully catch
+
+These require human judgment because the IR cannot measure them mechanically:
+
+- **Hard line breaks mid-sentence** (`<br>` or `\n` inside a paragraph, not at a sentence
+  boundary): the DOM collapses `<br>` before the linter sees the text, so `SLOP-BR-BREAK`
+  cannot be a YAML rule. Look for `<br>` in the source HTML of any paragraph or hero line.
+  Remove it; `max-width` and `line-height` control the column, not the markup. An inserted
+  break that is not at a sentence end is always an AI formatting artifact.
+
+- **Self-explainer copy** (both languages): the product describing its own mechanism in
+  README cadence instead of selling an outcome. Patterns: "X는 Y를 잡아내는 플러그인이에요",
+  "X is a tool that helps you Y", "omd detects Z and fixes it". These read as the model
+  quoting its own task description. Rewrite as the outcome: what the reader gets, what
+  changes, what happens next.
+
 ## The pink elephant (absolute, both languages)
 
 Copy must never state what the thing is NOT. Told "no clutter", a model writes "No
@@ -90,6 +112,16 @@ And **design rationale never appears in shipped copy.** If the text is page copy
 omd project, run `omd check <page>` — SLOP-LEAKED-RATIONALE fires when five consecutive
 words match `.omd/frame.md` or `decisions.md`. The frame explains the work; the page must
 never quote it.
+
+## What to write toward
+
+The tells above describe what to remove. `core/theory/voice.md` (or
+`${CLAUDE_PLUGIN_ROOT}/core/theory/voice.md` when running inside the plugin) describes
+what to write toward: sentence-length variance as the human signal, front-loading,
+concrete nouns over nominalisations, the Mailchimp plainspoken standard, the Toss "Easy
+to speak" test for Korean. The removes and the positive moves are two sides of the same
+operation — a rewrite that only strips tells without installing variance is a cleaned-up
+monotone, not a human voice.
 
 ## Procedure
 

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -463,6 +463,13 @@ checklist. S1 violations — connective commas (C-11), mechanical pronoun substi
 announces the work was generated. Humanize does not change what the copy says; it changes
 whether a person could have said it.
 
+The positive standard for what the copy should move toward — not just what it removes —
+is `core/theory/voice.md` (or `${CLAUDE_PLUGIN_ROOT}/core/theory/voice.md` inside the
+plugin). The key checks before handing off: sentence-length variance present (short after
+long, not uniform rhythm); information front-loaded in each paragraph; no Latinate
+nominalisations where a verb would serve; for Korean copy, one speech level held throughout
+and vocabulary temperature committed to 고유어 where precision allows.
+
 ```bash
 # inspect copy, then:
 omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come back clean

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -52,6 +52,22 @@ instructions: |
     `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,motion,components,craft,expressive}.md`.
     Theory citations are evidence. Taste is not.
 
+  ## Korean copy critique
+
+  When the page contains Korean copy, run two additional checks as part of the critique
+  — these are not covered by `omd check` when the IR has already collapsed the markup:
+
+  1. **Register consistency** — pick any two sentences in the same paragraph and compare
+     their endings. 해요체 (아요/어요/에요) and 합니다체 (습니다/ㅂ니다) must not alternate
+     inside one block. `SLOP-KO-REGISTER-MIX` fires at the text-node level; what that rule
+     cannot see is whether the *same speech level was chosen and held across the whole page*.
+     Name the level the voice study committed to; flag any block that deviates.
+
+  2. **Dash usage** — spaced em-dash ( — ) and en-dash ( – ) inside Korean sentences read
+     as translation artifacts. `SLOP-KO-EMDASH` fires on these; confirm no instance reached
+     the render. If one did, name the specific sentence and the rewrite (comma, colon, or
+     new sentence).
+
   ## Register-aware critique
 
   You will be given the committed register (quiet / confident / showpiece) alongside the

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -161,6 +161,34 @@ instructions: |
   - connective abuse: consecutive sentences opening with 또한/따라서/즉/Also/Moreover
   - decoration: bold everywhere, em-dash chains, emoji in headings
 
+  Four additional tells that are deterministically AI-flavoured in Korean copy — `omd check`
+  flags the first two; the second two are yours to police before the page ships:
+
+  **No spaced em-dash or en-dash in Korean sentences.** " — " and " – " inside Hangul-bearing
+  sentences are a direct transfer from English typography and appear in Korean AI output as a
+  translation artifact. Rewrite as a comma, a colon, or a new sentence. "빠릅니다 — 정확합니다"
+  → "빠르고 정확합니다." `SLOP-KO-EMDASH` fires on this pattern.
+
+  **One speech level, chosen from the voice study, held for the whole page.** 해요체 (아요/어요/
+  에요) and 합니다체 (습니다/ㅂ니다) must not alternate within the same paragraph or across
+  paragraphs on the same page. The voice study in `.omd/` names which level this product uses;
+  every sentence conforms to it. `SLOP-KO-REGISTER-MIX` fires when both endings appear in one
+  text node.
+
+  **No `<br>` or hard newlines mid-sentence.** Line wrapping is the CSS's job. A sentence broken
+  with `<br>` reads as AI-formatted text (the model inserting visual line breaks to match its
+  training data's layout conventions) and breaks reflow at every other viewport width. Write
+  continuous prose; let `max-width` and `line-height` control the line length. This tell cannot
+  be detected by `omd check` — the IR collapses `<br>` before the linter runs — so it is your
+  responsibility to catch it in the source HTML before handoff.
+
+  **No self-explainer copy.** The page sells outcomes; it does not describe its own mechanism
+  in README cadence. "X는 Y를 잡아내는 Claude Code 플러그인이에요" is documentation, not a hero
+  line. Write what the reader gets, what changes after they use the product, what happens next
+  — not what the tool is or how it works. If you catch yourself writing "X는/은 ~하는 ~이에요/
+  입니다" as the first sentence of a section, that is the self-explainer tell; delete it and
+  write the outcome instead.
+
   Placeholder copy is a defect. "Lorem ipsum" and "Your content here" never ship.
 
   ## Unmeasured decisions require a citation
@@ -179,8 +207,12 @@ instructions: |
   **Arbitrary decision is not a third option.** "I chose 1.333 because it felt right" is
   not a decision — it is a guess. The theory pack exists precisely to resolve the gaps the
   board leaves. Use it. Path: `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,
-  motion,components,craft,expressive}.md`. Read whichever file covers the gap, pull the
-  relevant condition→choice→reason entry, and record it in `omd decision`.
+  motion,components,craft,expressive,voice}.md`. Read whichever file covers the gap, pull
+  the relevant condition→choice→reason entry, and record it in `omd decision`. For copy
+  decisions — sentence rhythm, vocabulary temperature, register — cite `voice.md`
+  specifically: it maps the burstiness finding to practical sentence construction, the
+  Oppenheimer result to vocabulary choice, and the Toss/Mailchimp standards to the positive
+  form of each Korean and English tell.
 
   ## Write the motion spec before building anything
 

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -111,6 +111,15 @@ instructions: |
     SLOP-COPY / SLOP-COPY-KO rules target — its voice is not collectible: those patterns
     trace the model's training data, not a human writer's choices.
 
+    When writing the voice study principles, name which moves from `core/theory/voice.md`
+    the studied site exemplifies. The framework: does the site front-load information
+    (voice.md § scanning research)? Does it vary sentence length — short after long
+    (voice.md § statistical signature)? Does it use concrete nouns over nominalisations
+    (voice.md § plain language)? For Korean sites: which speech level, and does the
+    vocabulary temperature favour native 고유어 over Sino-Korean (voice.md § Korean copy)?
+    A principle that names the voice.md move gives the hand a citation to cite in
+    attribution.md; a principle that says "sentences are short and direct" gives nothing.
+
   ## Source trust hierarchy
 
   Not every source is equally trustworthy, and the slop problem is specifically a search

--- a/src/skills/omd-humanize/SKILL.md
+++ b/src/skills/omd-humanize/SKILL.md
@@ -61,6 +61,12 @@ makes rewrites noisy and trust collapse fast. Three tiers:
 - **Uniform rhythm**: 문장 길이 분산이 없음, 같은 어미 연속(-다/-다/-다, -입니다 3연속)
 - **E-7** (S3): 경어법 레벨 흔들림 — 합쇼체와 해체가 단락 안에서 섞임. 대화문 안의 흔들림은
   예외. 군집(5회+)일 때만 제거.
+- **E-8** (S1): 한국어 문장 안 스페이스드 대시 — " — " 또는 " – "(양옆 공백이 있는 em-dash/
+  en-dash)가 한글이 포함된 문장에 등장하면 즉시 제거. 영문 타이포그래피 관습이 번역 과정에서
+  그대로 옮겨진 패턴이다. 쉼표·콜론·새 문장으로 대체. `SLOP-KO-EMDASH` 규칙과 동일한 패턴.
+- **E-9** (S1): 경어법 혼용 — 해요체(아요/어요/예요/에요)와 합니다체(습니다/ㅂ니다)가 같은
+  단락에서 교차하면 S1으로 처리. 따옴표 안의 대화는 예외. 페이지 전체에서 보이스 스터디가
+  결정한 한 가지 어체만 사용. `SLOP-KO-REGISTER-MIX` 규칙과 동일한 패턴.
 - **Redundant modification**: 매우/정말/아주 습관적 사용, 유의어 쌍(명확하고 분명한),
   -적/-성/-화 접미사 남발
 - **Hedging stacks**: ~할 수 있을 것으로 보인다, ~일 수도 있다고 생각된다
@@ -76,6 +82,22 @@ makes rewrites noisy and trust collapse fast. Three tiers:
 - Hedging: "can potentially", "may possibly", "it could be argued"
 - Bold **key phrases** sprinkled as decoration
 
+## Four tells the linter cannot fully catch
+
+These require human judgment because the IR cannot measure them mechanically:
+
+- **Hard line breaks mid-sentence** (`<br>` or `\n` inside a paragraph, not at a sentence
+  boundary): the DOM collapses `<br>` before the linter sees the text, so `SLOP-BR-BREAK`
+  cannot be a YAML rule. Look for `<br>` in the source HTML of any paragraph or hero line.
+  Remove it; `max-width` and `line-height` control the column, not the markup. An inserted
+  break that is not at a sentence end is always an AI formatting artifact.
+
+- **Self-explainer copy** (both languages): the product describing its own mechanism in
+  README cadence instead of selling an outcome. Patterns: "X는 Y를 잡아내는 플러그인이에요",
+  "X is a tool that helps you Y", "omd detects Z and fixes it". These read as the model
+  quoting its own task description. Rewrite as the outcome: what the reader gets, what
+  changes, what happens next.
+
 ## The pink elephant (absolute, both languages)
 
 Copy must never state what the thing is NOT. Told "no clutter", a model writes "No
@@ -90,6 +112,16 @@ And **design rationale never appears in shipped copy.** If the text is page copy
 omd project, run `omd check <page>` — SLOP-LEAKED-RATIONALE fires when five consecutive
 words match `.omd/frame.md` or `decisions.md`. The frame explains the work; the page must
 never quote it.
+
+## What to write toward
+
+The tells above describe what to remove. `core/theory/voice.md` (or
+`${CLAUDE_PLUGIN_ROOT}/core/theory/voice.md` when running inside the plugin) describes
+what to write toward: sentence-length variance as the human signal, front-loading,
+concrete nouns over nominalisations, the Mailchimp plainspoken standard, the Toss "Easy
+to speak" test for Korean. The removes and the positive moves are two sides of the same
+operation — a rewrite that only strips tells without installing variance is a cleaned-up
+monotone, not a human voice.
 
 ## Procedure
 

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -463,6 +463,13 @@ checklist. S1 violations — connective commas (C-11), mechanical pronoun substi
 announces the work was generated. Humanize does not change what the copy says; it changes
 whether a person could have said it.
 
+The positive standard for what the copy should move toward — not just what it removes —
+is `core/theory/voice.md` (or `${CLAUDE_PLUGIN_ROOT}/core/theory/voice.md` inside the
+plugin). The key checks before handing off: sentence-length variance present (short after
+long, not uniform rhythm); information front-loaded in each paragraph; no Latinate
+nominalisations where a verb would serve; for Korean copy, one speech level held throughout
+and vocabulary temperature committed to 고유어 where precision allows.
+
 ```bash
 # inspect copy, then:
 omd check <page> --category slop   # SLOP-PINK-ELEPHANT and SLOP-COPY must come back clean

--- a/test/attribution.test.ts
+++ b/test/attribution.test.ts
@@ -44,7 +44,7 @@ const NESTED_COLOR_TOKENS = { color: { 'brand/primary': '#FF5A1F' } };
 const NESTED_TYPE_TOKENS = { font: { 'size-lg': '18px' } };
 
 const CAPTURE_NAMES = ['linear.com.hero', 'apple.com.global', 'stripe.com.pricing'];
-const THEORY_NAMES = ['color', 'typography', 'layout', 'motion', 'expressive', 'components', 'craft'];
+const THEORY_NAMES = ['color', 'typography', 'layout', 'motion', 'expressive', 'components', 'craft', 'voice'];
 
 // ── ATTR-MISSING ─────────────────────────────────────────────────────────────
 

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -199,6 +199,88 @@ test('SLOP-COPY-KO fires on 둘째, and 셋째, list-enumeration patterns', () =
   }
 });
 
+test('SLOP-KO-EMDASH fires when Hangul text contains a spaced em-dash or en-dash', () => {
+  const positives = [
+    '가장 흔한 답이 나와요 — 인디고에서 보라색으로 이어지는 그라디언트.',
+    '디자인은 결정이에요 — 기본값이 아니라.',
+    '모든 색은 이유가 있어요 – 브랜드가 결정한다.',
+    '우리는 다르게 생각합니다 — 평균이 아닌 입장.',
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-KO-EMDASH'), `expected SLOP-KO-EMDASH for: ${text}`);
+  }
+});
+
+test('SLOP-KO-EMDASH does not fire on English copy even with spaced em-dash', () => {
+  const negatives = [
+    'Design is a decision — not a default.',
+    'Every color has a reason — the brand decides.',
+    'We think differently — not the average.',
+    // Korean without any spaced dash
+    '디자인은 결정이에요, 기본값이 아니라.',
+    '모든 색은 이유가 있어요: 브랜드가 결정한다.',
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-EMDASH'), `unexpected SLOP-KO-EMDASH for: ${text}`);
+  }
+});
+
+test('SLOP-KO-REGISTER-MIX fires when 해요체 and 합니다체 alternate in one block', () => {
+  const positives = [
+    // exact screenshot text from the task
+    '모델은 정답을 만들지 않아요. 훈련 데이터의 평균을 만듭니다.',
+    '빠르고 정확해요. 품질을 보장합니다.',
+    '사용하기 쉬워요. 전문가도 만족합니다.',
+    '나와요. 평균을 만듭니다.',
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-KO-REGISTER-MIX'), `expected SLOP-KO-REGISTER-MIX for: ${text}`);
+  }
+});
+
+test('SLOP-KO-REGISTER-MIX does not fire on uniform-register blocks', () => {
+  const negatives = [
+    // all 해요체
+    '빠르고 정확해요. 사용하기 쉬워요. 품질이 좋아요.',
+    // all 합니다체
+    '빠르고 정확합니다. 사용하기 쉽습니다. 품질을 보장합니다.',
+    // non-Korean text
+    'Fast and accurate. Easy to use. Quality guaranteed.',
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-REGISTER-MIX'), `unexpected SLOP-KO-REGISTER-MIX for: ${text}`);
+  }
+});
+
+test('SLOP-KO-REGISTER-MIX stays silent when quotation marks are present', () => {
+  const negatives = [
+    // quoted dialogue legitimately mixes registers
+    '그는 "나는 좋아요"라고 했습니다.',
+    "그녀가 '정말 좋아요'라고 대답했습니다.",
+    '“빠르고 좋아요”라고 평가했습니다.',
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-REGISTER-MIX'), `unexpected SLOP-KO-REGISTER-MIX for: ${text}`);
+  }
+});
+
+test('SLOP-KO-EMDASH and SLOP-KO-REGISTER-MIX do not fire on English-only nodes', () => {
+  const englishNodes = [
+    'Design is a decision — not a default.',
+    'Fast. Accurate. Easy to use.',
+  ];
+  for (const text of englishNodes) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-EMDASH'), `unexpected SLOP-KO-EMDASH for: ${text}`);
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-REGISTER-MIX'), `unexpected SLOP-KO-REGISTER-MIX for: ${text}`);
+  }
+});
+
 test('SLOP-PINK-ELEPHANT does not fire on legitimate negative-statement copy', () => {
   const negatives = [
     // privacy / policy copy


### PR DESCRIPTION
- SLOP-KO-EMDASH, SLOP-KO-REGISTER-MIX (screenshot cases pinned as tests), slop definition widened to non-native prose
- core/theory/voice.md: 8th theory file, verified sources only (Nielsen, Oppenheimer, burstiness papers, 토스/배민)
- 392→398 tests