### PR TITLE
feat: component blueprints, Korean line-breaking, React default, voice calibration

### DIFF
--- a/agents/hand.md
+++ b/agents/hand.md
@@ -291,6 +291,45 @@ Composition constraints, each non-negotiable:
 - Sidebar margin annotations disappear below 900px; the mobile fallback must be
   designed, not just the desktop layout.
 
+## Transplanting a blueprint
+
+When the scout's board includes a blueprint for a component you are building, and the
+spec calls for it, you may transplant it — rebuilding its structure and metrics nearly
+verbatim. This is the only time structure is borrowed from a reference; it is bounded
+to one component, not the whole page.
+
+Rules, each non-negotiable:
+
+**Structure and metrics: nearly verbatim.** The node tree, box dimensions, padding,
+gap, direction, radius, shadow presence — reproduce them. The blueprint is a measurement,
+not a sketch; treating it as loose inspiration defeats the purpose of capturing it.
+
+**Color: never from the reference.** The blueprint stores roles (bg / surface / fg /
+muted / accent), not hex values. Map each role to the project's own design tokens —
+`bg` → `--color-bg`, `accent` → `--color-accent`, and so on. No color from the
+reference enters the build. If a role has no equivalent token, add the token first.
+
+**Type sizes: re-fit to the project's scale.** Keep the blueprint's *hierarchy ratios*
+— if the blueprint shows a 1.5× difference between label and heading, preserve that
+ratio using the project's own type scale. Absolute px values from the blueprint are
+not transplanted unless the spec explicitly says otherwise.
+
+**Attribution: declare it.** Write the attribution row as:
+
+```
+| Nav structure | nav-capture (blueprint) | Transplanted node tree; color roles mapped to project tokens; type sizes re-fitted to 1.25 scale |
+```
+
+**Copy: written fresh.** The blueprint carries a text length class (label / phrase /
+paragraph) per node, not the reference's actual words. Write new copy in the project's
+voice, at the appropriate length, citing the voice study. Transplanting copy is the same
+defect as transplanting color — it announces where the work came from.
+
+**The page-distance guard still applies.** Run `omd ref distance` after the build.
+A transplanted component does not exempt the page from the ≥0.6 similarity threshold —
+the guard fires on overall structural resemblance, and a transplanted nav is one signal
+among many. If the page trips the threshold, change the other drivers.
+
 ## Imagery — no grey placeholder boxes, ever
 
 Every image zone must ship with a deliberate alternative when photography is absent.

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -373,11 +373,54 @@ Before writing a single file, read `package.json` in the working directory if it
   If you cannot determine the pattern from package.json alone, read one existing component
   before writing anything new.
 - If no package.json exists or it names no recognised framework, use the stack the brief
-  specifies. If the brief is silent on stack, build plain HTML + CSS + minimal vanilla JS
-  — the least infrastructure that delivers the design.
+  specifies. If the brief is silent on stack, **default to React with Vite**
+  (`npm create vite@latest . -- --template react-ts`). Plain HTML + CSS + minimal vanilla
+  JS is used only when the user explicitly asked for it, or when the artifact is a single
+  static page where React buys nothing — no interactive state, no reusable components, just
+  styled markup (a single self-contained landing page, an email template, a static document).
+  If you take the plain-HTML path without explicit instruction, record the reason:
+  `omd decision "Using plain HTML — single-page static artifact; no interactive state or component reuse required"`.
 
 The point of this step is that a React project that ships a raw `index.html` alongside its
-component tree has two design systems competing. Match what is there.
+component tree has two design systems competing. Match what is there. Greenfield projects
+default to React because the component model prevents CSS bleed, enables token-based
+styling via CSS modules or styled-components, and gives the eye a real tree to inspect —
+not because React is universally correct, but because the decision to use plain HTML must
+be a stated judgment, not an omission.
+
+## Korean page defaults
+
+When the page's primary language is Korean — the brief is written in Korean, the copy is
+Korean, or `lang="ko"` is set — apply these base-layer styles before any component styles:
+
+    * { word-break: keep-all; overflow-wrap: break-word; }
+    h1, h2, h3, h4, h5, h6 { text-wrap: balance; }
+
+`word-break: keep-all` prevents Korean eojeol (어절) from splitting mid-word across line
+breaks — "동시접속" wrapping as "동\n시접속" is the single loudest AI-generated-page tell
+for Korean readers, and it is the first thing `omd check` (`KO-KEEP-ALL`) measures. Apply
+it once at the `*` level and it covers every text node on the page without per-component
+effort.
+
+`overflow-wrap: break-word` handles long URLs, code strings, and any run of characters
+without a natural break point that would otherwise cause horizontal overflow.
+
+`text-wrap: balance` on headings distributes line length evenly across lines, preventing
+a single orphaned syllable on the last line (the Korean typographic widow). Browser support:
+Chrome 114+, Firefox 121+; older browsers ignore it gracefully.
+
+**clamp() display text must be verified at 375px.** `word-break: keep-all` changes where
+lines break, which changes the measured height of text containers at narrow widths. A hero
+heading sized with `clamp(2rem, 8vw, 6rem)` that fits in two lines at 768px may wrap to
+three lines at 375px. If the container has an explicit height or `overflow: hidden`, the
+last line's descender is cut off — `SYS-TEXT-CLIP` fires on this at check time. Before
+handoff, resize to 375px in devtools and confirm no heading descender is clipped. Fix
+options: reduce the `clamp()` minimum, add `padding-bottom` to accommodate the extra line,
+or remove the explicit height and let the container size to its content.
+
+These four lines are not optional for Korean pages. Omitting them produces the same class
+of defect as omitting `prefers-reduced-motion` on an animated page — a correctness failure,
+not a style preference.
 
 ## Build mechanics
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -298,6 +298,33 @@ what it has seen is its training objective. **So you never describe how a refere
 looks.** "Linear has a dark sidebar with a rounded search input" is the sentence that
 produces a Linear knockoff.
 
+## Blueprint capture
+
+A blueprint is a full-resolution structural measurement of one component, with the skin
+abstracted to color roles (bg / surface / fg / muted / accent). It is captured with:
+
+```bash
+omd ref add <url> --as <name> --selector ".nav" --blueprint
+```
+
+Use `--blueprint` only when:
+- The component solves *exactly* the structural problem the build faces (e.g. the spec
+  asks for a nav with a specific left-panel + search-bar + action-row arrangement), or
+- The user pointed at a specific component and said "use something like this".
+
+**Maximum 3 blueprints per board.** A board of blueprints is a collage — the value of
+the reference system is that the build has to *think*, not assemble. Three is enough to
+cover the build's hardest structural problems; anything more is a kit of parts.
+
+### The honest update to the Jansson & Smith clause
+
+The fixation rule was "never see a reference's pixels." A blueprint is not pixels — it
+is measurement at full resolution, bounded to one component, with the skin abstracted to
+roles. The risk is priced: structure transplants, skin never does, and the page-distance
+guard still fires on a clone. The guard does not replace good judgement; it is the last
+line of defence. The scout's job is to capture blueprints only when they serve the build,
+not to collect them as insurance.
+
 ## What you do at each capture
 
 1. Capture: `omd ref add <url> --as <name> [--selector ".nav"]`

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -36,11 +36,13 @@ interface Opts {
   image?: boolean;
   filmstrip?: boolean;
   fromUser?: boolean;
+  /** Capture a full-resolution structural blueprint of the selected component. */
+  blueprint?: boolean;
   /** Directory of pages for cross-page site consistency check (`omd check --site <dir>`). */
   site?: string;
 }
 
-const FLAGS = new Set(['json', 'no-log', 'image', 'filmstrip', 'from-user']);
+const FLAGS = new Set(['json', 'no-log', 'image', 'filmstrip', 'from-user', 'blueprint']);
 const ALIASES: Record<string, keyof Opts> = { o: 'out', 'no-log': 'noLog', 'from-user': 'fromUser' };
 
 function parseArgs(args: string[]): Opts {
@@ -353,6 +355,10 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
     console.error('--image and --selector cannot be used together: an image has no subtree to scope.');
     process.exit(1);
   }
+  if (opts.blueprint && !opts.selector) {
+    console.error('--blueprint requires --selector: a blueprint measures one component, not a whole page.');
+    process.exit(1);
+  }
   const { saveRef } = await import('../core/ref/store.ts');
 
   if (opts.image) {
@@ -391,6 +397,15 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
   const { captureEnergy, parseViewport } = await import('../core/render/index.ts');
   const energyCurve = await captureEnergy(target, { viewport: parseViewport(opts.viewport) });
 
+  // Blueprint: full-resolution structural snapshot with skin abstracted to color roles.
+  // Only captured when --blueprint is passed together with --selector.
+  let blueprint: import('../core/types.ts').Blueprint | undefined;
+  if (opts.blueprint && opts.selector) {
+    const { captureBlueprint } = await import('../core/ref/blueprint.ts');
+    blueprint = captureBlueprint(raw.nodes, opts.selector);
+    console.error(`blueprint: ${blueprint.nodes.length} nodes captured`);
+  }
+
   const path = saveRef(process.cwd(), {
     source: target,
     component: opts.as,
@@ -402,6 +417,7 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
     slopCount,
     ...(opts.fromUser ? { origin: 'user' as const } : {}),
     ...(energyCurve !== null ? { energyCurve } : {}),
+    ...(blueprint !== undefined ? { blueprint } : {}),
   });
   console.log(path);
   console.log(JSON.stringify(invariants, null, 2));
@@ -469,7 +485,48 @@ async function cmdRefShow(opts: Opts): Promise<never> {
     console.log('\nPrinciples:');
     for (const p of ref.principles) console.log(`  - ${p}`);
   }
+  if (ref.blueprint) {
+    printBlueprint(ref.blueprint);
+  }
   process.exit(0);
+}
+
+/**
+ * Print a blueprint as an indented, buildable spec. Each line is one node with its
+ * role, dimensions, typography, surface, color roles, and motion timings. The tree
+ * structure is reconstructed from the children arrays.
+ */
+function printBlueprint(bp: import('../core/types.ts').Blueprint): void {
+  const childIds = new Set(bp.nodes.flatMap((n) => n.children));
+  const roots = bp.nodes.filter((n) => !childIds.has(n.id));
+  const byId = new Map(bp.nodes.map((n) => [n.id, n]));
+
+  const printNode = (id: string, depth: number): void => {
+    const node = byId.get(id);
+    if (!node) return;
+    const indent = '  '.repeat(depth);
+    const parts: string[] = [node.role, `${node.box.w}×${node.box.h}`];
+    if (node.fontSize != null) parts.push(`${node.fontSize}px`);
+    if (node.fontWeight != null) parts.push(`fw:${node.fontWeight}`);
+    if (node.lineHeight != null) parts.push(`lh:${node.lineHeight}`);
+    if (node.radius != null) parts.push(`r=${node.radius}`);
+    if (node.hasShadow) parts.push('shadow');
+    if (node.fillRole) parts.push(`fill:${node.fillRole}`);
+    if (node.textRole) parts.push(`text:${node.textRole}`);
+    if (node.textLength) parts.push(`[${node.textLength}]`);
+    if (node.motionDurations?.length) parts.push(`motion:${node.motionDurations.join(',')}ms`);
+    if (node.direction) parts.push(node.direction === 'VERTICAL' ? 'col' : 'row');
+    if (node.gap != null) parts.push(`gap:${node.gap}`);
+    if (node.padding) {
+      const [t, r, b, l] = node.padding;
+      if ((t ?? 0) + (r ?? 0) + (b ?? 0) + (l ?? 0) > 0) parts.push(`p:${t}/${r}/${b}/${l}`);
+    }
+    console.log(`${indent}${parts.join('  ')}`);
+    for (const childId of node.children) printNode(childId, depth + 1);
+  };
+
+  console.log(`\nBlueprint  selector: ${bp.selector}  (${bp.nodes.length} nodes)`);
+  for (const root of roots) printNode(root.id, 0);
 }
 
 async function cmdRefList(): Promise<never> {
@@ -626,8 +683,9 @@ function usage(): never {
     + '  decision "what" --why "why"\n'
     + '  taste profile\n'
     + '\n'
-    + '  ref add <url|file> --as <component> [--selector "css"] [--image]\n'
+    + '  ref add <url|file> --as <component> [--selector "css"] [--image] [--blueprint]\n'
     + '                                                render, extract invariants, save\n'
+    + '  ref add ... --selector ".nav" --blueprint     also capture a component blueprint\n'
     + '  ref list                                    one line per saved reference\n'
     + '  ref distance <page>                         compare a page to every saved reference\n'
     + '  ref principles <source> --as C --add "..."   record why a reference works\n'

--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -141,7 +141,16 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
         const lh = parseFloat(cs.lineHeight);
         node.lineHeight = fontSize > 0 && !Number.isNaN(lh) ? Math.round((lh / fontSize) * 100) / 100 : 1.2;
       }
+      // word-break is well-supported; always capture on text nodes.
+      if (cs.wordBreak) node.wordBreak = cs.wordBreak;
+      // text-wrap (CSS text-wrap shorthand) landed in Chrome 114 / Firefox 121.
+      // Access via bracket notation to avoid TypeScript complaints on older lib versions.
+      const tw = (cs as unknown as Record<string, string>)['textWrap'];
+      if (tw) node.textWrap = tw;
     }
+    // Capture overflow when non-default so SYS-TEXT-CLIP can identify clipping parents.
+    // Skip 'visible' (the CSS default) to keep the IR sparse.
+    if (cs.overflow && cs.overflow !== 'visible') node.overflow = cs.overflow;
 
     // Motion: non-zero transition-durations, non-zero animation-durations, and any named
     // animation. `transition-duration`/`transition-timing-function` and

--- a/core/ref/blueprint.ts
+++ b/core/ref/blueprint.ts
@@ -1,0 +1,199 @@
+import type { RawNode } from '../types.ts';
+import type { Blueprint, BlueprintNode, ColorRole, NodeRole, TextLengthClass } from '../types.ts';
+
+/**
+ * WCAG relative luminance from a hex string like '#AABBCC'.
+ * Returns 0 for unrecognised values.
+ */
+export function relativeLuminance(hex: string): number {
+  const clean = hex.replace('#', '');
+  if (clean.length !== 6) return 0;
+  const f = (c: number): number => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  const r = f(parseInt(clean.slice(0, 2), 16) / 255);
+  const g = f(parseInt(clean.slice(2, 4), 16) / 255);
+  const b = f(parseInt(clean.slice(4, 6), 16) / 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * HSL saturation (0..1) from a hex string. Near-grey colors return 0.
+ * Used to identify accent colors that stand out by hue rather than by luminance.
+ */
+export function hexSaturation(hex: string): number {
+  const clean = hex.replace('#', '');
+  if (clean.length !== 6) return 0;
+  const r = parseInt(clean.slice(0, 2), 16) / 255;
+  const g = parseInt(clean.slice(2, 4), 16) / 255;
+  const b = parseInt(clean.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+  return l > 0.5 ? d / (2 - max - min) : d / (max + min);
+}
+
+export interface ColorEntry {
+  hex: string;
+  count: number;
+  /** True for background/fill colors; false for text colors. */
+  isFill: boolean;
+}
+
+/**
+ * Cluster component colors into semantic roles using usage frequency and relative luminance.
+ * Literal hex values never leave this function; only roles are stored in the blueprint.
+ *
+ * Assignment order (each hex is claimed by the first matching rule):
+ * 1. accent  — minority color (count < max) with highest HSL saturation > 0.25;
+ *              text colors are preferred over fills since interactive elements often use text
+ * 2. bg      — most-frequent fill (darker fill wins ties)
+ * 3. surface — remaining fills (elevated panels, cards)
+ * 4. fg      — most-frequent text color (darker text wins ties)
+ * 5. muted   — remaining text colors
+ *
+ * This is a pure function: identical input → identical output.
+ */
+export function clusterColorRoles(colors: ColorEntry[]): Map<string, ColorRole> {
+  const result = new Map<string, ColorRole>();
+  if (colors.length === 0) return result;
+
+  const maxCount = Math.max(...colors.map((c) => c.count));
+
+  // Accent: a minority saturated color that stands out from the structural palette.
+  // Text colors are preferred (CTAs, links), then fills (branded buttons).
+  // A color at max frequency is structural — it cannot be an accent.
+  const accentCandidate = [...colors]
+    .filter((c) => c.count < maxCount && hexSaturation(c.hex) > 0.25)
+    .sort((a, b) => {
+      // Text colors first; within same kind, higher saturation wins.
+      if (a.isFill !== b.isFill) return a.isFill ? 1 : -1;
+      return hexSaturation(b.hex) - hexSaturation(a.hex);
+    })[0];
+  if (accentCandidate) result.set(accentCandidate.hex, 'accent');
+
+  // Fills: most-frequent → bg; rest → surface.
+  // Ties in frequency are broken by luminance (darker fill = more dominant backdrop).
+  const fills = colors
+    .filter((c) => c.isFill && !result.has(c.hex))
+    .sort((a, b) => b.count - a.count || relativeLuminance(a.hex) - relativeLuminance(b.hex));
+  fills.forEach((f, i) => result.set(f.hex, i === 0 ? 'bg' : 'surface'));
+
+  // Text colors: most-frequent → fg; rest → muted.
+  const texts = colors
+    .filter((c) => !c.isFill && !result.has(c.hex))
+    .sort((a, b) => b.count - a.count || relativeLuminance(a.hex) - relativeLuminance(b.hex));
+  texts.forEach((t, i) => result.set(t.hex, i === 0 ? 'fg' : 'muted'));
+
+  return result;
+}
+
+/** Derive the semantic role of a node from its IR fields. */
+export function deriveNodeRole(node: Pick<RawNode, 'type' | 'interactive' | 'heading' | 'name'>): NodeRole {
+  if (node.interactive) return 'interactive';
+  if (node.heading !== undefined) return 'heading';
+  if (node.type === 'TEXT') return 'text';
+  // Heuristic for image elements: the DOM extractor encodes the tag name as the first
+  // segment of node.name (tagname.firstClass). Match common image container tags.
+  const tag = (node.name.split('.')[0] ?? '').toLowerCase();
+  if (tag === 'img' || tag === 'svg' || tag === 'picture' || tag === 'figure') return 'image';
+  return 'container';
+}
+
+/** Derive the text length class from node text content. Copy is never stored. */
+export function deriveTextLength(text: string): TextLengthClass {
+  if (text.length <= 20) return 'label';
+  if (text.length <= 80) return 'phrase';
+  return 'paragraph';
+}
+
+/**
+ * Build a Blueprint from a component's raw nodes.
+ *
+ * What is stored per node: role, box dimensions, layout metrics (padding, gap, direction),
+ * typography metrics (fontSize, fontWeight, lineHeight), surface geometry (radius, shadow),
+ * color roles (bg/surface/fg/muted/accent — no literal hex values), motion timings, and a
+ * text length class (label/phrase/paragraph — no actual copy).
+ *
+ * What is NOT stored: text content, literal color values, alignment (not measured by the
+ * IR extractor), border details (not measured by the IR extractor).
+ *
+ * Inherited fills — transparent nodes that show an ancestor's backdrop — are excluded from
+ * the color inventory and from each node's fillRole so the component's own palette is what
+ * gets clustered.
+ *
+ * @param nodes     Raw nodes from extractIr, already scoped to the selector.
+ * @param selector  The CSS selector that bounded this capture (stored as metadata).
+ */
+export function captureBlueprint(nodes: RawNode[], selector: string): Blueprint {
+  // Build color frequency map. Keyed by hex+kind so the same color can appear as both a
+  // fill (background) and a text color — they are different roles in different slots.
+  const colorMap = new Map<string, ColorEntry>();
+  const trackColor = (hex: string, isFill: boolean): void => {
+    const key = `${hex}:${isFill ? 'f' : 't'}`;
+    const entry = colorMap.get(key);
+    if (entry) entry.count += 1;
+    else colorMap.set(key, { hex, count: 1, isFill });
+  };
+
+  for (const node of nodes) {
+    // Only authored (non-inherited) fills represent the node's own background.
+    const fill = node.fill;
+    if (fill && typeof fill.value === 'string' && !fill.inherited) {
+      trackColor(fill.value, true);
+    }
+    if (node.color) trackColor(node.color, false);
+  }
+
+  const colorRoleMap = clusterColorRoles([...colorMap.values()]);
+
+  const bpNodes: BlueprintNode[] = nodes.map((node): BlueprintNode => {
+    const role = deriveNodeRole(node);
+
+    const bp: BlueprintNode = {
+      id: node.id,
+      role,
+      children: [...node.children],
+      box: { w: node.box.w, h: node.box.h },
+    };
+
+    // Layout: store padding and gap only when non-trivial; direction always when present.
+    if (node.layout) {
+      bp.padding = node.layout.padding;
+      if (node.layout.gap > 0) bp.gap = node.layout.gap;
+      bp.direction = node.layout.mode;
+    }
+
+    // Typography: only the fields the extractor actually measured.
+    if (node.fontSize != null) bp.fontSize = node.fontSize;
+    if (node.fontWeight != null) bp.fontWeight = node.fontWeight;
+    if (node.lineHeight != null) bp.lineHeight = node.lineHeight;
+
+    // Surface geometry.
+    const rv = node.radius?.value;
+    if (typeof rv === 'number' && rv > 0) bp.radius = rv;
+    if (node.shadow?.value) bp.hasShadow = true;
+
+    // Color roles — literal hexes never leave this function.
+    const fillHex = node.fill?.value;
+    if (typeof fillHex === 'string' && !node.fill?.inherited) {
+      const cr = colorRoleMap.get(fillHex);
+      if (cr) bp.fillRole = cr;
+    }
+    if (node.color) {
+      const cr = colorRoleMap.get(node.color);
+      if (cr) bp.textRole = cr;
+    }
+
+    // Motion timings: durations and easings, no animation names.
+    if (node.motion?.durations?.length) bp.motionDurations = [...node.motion.durations];
+    if (node.motion?.easings?.length) bp.motionEasings = [...node.motion.easings];
+
+    // Text length class — content stripped, only length signal remains.
+    if (node.text) bp.textLength = deriveTextLength(node.text);
+
+    return bp;
+  });
+
+  return { selector, capturedAt: new Date().toISOString(), nodes: bpNodes };
+}

--- a/core/ref/store.ts
+++ b/core/ref/store.ts
@@ -83,6 +83,9 @@ export function loadRefs(cwd: string): Reference[] {
           // energyCurve is absent on references captured before energy measurement was
           // added — omit the key so downstream code can use `?? null` to detect absence.
           ...(parsed.energyCurve !== undefined ? { energyCurve: parsed.energyCurve } : {}),
+          // blueprint is absent on references captured before --blueprint was introduced.
+          // Omit the key so downstream code can check `ref.blueprint !== undefined`.
+          ...(parsed.blueprint !== undefined ? { blueprint: parsed.blueprint } : {}),
         });
       }
     } catch {

--- a/core/rules/builtin/ko.yaml
+++ b/core/rules/builtin/ko.yaml
@@ -1,0 +1,37 @@
+# Korean-specific rules. These are not slop (not design-mean convergence failures) and not
+# generic a11y — they are correctness requirements specific to pages whose primary text is
+# Korean. Category 'a11y' because each rule describes a readability defect that affects all
+# Korean readers, equivalent in weight to minimum font size or contrast ratio for Latin text.
+
+# KO-KEEP-ALL: fires once per page when any Hangul-bearing text node is missing
+# word-break: keep-all.
+#
+# word-break: keep-all prevents the browser from breaking Korean eojeol (어절 — the
+# space-delimited word units Korean uses) mid-word across line boundaries. The CSS default
+# 'normal' treats each syllable block as a break opportunity, which produces:
+#   "동시접속" → "동\n시접속"
+#   "확인했어요" → "확인했\n어요"
+#   "연락 주세요" → "연락 주\n세요"
+# These are the most prominent visual tells that identify an AI-generated Korean page.
+# No native Korean UI designer would ship without keep-all; applying it is the first
+# typographic act, not an afterthought.
+#
+# Fires ONCE PER PAGE (root node only), not per text node. keep-all belongs on the base
+# layer (`* { word-break: keep-all; }`) so one fix covers the whole page. Per-node
+# repetition would produce dozens of identical findings and obscure the single action needed.
+# The value reports the count of affected nodes so the engineer knows the scope.
+#
+# Category: a11y — not a style preference. Mid-eojeol breaks impair reading comprehension
+# for all Korean readers; the W3C klreq (Requirements for Hangul Text Layout) explicitly
+# requires word-boundary-aware line breaking for Korean text.
+#
+# Positive test:  node with Korean text, wordBreak !== 'keep-all' → fires
+# Negative tests: all Korean nodes have keep-all → silent; page has no Korean text → silent
+- id: KO-KEEP-ALL
+  layer: 1
+  category: a11y
+  severity: warn
+  when: "node.parent === null && ir.nodes.some(n => Boolean(n.text) && /[가-힣]/u.test(n.text))"
+  value: "ir.nodes.filter(n => Boolean(n.text) && /[가-힣]/u.test(n.text) && n.wordBreak !== 'keep-all').length"
+  assert: "value === 0"
+  message: "{value} Korean text node(s) missing word-break: keep-all. Without it, Korean eojeol (어절) break mid-word across lines — '동시접속' → '동\\n시접속', '확인했어요' → '확인했\\n어요'. This is the single loudest AI-generated-page tell for Korean readers. Fix: add `* { word-break: keep-all; overflow-wrap: break-word; }` to the base CSS layer."

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -187,3 +187,35 @@
   value: "node.computed.identicalSiblings"
   assert: "false"
   message: "{value} structurally identical cards sit side by side. Three feature cards are not an information architecture; they are a confession that nobody decided what matters most. Decide, then make that one bigger."
+
+# Korean document-structure narration. These phrases announce the document's own organisation
+# rather than communicating what the product does: "아래는 그 기록이에요" (below is the record),
+# "다음은 기능 목록입니다" (the following is the feature list). On a product page, this cadence
+# exposes the model's essay or README skeleton — the AI introducing its own bullet list instead
+# of writing the bullet list. A human copywriter presents the content; they do not narrate
+# that content is about to appear.
+#
+# Two patterns, both gated on Korean text presence:
+#
+# Pattern 1: 아래는 <words> <기록|내용|목록|정리>
+#   "아래는 그 기록이에요" → fires
+#   "아래는 변경 내용이에요" → fires
+#   "아래 버튼을 누르세요" → passes (아래 without 는 particle; spatial adverb not a structure marker)
+#   "아래에서 다운로드하세요" → passes (아래에서, not 아래는)
+#
+# Pattern 2: 다음은 <words> <입니다|이에요>
+#   "다음은 기능 목록입니다" → fires
+#   "다음은 그 이유이에요" → fires
+#   "다음에 다시 시도해주세요" → passes (다음에, not 다음은)
+#
+# The .{0,30} span is deliberately short: a sentence that says "아래는 그 기록이에요" has
+# the structure word within 30 characters of 아래는. A longer span risks matching sentences
+# that happen to contain 기록 as part of an unrelated clause.
+- id: SLOP-KO-SIGNPOST
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.text) && node.text.length > 8 && /[가-힣]/u.test(node.text)"
+  value: "node.text"
+  assert: "!/아래는\\s+.{0,30}(?:기록|내용|목록|정리)|다음은\\s+.{0,30}(?:입니다|이에요)/u.test(value)"
+  message: "Document-structure narration copy: \"{value}\". '아래는 … 기록/내용/목록' and '다음은 … 입니다/이에요' introduce the document's structure in essay cadence. On a product page, write what the product does — not that we will now look at what the product does. Delete the announcing sentence and replace it with the specific fact or action it was narrating."

--- a/core/rules/builtin/system.yaml
+++ b/core/rules/builtin/system.yaml
@@ -1,0 +1,42 @@
+# System-level correctness rules that do not fit the existing per-category files.
+# Category 'system' means something is measurably wrong in the implementation — not a
+# design-mean convergence failure (slop), not a user-facing access barrier (a11y), and not
+# an animation craft defect (motion).
+
+# SYS-TEXT-CLIP: detects a text node whose rendered layout box extends below its parent's
+# bottom edge when the parent clips overflow (overflow: hidden or clip). The canonical case
+# is a clamp()-sized display heading whose last-line descender is cut off at the container.
+#
+# Measurement basis: getBoundingClientRect() returns the full CSS layout rect of the text
+# element, not the visually clipped rect — so node.box.h reflects the unclipped text height
+# even when the parent hides it. If text.box.bottom > parent.box.bottom + 4px and the
+# parent clips, the descender IS visually cut off and the user sees incomplete text.
+#
+# Guard on overflow value:
+#   overflow: hidden / clip  → clips without a scroll escape → rule fires
+#   overflow: visible        → text bleeds out intentionally → silent (not stored, treated as absent)
+#   overflow: scroll / auto  → clips but provides a scrollbar → silent (content accessible)
+#
+# Vertical-only check: only bottom-edge overflow is tested. Horizontal overflow is excluded
+# to avoid false positives from marquee tracks, which extend rightward inside an
+# overflow: hidden container by design (see core/motion/recipes/marquee.md).
+#
+# Threshold: 4px. Sub-pixel rounding and browser differences can produce 1–2px mismatches
+# on legitimate layouts; 4px filters those without masking real descender clips (which
+# are typically 8–20px depending on font and size).
+#
+# Known limitation: position: absolute / fixed children that legitimately overflow a
+# clipping ancestor will false-positive here. If the false-positive rate proves significant
+# in practice, extend dom.ts to capture cs.position on each node and add the guard:
+#   !node.position || (node.position !== 'absolute' && node.position !== 'fixed')
+#
+# Positive test:  text.box.y + text.box.h > parent.box.y + parent.box.h + 4, parent.overflow === 'hidden' → fires
+# Negative tests: parent.overflow absent (visible default) → silent; overflow within threshold → silent
+- id: SYS-TEXT-CLIP
+  layer: 1
+  category: system
+  severity: warn
+  when: "Boolean(node.text) && node.parent !== null"
+  value: "(() => { const parent = ir.nodes.find(n => n.id === node.parent); if (!parent) return null; if (parent.overflow !== 'hidden' && parent.overflow !== 'clip') return null; const overflowPx = (node.box.y + node.box.h) - (parent.box.y + parent.box.h); return overflowPx > 4 ? overflowPx : null; })()"
+  assert: "value === null"
+  message: "Text overflows its clipping parent by {value}px (bottom edge). The parent has overflow: hidden — the descender or last line is visually cut off. Fix: remove the explicit height from the parent and let it size to its content, add padding-bottom to accommodate the text at the smallest clamp() value, or verify that the clamp() minimum renders without clipping at 375px viewport width."

--- a/core/theory/typography.md
+++ b/core/theory/typography.md
@@ -280,6 +280,42 @@ with many strokes (e.g., 흙, 닭). At 14px, all modern Korean fonts render clea
 
 ---
 
+## Korean line-breaking: word-break: keep-all
+
+Korean text is written without spaces between syllables within a word unit (어절), but with
+spaces between word units. The CSS default `word-break: normal` treats each syllable block
+as a breakable unit, which produces splits like "동\n시접속" (simultaneous connection) or
+"확인했\n어요" (I confirmed) — a break inside a meaningful word unit that no Korean writer
+would produce and that any Korean reader registers immediately as a layout error.
+
+`word-break: keep-all` prevents the browser from breaking inside a Korean eojeol. A line
+break can occur only at the space boundaries between word units, matching how Korean readers
+expect text to wrap. This is not a style preference. It is a readability requirement — the
+W3C *Requirements for Hangul Text Layout* (klreq) explicitly defines word-boundary-aware
+line breaking as the correct behaviour for Korean text.
+
+**Implementation**: apply at the base layer, not component-by-component:
+
+    * { word-break: keep-all; overflow-wrap: break-word; }
+    h1, h2, h3, h4, h5, h6 { text-wrap: balance; }
+
+`overflow-wrap: break-word` handles long URLs and code strings that cannot break at
+word boundaries. `text-wrap: balance` on headings distributes line length evenly across
+lines, preventing a single orphaned syllable on the last line of a heading — the Korean
+equivalent of a typographic widow.
+
+**Verification at narrow viewport**: `word-break: keep-all` changes how text wraps, which
+changes the measured height of containers at narrow widths. After applying it, verify the
+layout at 375px. A `clamp()`-sized display heading that fitted comfortably at 768px may
+overflow its container at 375px after wrap behaviour changes — the last line's descender
+can be cut off by `overflow: hidden` on the container. Fixes: reduce the `clamp()` minimum
+value, add `padding-bottom` to accommodate the extra line, or set `overflow: visible` with
+enough vertical whitespace below. `KO-KEEP-ALL` in `omd check` fires once per page when any
+Hangul text node is missing `word-break: keep-all`, measuring the actual computed value from
+the live DOM.
+
+---
+
 ## Sources
 
 - Bringhurst, *The Elements of Typographic Style* (4th ed., 2012) — modular scale,

--- a/core/theory/voice.md
+++ b/core/theory/voice.md
@@ -235,6 +235,51 @@ UX writer's mandate as "ensuring the text inside the app communicates clearly wi
 and protecting consistency." The register is brand-specific; the structural commitment is
 universal.
 
+### Document-structure narration: write the content, not that content is coming
+
+AI-generated Korean product copy has a structural tell: it narrates the document before
+presenting the document. "아래는 그 기록이에요" (below is the record), "다음은 기능 목록입니다"
+(the following is the feature list) — these sentences announce the organisation of what
+follows rather than delivering it. The cadence comes from the essay or README skeleton the
+model was trained on. A human copywriter does not introduce their own bullet list; they write
+the bullet list.
+
+`SLOP-KO-SIGNPOST` fires on the deterministic patterns: `아래는 … 기록/내용/목록/정리` and
+`다음은 … 입니다/이에요`. The fix is deletion: remove the announcing sentence and start with
+the content it was announcing. "아래는 그 기록이에요." → delete it; begin with the first item.
+
+The negative to hold in mind: "아래 버튼을 누르세요" does not fire. 아래 used as a spatial
+adverb (without the topic marker 는) is navigation copy, not structural narration.
+
+### Uniform sentence endings and not-X-but-Y: pre-handoff checks, not linter rules
+
+Two Korean AI tells are real but cannot be made into safe deterministic rules:
+
+**Three or more consecutive identical sentence-final endings** (이에요./이에요./이에요. or
+합니다./합니다./합니다.) are a statistical signal of AI generation — a human writer varies
+structure. However, product benefit lists deliberately use parallel endings: "빠릅니다.
+정확합니다. 쉽습니다." is valid copy that would false-positive on every legitimate feature
+section. A linter rule would fire on too much legitimate writing to be trusted.
+
+Pre-handoff check: if three or more adjacent sentences share the same final ending, vary
+at least one — rewrite to a shorter sentence, a question, or a clause that ends differently.
+The goal is not to eliminate parallel endings but to break a uniform rhythm that reads as
+output from a loop rather than from a writer.
+
+**The not-X-but-Y construction** (`~게 아니라 ~했어요` / `~이 아니라 ~입니다`) appears in
+AI output as performed contrast in response to a brief that said "be honest" or "be direct."
+It also appears in legitimate copy: a brand that deliberately contrasts itself with a
+category norm ("빠른 게 아니라 정확합니다") uses this construction with intent. No narrow
+regex distinguishes the cases reliably.
+
+Pre-handoff check: when this construction appears in the hero or opening paragraph, ask
+whether the contrast was a designed claim (cite it in decisions.md with the brand reason)
+or a model hedging its own confidence. Delete hedges; keep designed contrasts. "AI가 만든
+게 아니라, 사람이 썼어요" as a self-description of the tool is a hedge; "비싼 게 아니라
+오래 씁니다" as a product claim is a designed contrast.
+
+Neither pattern has an `omd check` rule. Both belong on the hand's pre-handoff review pass.
+
 Translated English marketing is the loudest failure mode. The sentence structure of
 English product copy — subject, action verb, object, benefit clause — does not map cleanly
 onto Korean's SOV order or its topic-comment preference. Copy that was conceived in English

--- a/core/theory/voice.md
+++ b/core/theory/voice.md
@@ -251,6 +251,109 @@ the content it was announcing. "아래는 그 기록이에요." → delete it; b
 The negative to hold in mind: "아래 버튼을 누르세요" does not fire. 아래 used as a spatial
 adverb (without the topic marker 는) is navigation copy, not structural narration.
 
+### Calibration evidence: what the measured gap between human and pipeline prose reveals
+
+The following lessons come from a direct calibration: a 16,000-character Korean personal tech
+essay by Evan Moon (evan-moon.github.io/2020/12/29/2020-retrospective/, published December 2020,
+fully human-authored) was used as the baseline. A parallel version covering the same facts was
+written by following voice.md and the humanize skill rules faithfully. The two versions were
+measured against the same metrics. The gaps name what our rules actively get wrong.
+
+**Measured diff table (N=26–36 sentences per version, character lengths exclude spaces):**
+
+| Metric | Human essay | Our version |
+|---|---|---|
+| Sentence length min | 8 chars | 8 chars |
+| Sentence length max | 114 chars | 48 chars |
+| Sentence length mean | 50.4 chars | 19.9 chars |
+| Sentence length σ | 26.1 | 9.8 |
+| Ending diversity (unique/total) | 0.86 | 0.96 |
+| Connective rate (per sentence) | 0.42 | 0.00 |
+| C-11 violations (connective+comma) | 1 | 0 |
+| Parenthetical asides | 6 in full article | 0 |
+| Unresolved uncertainty markers | 5 | 0 |
+
+**Lesson 1 — Register context: 해요체 is for product copy, not essays**
+
+The sampled human essay uses the informal narrative register (-다 style) throughout: 해였다,
+것 같다, 생각이었다, 모르겠다. None of these are 해요체 or 합니다체. Korean personal essays,
+회고글, and reflective blog posts are written in this register — it is the written voice of a
+person narrating their own experience, not the addressed voice of a product speaking to a user.
+
+Our rules prescribe 해요체 for Korean copy. Applied to an essay, that produces a newsletter
+register: warm, present-tense, second-person-inflected — correct for UI strings and product
+stories but wrong for first-person retrospective prose. A 회고글 in 해요체 sounds like a
+product announcement; a 회고글 in -다 register sounds like someone who was actually there.
+
+Condition → choice → reason: before applying the 해요체 standard, identify the genre. Product
+copy (UI strings, error messages, landing pages, marketing copy): 해요체, without exception.
+Personal essays, 회고글, developer blog posts: match the register the genre demands. The rule
+from voice.md applies at the product layer; it was never a claim about all Korean writing.
+
+**Lesson 2 — Connective overcorrection: the tell is the comma, not the connective**
+
+The sampled human essay uses connectives at a rate of 0.42 per sentence — 15 connectives
+across 36 sentences, including 하지만, 그래서, 그런데, 물론, 또한, 사실, 결국. Not one
+is followed by a comma (C-11 count: 1, a naturally-occurring case). The human connective
+rate is high because connectives carry logical structure; they are not AI tells by themselves.
+
+The pipeline version, shaped by the SKILL.md rule against "connector abuse," produced zero
+connectives across 26 sentences. That is not more human — it is a different kind of abnormal.
+Abrupt juxtaposition without connectives reads as choppy, clipped, produced by a sentence-by-
+sentence generator rather than a mind that knows where the paragraph is going.
+
+What the C-11 rule identifies is the specific pattern of a connective immediately followed by
+a comma — 하지만, / 그러나, / 또한, / 따라서, — which appears in Korean generated text but
+almost never in natural writing. The rule does not say: remove all connectives.
+
+Condition → choice → reason: the connective-abuse tell is clustering (3+ consecutive sentences
+opening with connectives) and the comma after the connective. A paragraph that uses 하지만 or
+그런데 once to mark a logical turn is natural. A paragraph that opens five consecutive sentences
+with 또한/따라서/즉/그리고 is the fingerprint. Eliminate the pattern, not the words.
+
+**Lesson 3 — Parenthetical asides: a positive model our rules never named**
+
+The sampled essay contains six parenthetical asides across 16,000 characters — roughly one per
+1,000 characters, or once every three to four paragraphs: "(살면서 노래방을 이렇게 안 가본 게
+처음…)", "(결국 이러다가 번아웃이 왔었지만, 습관은 잘 안 고쳐지더라…)", "(그리고 스스로 뭔가
+꼰대 같다는 생각이 들어서 이걸 깨닫고 한동안 우울했었다)". These are self-interruptions —
+second thoughts, humor, corrections — that signal a mind present on the page, not a generator
+completing a paragraph.
+
+The pipeline produces zero. The tells list names what to remove; it has no positive model for
+this form. An essay with no parenthetical asides in 3,000+ characters is measurably flatter
+than the human baseline.
+
+Condition → choice → reason: in essayistic Korean prose (blog posts, 회고글, product stories),
+if no parenthetical aside has appeared in 1,000+ characters, look for a place where a second
+thought belongs. Not as decoration — as the actual second thought being suppressed to keep the
+paragraph clean. The aside earns its position when the main sentence structure has nowhere to
+put what needs to be said.
+
+**Lesson 4 — σ and unresolved uncertainty: the most human signal is incompleteness**
+
+The human essay's sentence-length σ was 26.1; the pipeline's was 9.8. The maximum sentence
+length in the human essay was 114 characters (no spaces); the pipeline capped at 48. The
+burstiness rule in voice.md is correct in direction, but execution under the rules remains too
+controlled. "After two long sentences, write a short one" is necessary but not sufficient —
+the human also writes two long sentences after the short one, and then another 114-character
+one. The human doesn't manage rhythm; the human follows thought wherever it goes.
+
+The sampled human essay closed its mentoring section with: "하지만 아직도 잘 모르겠다." Thirteen
+characters. The pipeline produced: "이게 올해가 남긴 가장 큰 질문이에요." That is a packaged
+takeaway. It names the lesson; it does not live in the uncertainty. The human's 13-character
+sentence is more trustworthy precisely because it refuses to resolve what has not been resolved.
+
+The full article closed with: "2020년에는 결국 이렇게 답을 찾지 못한 질문으로 회고를 마무리하지만,
+내년 2021년 회고에는 이 질문과 고민에 대한 답을 찾아서 회고에 적는 것을 목표로 잡아야겠다." The
+human commits to finding the answer next year rather than having found it this year.
+
+Condition → choice → reason: when an essay section ends, ask whether a tidy conclusion is
+honest or performed. A genuine takeaway — something the writer actually learned and can state
+— earns the closure. A resolution that smoothes over ongoing uncertainty is a model completing
+its pattern. "아직도 잘 모르겠다" is human; "이게 핵심 교훈이에요" for a lesson still in progress
+is a tell. If the answer does not exist yet, state that instead.
+
 ### Uniform sentence endings and not-X-but-Y: pre-handoff checks, not linter rules
 
 Two Korean AI tells are real but cannot be made into safe deterministic rules:

--- a/core/types.ts
+++ b/core/types.ts
@@ -332,6 +332,79 @@ export interface MotionMeasurement {
  */
 export type RefKind = 'page' | 'component' | 'image';
 
+// ── blueprint ────────────────────────────────────────────────────────────────
+
+/**
+ * Semantic color role assigned to a node's fill or text color.
+ * Literal hex values never appear in a blueprint; only roles do.
+ */
+export type ColorRole = 'bg' | 'surface' | 'fg' | 'muted' | 'accent';
+
+/** Structural role of a blueprint node, derived from the IR node type and computed fields. */
+export type NodeRole = 'container' | 'heading' | 'text' | 'interactive' | 'image';
+
+/**
+ * Length class of a text node's content. Copy is never transplanted, but knowing whether
+ * a slot holds a single word, a headline, or a paragraph guides reconstruction.
+ */
+export type TextLengthClass = 'label' | 'phrase' | 'paragraph';
+
+/**
+ * One node in a blueprint — a full-resolution structural measurement with the skin
+ * abstracted to color roles. Literal hex values, token names, and text content are
+ * absent; only what is measurable and transferable remains.
+ *
+ * Fields are present only when the IR extractor actually measured them — no invented
+ * values for fields the extractor cannot fill.
+ */
+export interface BlueprintNode {
+  id: string;
+  role: NodeRole;
+  /** IDs of direct children, in document order. */
+  children: string[];
+  /** Bounding box dimensions. Position is intentionally omitted (component-relative). */
+  box: { w: number; h: number };
+  // layout — present when the node declared flex/grid or any padding
+  padding?: [number, number, number, number];
+  /** Non-zero gap between children. Absent when 0 or unmeasured. */
+  gap?: number;
+  /** Flex/grid main axis direction. */
+  direction?: 'VERTICAL' | 'HORIZONTAL';
+  // typography — present only on text and heading nodes
+  fontSize?: number;
+  fontWeight?: number;
+  lineHeight?: number;
+  // surface geometry
+  /** Border-radius in px. Absent when 0. */
+  radius?: number;
+  /** True when the node has a non-none box-shadow. */
+  hasShadow?: boolean;
+  // color roles — no literal hex values
+  /** Semantic role of the node's background fill. Absent for transparent/inherited fills. */
+  fillRole?: ColorRole;
+  /** Semantic role of the node's text color. Absent for non-text nodes. */
+  textRole?: ColorRole;
+  // motion
+  motionDurations?: number[];
+  motionEasings?: string[];
+  // text length signal — no actual copy
+  /** Length class of the node's own text content. Absent for non-text nodes. */
+  textLength?: TextLengthClass;
+}
+
+/**
+ * Full-resolution structural measurement of one component, with the skin abstracted to
+ * color roles. The blueprint captures what the component IS structurally, not what it
+ * looks like. Transplanting a blueprint means rebuilding its structure and metrics nearly
+ * verbatim, remapping color roles to the project's own tokens, and writing fresh copy.
+ */
+export interface Blueprint {
+  /** The CSS selector that scoped this capture. */
+  selector: string;
+  capturedAt: string;
+  nodes: BlueprintNode[];
+}
+
 export interface Reference {
   source: string;
   component: string;
@@ -368,6 +441,18 @@ export interface Reference {
    * pixel-level motion including GSAP/rAF — closing the getAnimations() blind spot.
    */
   energyCurve?: EnergyCurve | null;
+  /**
+   * Full-resolution structural measurement of one component, skin abstracted to color
+   * roles. Present only when `--blueprint` was passed at capture time and a `--selector`
+   * was given. Absent on references captured before this field was introduced — treat
+   * absence as undefined at usage sites.
+   *
+   * Transplanting a blueprint means rebuilding its structure and metrics nearly verbatim,
+   * remapping colorRoles to the project's own tokens, re-fitting type sizes to the
+   * project's scale (keep hierarchy ratios, not absolute px), and writing fresh copy in
+   * the project's voice. The page-distance guard still fires on a clone.
+   */
+  blueprint?: Blueprint;
 }
 
 /** How close a page sits to a reference. 1 is identical; the warning threshold is 0.6. */

--- a/core/types.ts
+++ b/core/types.ts
@@ -57,6 +57,25 @@ export interface RawNode {
   /** line-height as a ratio to font-size, 2dp. 'normal' resolves to 1.2. */
   lineHeight?: number;
 
+  /**
+   * Computed word-break value, captured on text-bearing nodes.
+   * 'keep-all' is required for Korean text to prevent mid-eojeol (어절) line breaks.
+   * Set only on text-bearing nodes (where `type === 'TEXT'`).
+   */
+  wordBreak?: string;
+  /**
+   * Computed text-wrap value, captured on text-bearing nodes when the browser supports it
+   * (Chrome 114+, Firefox 121+). 'balance' is the recommended value for headings to prevent
+   * orphaned syllables. Absent when the browser returns an empty or unsupported value.
+   */
+  textWrap?: string;
+  /**
+   * Computed overflow value. Absent when 'visible' (the CSS default) to save space.
+   * Used by SYS-TEXT-CLIP to identify parents that visually clip their overflowing children.
+   * Only 'hidden' and 'clip' cut off content without providing a scrollbar escape.
+   */
+  overflow?: string;
+
   /** Set on any node with a non-zero transition-duration or a named animation. */
   motion?: {
     /** ms, rounded. Transition AND animation durations both land here; zero-length transitions are dropped. */

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -70,7 +70,13 @@ makes rewrites noisy and trust collapse fast. Three tiers:
 - **Redundant modification**: 매우/정말/아주 습관적 사용, 유의어 쌍(명확하고 분명한),
   -적/-성/-화 접미사 남발
 - **Hedging stacks**: ~할 수 있을 것으로 보인다, ~일 수도 있다고 생각된다
-- **Connector abuse**: 또한/따라서/즉/그리고 로 연속 문장 시작
+- **Connector abuse**: 또한/따라서/즉/그리고 로 연속 문장 시작 — 3문장 이상 연속으로 접속어가 오거나,
+  C-11 패턴(접속어 직후 쉼표)이 있을 때만 처리. 접속어 자체는 삭제하지 않는다. 자연어에서 접속어
+  사용률은 문장당 0.4 수준이 정상이다. 접속어를 전부 제거하면 끊어읽기가 비인간적으로 느껴진다.
+- **Tidy closure** (S2): 에세이·회고글 등 essayistic 장르에서 아직 해결되지 않은 질문을
+  해결된 것처럼 포장하는 문단 마무리. "이게 가장 큰 교훈이에요", "올해의 핵심 수확이에요" 형태로
+  불확실성을 지운다. 인간 필자는 "하지만 아직도 잘 모르겠다" 처럼 열린 결말을 쓴다. 단, product
+  copy나 튜토리얼은 예외 — 명확한 takeaway가 정당하다. essayistic 맥락에서만 플래그.
 - **Formal-noun padding**: ~것이다, ~점이다, ~수 있다 로만 끝나는 문단
 
 ## The tells (English)

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -23,19 +23,27 @@ card, form field, and footer the build will need, listed before the first captur
 works to a floor of **eighteen captures, targeting twenty-five**:
 
 ```bash
-omd ref add <user-url> --as <name> --from-user     # user-provided URL — captured first, quota-exempt
-omd ref add <url> --as <name>                      # whole page — rhythm and feel (3–4)
-omd ref add <url> --as <name> --selector ".nav"    # one component's anatomy (one per inventory item)
-omd ref add <url> --as type-study-1                # chosen for its typography — minimum 2
-omd ref add <url> --as type-study-2                # different register, different pairing
-omd ref add <url> --as motion-study-1              # chosen for its motion — minimum 2, minimum 4 if brief mentions animation or register is showpiece
-omd ref add <url> --as motion-study-2              # different domain, different vocabulary
-omd ref add <pin-url> --as mood --image            # unrenderable — reasoning only
-omd ref add <reddit-url> --as list-debate --image  # community: what people felt and why (minimum 2)
-omd ref add <url> --as voice-study --image         # how a real product writes
-omd ref principles <url> --as <name> --add "..."   # why it works, one sentence
+omd ref add <user-url> --as <name> --from-user                   # user-provided URL — captured first, quota-exempt
+omd ref add <url> --as <name>                                    # whole page — rhythm and feel (3–4)
+omd ref add <url> --as <name> --selector ".nav"                  # one component's anatomy (one per inventory item)
+omd ref add <url> --as <name> --selector ".nav" --blueprint      # full-resolution structural blueprint — max 3 per board
+omd ref add <url> --as type-study-1                              # chosen for its typography — minimum 2
+omd ref add <url> --as type-study-2                              # different register, different pairing
+omd ref add <url> --as motion-study-1                            # chosen for its motion — minimum 2, minimum 4 if brief mentions animation or register is showpiece
+omd ref add <url> --as motion-study-2                            # different domain, different vocabulary
+omd ref add <pin-url> --as mood --image                          # unrenderable — reasoning only
+omd ref add <reddit-url> --as list-debate --image                # community: what people felt and why (minimum 2)
+omd ref add <url> --as voice-study --image                       # how a real product writes
+omd ref principles <url> --as <name> --add "..."                 # why it works, one sentence
 omd ref list
 ```
+
+**Blueprints: use sparingly, max 3.** A blueprint (`--blueprint --selector`) captures the full
+node tree of one component with the skin abstracted to color roles. Use it only when the component
+solves the exact structural problem the build faces, or when the user pointed at a specific component.
+A blueprint is not pixels — it is measurement at full resolution bounded to one component, with color
+roles replacing literal values. Structure transplants; skin never does; the page-distance guard still
+fires on a clone.
 
 Before the first capture the scout runs at least six WebSearch queries — problem domain,
 craft, community, typography, motion, and competitor — and logs them all on the board.

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -293,6 +293,13 @@ omd decision "Rejected Raycast's motion" --why "A quiet library does not hurry."
 Assembly is not collage. Collage takes everything that looks good. **Design discards most of
 it against a single standard.**
 
+**Blueprint capture for user-pointed components.** When the user says "use something like
+this nav" or points at a specific component, instruct the scout to add `--blueprint` to that
+capture. A blueprint records the component's full node tree with the skin abstracted to color
+roles — it is not pixels. The hand can transplant the structure nearly verbatim, remapping
+roles to the project's own tokens and re-fitting type sizes to the project's scale. Max 3
+blueprints per board: a board of blueprints is a collage.
+
 ---
 
 ## 4. COMMIT — one structure, its cost named
@@ -348,6 +355,15 @@ Declare colour, spacing, radius, **type, and motion** as custom properties on `:
 eye reads those as the design system; an inline hex is reported as a defect, correctly.
 Typography comes from the reference type studies — a chosen scale and faces with a reason —
 never from defaults; motion durations and easing come from the motion study.
+
+**Blueprint transplantation.** When the board includes a blueprint for a component the spec
+calls for, pass it to `omd:hand` and instruct it to transplant: rebuild the node tree and
+metrics nearly verbatim, map each colorRole to the project's own design tokens (never the
+reference's hex values), re-fit type sizes to the project's scale keeping hierarchy ratios,
+and write fresh copy in the project's voice. The attribution row must read "transplanted from
+`<capture>` (blueprint)" and appear in `.omd/attribution.md`. The page-distance guard still
+applies after the build — a transplanted component does not exempt the page from `omd ref
+distance`.
 
 The motion cookbook is at `${CLAUDE_PLUGIN_ROOT}/core/motion/` — easing vocabulary in
 `easing.md`, twelve implementation recipes in `recipes/`. The hand implements motion FROM

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -375,11 +375,54 @@ instructions: |
     If you cannot determine the pattern from package.json alone, read one existing component
     before writing anything new.
   - If no package.json exists or it names no recognised framework, use the stack the brief
-    specifies. If the brief is silent on stack, build plain HTML + CSS + minimal vanilla JS
-    — the least infrastructure that delivers the design.
+    specifies. If the brief is silent on stack, **default to React with Vite**
+    (`npm create vite@latest . -- --template react-ts`). Plain HTML + CSS + minimal vanilla
+    JS is used only when the user explicitly asked for it, or when the artifact is a single
+    static page where React buys nothing — no interactive state, no reusable components, just
+    styled markup (a single self-contained landing page, an email template, a static document).
+    If you take the plain-HTML path without explicit instruction, record the reason:
+    `omd decision "Using plain HTML — single-page static artifact; no interactive state or component reuse required"`.
 
   The point of this step is that a React project that ships a raw `index.html` alongside its
-  component tree has two design systems competing. Match what is there.
+  component tree has two design systems competing. Match what is there. Greenfield projects
+  default to React because the component model prevents CSS bleed, enables token-based
+  styling via CSS modules or styled-components, and gives the eye a real tree to inspect —
+  not because React is universally correct, but because the decision to use plain HTML must
+  be a stated judgment, not an omission.
+
+  ## Korean page defaults
+
+  When the page's primary language is Korean — the brief is written in Korean, the copy is
+  Korean, or `lang="ko"` is set — apply these base-layer styles before any component styles:
+
+      * { word-break: keep-all; overflow-wrap: break-word; }
+      h1, h2, h3, h4, h5, h6 { text-wrap: balance; }
+
+  `word-break: keep-all` prevents Korean eojeol (어절) from splitting mid-word across line
+  breaks — "동시접속" wrapping as "동\n시접속" is the single loudest AI-generated-page tell
+  for Korean readers, and it is the first thing `omd check` (`KO-KEEP-ALL`) measures. Apply
+  it once at the `*` level and it covers every text node on the page without per-component
+  effort.
+
+  `overflow-wrap: break-word` handles long URLs, code strings, and any run of characters
+  without a natural break point that would otherwise cause horizontal overflow.
+
+  `text-wrap: balance` on headings distributes line length evenly across lines, preventing
+  a single orphaned syllable on the last line (the Korean typographic widow). Browser support:
+  Chrome 114+, Firefox 121+; older browsers ignore it gracefully.
+
+  **clamp() display text must be verified at 375px.** `word-break: keep-all` changes where
+  lines break, which changes the measured height of text containers at narrow widths. A hero
+  heading sized with `clamp(2rem, 8vw, 6rem)` that fits in two lines at 768px may wrap to
+  three lines at 375px. If the container has an explicit height or `overflow: hidden`, the
+  last line's descender is cut off — `SYS-TEXT-CLIP` fires on this at check time. Before
+  handoff, resize to 375px in devtools and confirm no heading descender is clipped. Fix
+  options: reduce the `clamp()` minimum, add `padding-bottom` to accommodate the extra line,
+  or remove the explicit height and let the container size to its content.
+
+  These four lines are not optional for Korean pages. Omitting them produces the same class
+  of defect as omitting `prefers-reduced-motion` on an animated page — a correctness failure,
+  not a style preference.
 
   ## Build mechanics
 

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -293,6 +293,45 @@ instructions: |
   - Sidebar margin annotations disappear below 900px; the mobile fallback must be
     designed, not just the desktop layout.
 
+  ## Transplanting a blueprint
+
+  When the scout's board includes a blueprint for a component you are building, and the
+  spec calls for it, you may transplant it — rebuilding its structure and metrics nearly
+  verbatim. This is the only time structure is borrowed from a reference; it is bounded
+  to one component, not the whole page.
+
+  Rules, each non-negotiable:
+
+  **Structure and metrics: nearly verbatim.** The node tree, box dimensions, padding,
+  gap, direction, radius, shadow presence — reproduce them. The blueprint is a measurement,
+  not a sketch; treating it as loose inspiration defeats the purpose of capturing it.
+
+  **Color: never from the reference.** The blueprint stores roles (bg / surface / fg /
+  muted / accent), not hex values. Map each role to the project's own design tokens —
+  `bg` → `--color-bg`, `accent` → `--color-accent`, and so on. No color from the
+  reference enters the build. If a role has no equivalent token, add the token first.
+
+  **Type sizes: re-fit to the project's scale.** Keep the blueprint's *hierarchy ratios*
+  — if the blueprint shows a 1.5× difference between label and heading, preserve that
+  ratio using the project's own type scale. Absolute px values from the blueprint are
+  not transplanted unless the spec explicitly says otherwise.
+
+  **Attribution: declare it.** Write the attribution row as:
+
+  ```
+  | Nav structure | nav-capture (blueprint) | Transplanted node tree; color roles mapped to project tokens; type sizes re-fitted to 1.25 scale |
+  ```
+
+  **Copy: written fresh.** The blueprint carries a text length class (label / phrase /
+  paragraph) per node, not the reference's actual words. Write new copy in the project's
+  voice, at the appropriate length, citing the voice study. Transplanting copy is the same
+  defect as transplanting color — it announces where the work came from.
+
+  **The page-distance guard still applies.** Run `omd ref distance` after the build.
+  A transplanted component does not exempt the page from the ≥0.6 similarity threshold —
+  the guard fires on overall structural resemblance, and a transplanted nav is one signal
+  among many. If the page trips the threshold, change the other drivers.
+
   ## Imagery — no grey placeholder boxes, ever
 
   Every image zone must ship with a deliberate alternative when photography is absent.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -309,6 +309,33 @@ instructions: |
   looks.** "Linear has a dark sidebar with a rounded search input" is the sentence that
   produces a Linear knockoff.
 
+  ## Blueprint capture
+
+  A blueprint is a full-resolution structural measurement of one component, with the skin
+  abstracted to color roles (bg / surface / fg / muted / accent). It is captured with:
+
+  ```bash
+  omd ref add <url> --as <name> --selector ".nav" --blueprint
+  ```
+
+  Use `--blueprint` only when:
+  - The component solves *exactly* the structural problem the build faces (e.g. the spec
+    asks for a nav with a specific left-panel + search-bar + action-row arrangement), or
+  - The user pointed at a specific component and said "use something like this".
+
+  **Maximum 3 blueprints per board.** A board of blueprints is a collage — the value of
+  the reference system is that the build has to *think*, not assemble. Three is enough to
+  cover the build's hardest structural problems; anything more is a kit of parts.
+
+  ### The honest update to the Jansson & Smith clause
+
+  The fixation rule was "never see a reference's pixels." A blueprint is not pixels — it
+  is measurement at full resolution, bounded to one component, with the skin abstracted to
+  roles. The risk is priced: structure transplants, skin never does, and the page-distance
+  guard still fires on a clone. The guard does not replace good judgement; it is the last
+  line of defence. The scout's job is to capture blueprints only when they serve the build,
+  not to collect them as insurance.
+
   ## What you do at each capture
 
   1. Capture: `omd ref add <url> --as <name> [--selector ".nav"]`

--- a/src/skills/omd-humanize/SKILL.md
+++ b/src/skills/omd-humanize/SKILL.md
@@ -70,7 +70,13 @@ makes rewrites noisy and trust collapse fast. Three tiers:
 - **Redundant modification**: 매우/정말/아주 습관적 사용, 유의어 쌍(명확하고 분명한),
   -적/-성/-화 접미사 남발
 - **Hedging stacks**: ~할 수 있을 것으로 보인다, ~일 수도 있다고 생각된다
-- **Connector abuse**: 또한/따라서/즉/그리고 로 연속 문장 시작
+- **Connector abuse**: 또한/따라서/즉/그리고 로 연속 문장 시작 — 3문장 이상 연속으로 접속어가 오거나,
+  C-11 패턴(접속어 직후 쉼표)이 있을 때만 처리. 접속어 자체는 삭제하지 않는다. 자연어에서 접속어
+  사용률은 문장당 0.4 수준이 정상이다. 접속어를 전부 제거하면 끊어읽기가 비인간적으로 느껴진다.
+- **Tidy closure** (S2): 에세이·회고글 등 essayistic 장르에서 아직 해결되지 않은 질문을
+  해결된 것처럼 포장하는 문단 마무리. "이게 가장 큰 교훈이에요", "올해의 핵심 수확이에요" 형태로
+  불확실성을 지운다. 인간 필자는 "하지만 아직도 잘 모르겠다" 처럼 열린 결말을 쓴다. 단, product
+  copy나 튜토리얼은 예외 — 명확한 takeaway가 정당하다. essayistic 맥락에서만 플래그.
 - **Formal-noun padding**: ~것이다, ~점이다, ~수 있다 로만 끝나는 문단
 
 ## The tells (English)

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -23,19 +23,27 @@ card, form field, and footer the build will need, listed before the first captur
 works to a floor of **eighteen captures, targeting twenty-five**:
 
 ```bash
-omd ref add <user-url> --as <name> --from-user     # user-provided URL — captured first, quota-exempt
-omd ref add <url> --as <name>                      # whole page — rhythm and feel (3–4)
-omd ref add <url> --as <name> --selector ".nav"    # one component's anatomy (one per inventory item)
-omd ref add <url> --as type-study-1                # chosen for its typography — minimum 2
-omd ref add <url> --as type-study-2                # different register, different pairing
-omd ref add <url> --as motion-study-1              # chosen for its motion — minimum 2, minimum 4 if brief mentions animation or register is showpiece
-omd ref add <url> --as motion-study-2              # different domain, different vocabulary
-omd ref add <pin-url> --as mood --image            # unrenderable — reasoning only
-omd ref add <reddit-url> --as list-debate --image  # community: what people felt and why (minimum 2)
-omd ref add <url> --as voice-study --image         # how a real product writes
-omd ref principles <url> --as <name> --add "..."   # why it works, one sentence
+omd ref add <user-url> --as <name> --from-user                   # user-provided URL — captured first, quota-exempt
+omd ref add <url> --as <name>                                    # whole page — rhythm and feel (3–4)
+omd ref add <url> --as <name> --selector ".nav"                  # one component's anatomy (one per inventory item)
+omd ref add <url> --as <name> --selector ".nav" --blueprint      # full-resolution structural blueprint — max 3 per board
+omd ref add <url> --as type-study-1                              # chosen for its typography — minimum 2
+omd ref add <url> --as type-study-2                              # different register, different pairing
+omd ref add <url> --as motion-study-1                            # chosen for its motion — minimum 2, minimum 4 if brief mentions animation or register is showpiece
+omd ref add <url> --as motion-study-2                            # different domain, different vocabulary
+omd ref add <pin-url> --as mood --image                          # unrenderable — reasoning only
+omd ref add <reddit-url> --as list-debate --image                # community: what people felt and why (minimum 2)
+omd ref add <url> --as voice-study --image                       # how a real product writes
+omd ref principles <url> --as <name> --add "..."                 # why it works, one sentence
 omd ref list
 ```
+
+**Blueprints: use sparingly, max 3.** A blueprint (`--blueprint --selector`) captures the full
+node tree of one component with the skin abstracted to color roles. Use it only when the component
+solves the exact structural problem the build faces, or when the user pointed at a specific component.
+A blueprint is not pixels — it is measurement at full resolution bounded to one component, with color
+roles replacing literal values. Structure transplants; skin never does; the page-distance guard still
+fires on a clone.
 
 Before the first capture the scout runs at least six WebSearch queries — problem domain,
 craft, community, typography, motion, and competitor — and logs them all on the board.

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -293,6 +293,13 @@ omd decision "Rejected Raycast's motion" --why "A quiet library does not hurry."
 Assembly is not collage. Collage takes everything that looks good. **Design discards most of
 it against a single standard.**
 
+**Blueprint capture for user-pointed components.** When the user says "use something like
+this nav" or points at a specific component, instruct the scout to add `--blueprint` to that
+capture. A blueprint records the component's full node tree with the skin abstracted to color
+roles — it is not pixels. The hand can transplant the structure nearly verbatim, remapping
+roles to the project's own tokens and re-fitting type sizes to the project's scale. Max 3
+blueprints per board: a board of blueprints is a collage.
+
 ---
 
 ## 4. COMMIT — one structure, its cost named
@@ -348,6 +355,15 @@ Declare colour, spacing, radius, **type, and motion** as custom properties on `:
 eye reads those as the design system; an inline hex is reported as a defect, correctly.
 Typography comes from the reference type studies — a chosen scale and faces with a reason —
 never from defaults; motion durations and easing come from the motion study.
+
+**Blueprint transplantation.** When the board includes a blueprint for a component the spec
+calls for, pass it to `omd-hand` and instruct it to transplant: rebuild the node tree and
+metrics nearly verbatim, map each colorRole to the project's own design tokens (never the
+reference's hex values), re-fit type sizes to the project's scale keeping hierarchy ratios,
+and write fresh copy in the project's voice. The attribution row must read "transplanted from
+`<capture>` (blueprint)" and appear in `.omd/attribution.md`. The page-distance guard still
+applies after the build — a transplanted component does not exempt the page from `omd ref
+distance`.
 
 The motion cookbook is at `${CLAUDE_PLUGIN_ROOT}/core/motion/` — easing vocabulary in
 `easing.md`, twelve implementation recipes in `recipes/`. The hand implements motion FROM

--- a/test/blueprint.test.ts
+++ b/test/blueprint.test.ts
@@ -1,0 +1,490 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clusterColorRoles,
+  captureBlueprint,
+  deriveNodeRole,
+  deriveTextLength,
+  relativeLuminance,
+  hexSaturation,
+  type ColorEntry,
+} from '../core/ref/blueprint.ts';
+import { saveRef, loadRefs } from '../core/ref/store.ts';
+import type { Blueprint, BlueprintNode, Reference } from '../core/types.ts';
+import type { RawNode } from '../core/types.ts';
+
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-bp-'));
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function rawNode(overrides: Partial<RawNode> & { id: string }): RawNode {
+  return {
+    name: 'div',
+    type: 'FRAME',
+    path: `body/${overrides.id}`,
+    parent: null,
+    box: { x: 0, y: 0, w: 100, h: 40 },
+    children: [],
+    ...overrides,
+  };
+}
+
+// ── relativeLuminance ─────────────────────────────────────────────────────────
+
+test('relativeLuminance: black is 0', () => {
+  assert.equal(relativeLuminance('#000000'), 0);
+});
+
+test('relativeLuminance: white is 1', () => {
+  assert.ok(Math.abs(relativeLuminance('#FFFFFF') - 1) < 0.001);
+});
+
+test('relativeLuminance: dark color has lower luminance than light color', () => {
+  assert.ok(relativeLuminance('#111111') < relativeLuminance('#EEEEEE'));
+});
+
+// ── hexSaturation ─────────────────────────────────────────────────────────────
+
+test('hexSaturation: grey has zero saturation', () => {
+  assert.equal(hexSaturation('#888888'), 0);
+  assert.equal(hexSaturation('#000000'), 0);
+  assert.equal(hexSaturation('#FFFFFF'), 0);
+});
+
+test('hexSaturation: vivid color has high saturation', () => {
+  // #FF3366 is a vivid red-pink
+  assert.ok(hexSaturation('#FF3366') > 0.8);
+  assert.ok(hexSaturation('#0066FF') > 0.8);
+});
+
+// ── clusterColorRoles ─────────────────────────────────────────────────────────
+
+test('clusterColorRoles: dominant dark fill maps to bg', () => {
+  const colors: ColorEntry[] = [
+    { hex: '#111111', count: 20, isFill: true },
+    { hex: '#EEEEEE', count: 15, isFill: false },
+  ];
+  const roles = clusterColorRoles(colors);
+  assert.equal(roles.get('#111111'), 'bg');
+  assert.equal(roles.get('#EEEEEE'), 'fg');
+});
+
+test('clusterColorRoles: dominant light fill maps to bg, secondary fill to surface', () => {
+  const colors: ColorEntry[] = [
+    { hex: '#FFFFFF', count: 30, isFill: true },
+    { hex: '#F5F5F5', count: 12, isFill: true },
+    { hex: '#111111', count: 20, isFill: false },
+  ];
+  const roles = clusterColorRoles(colors);
+  assert.equal(roles.get('#FFFFFF'), 'bg');
+  assert.equal(roles.get('#F5F5F5'), 'surface');
+  assert.equal(roles.get('#111111'), 'fg');
+});
+
+test('clusterColorRoles: high-saturation minority fill maps to accent', () => {
+  const colors: ColorEntry[] = [
+    { hex: '#111111', count: 20, isFill: true },
+    { hex: '#FF3366', count: 2, isFill: true },  // bright, minority → accent
+    { hex: '#EEEEEE', count: 15, isFill: false },
+  ];
+  const roles = clusterColorRoles(colors);
+  assert.equal(roles.get('#FF3366'), 'accent');
+  assert.equal(roles.get('#111111'), 'bg');
+  assert.equal(roles.get('#EEEEEE'), 'fg');
+});
+
+test('clusterColorRoles: high-saturation minority text color maps to accent', () => {
+  const colors: ColorEntry[] = [
+    { hex: '#FFFFFF', count: 20, isFill: true },
+    { hex: '#111111', count: 18, isFill: false }, // dominant text → fg
+    { hex: '#0066FF', count: 3, isFill: false },  // saturated, minority text → accent
+  ];
+  const roles = clusterColorRoles(colors);
+  assert.equal(roles.get('#0066FF'), 'accent');
+  assert.equal(roles.get('#111111'), 'fg');
+  assert.equal(roles.get('#FFFFFF'), 'bg');
+});
+
+test('clusterColorRoles: secondary text color maps to muted', () => {
+  const colors: ColorEntry[] = [
+    { hex: '#FFFFFF', count: 20, isFill: true },
+    { hex: '#111111', count: 15, isFill: false },
+    { hex: '#888888', count: 8, isFill: false },
+  ];
+  const roles = clusterColorRoles(colors);
+  assert.equal(roles.get('#111111'), 'fg');
+  assert.equal(roles.get('#888888'), 'muted');
+});
+
+test('clusterColorRoles: at-max-frequency color is not accent even if saturated', () => {
+  // When a saturated color is the most frequent, it is structural, not an accent.
+  const colors: ColorEntry[] = [
+    { hex: '#0066FF', count: 20, isFill: true }, // dominant fill, even though saturated
+    { hex: '#FFFFFF', count: 10, isFill: false },
+  ];
+  const roles = clusterColorRoles(colors);
+  // accent requires count < maxCount; 20 === maxCount, so not accent
+  assert.notEqual(roles.get('#0066FF'), 'accent');
+  assert.equal(roles.get('#0066FF'), 'bg');
+});
+
+test('clusterColorRoles: empty colors returns empty map', () => {
+  assert.equal(clusterColorRoles([]).size, 0);
+});
+
+test('clusterColorRoles: single fill returns bg, single text returns fg', () => {
+  const roles = clusterColorRoles([
+    { hex: '#222222', count: 5, isFill: true },
+    { hex: '#FFFFFF', count: 5, isFill: false },
+  ]);
+  // Both at maxCount → neither is accent
+  assert.equal(roles.get('#222222'), 'bg');
+  assert.equal(roles.get('#FFFFFF'), 'fg');
+});
+
+// ── deriveNodeRole ─────────────────────────────────────────────────────────────
+
+test('deriveNodeRole: interactive flag → interactive', () => {
+  assert.equal(deriveNodeRole({ type: 'FRAME', interactive: true, name: 'button' }), 'interactive');
+});
+
+test('deriveNodeRole: heading present → heading', () => {
+  assert.equal(deriveNodeRole({ type: 'TEXT', heading: 1, name: 'h1' }), 'heading');
+});
+
+test('deriveNodeRole: TEXT type without heading → text', () => {
+  assert.equal(deriveNodeRole({ type: 'TEXT', name: 'p' }), 'text');
+});
+
+test('deriveNodeRole: img tag → image', () => {
+  assert.equal(deriveNodeRole({ type: 'FRAME', name: 'img.hero' }), 'image');
+});
+
+test('deriveNodeRole: svg tag → image', () => {
+  assert.equal(deriveNodeRole({ type: 'FRAME', name: 'svg' }), 'image');
+});
+
+test('deriveNodeRole: container FRAME → container', () => {
+  assert.equal(deriveNodeRole({ type: 'FRAME', name: 'div.card' }), 'container');
+});
+
+// ── deriveTextLength ──────────────────────────────────────────────────────────
+
+test('deriveTextLength: short text → label', () => {
+  assert.equal(deriveTextLength('Submit'), 'label');
+  assert.equal(deriveTextLength('Learn more'), 'label');
+  assert.equal(deriveTextLength('A'.repeat(20)), 'label');
+});
+
+test('deriveTextLength: medium text → phrase', () => {
+  assert.equal(deriveTextLength('Build beautiful interfaces faster'), 'phrase');
+  assert.equal(deriveTextLength('A'.repeat(21)), 'phrase');
+  assert.equal(deriveTextLength('A'.repeat(80)), 'phrase');
+});
+
+test('deriveTextLength: long text → paragraph', () => {
+  assert.equal(deriveTextLength('A'.repeat(81)), 'paragraph');
+  assert.equal(deriveTextLength('Our platform helps thousands of designers build stunning interfaces every day and night.'), 'paragraph');
+});
+
+// ── captureBlueprint ──────────────────────────────────────────────────────────
+
+test('captureBlueprint: text content is absent from stored nodes', () => {
+  const nodes: RawNode[] = [
+    rawNode({
+      id: 'n0',
+      type: 'TEXT',
+      text: 'Hello world, this is some text content that must not be stored',
+      color: '#111111',
+    }),
+    rawNode({
+      id: 'n1',
+      type: 'TEXT',
+      text: 'Submit',
+      color: '#111111',
+    }),
+  ];
+  const bp = captureBlueprint(nodes, '.component');
+  for (const node of bp.nodes) {
+    assert.equal(
+      (node as unknown as Record<string, unknown>)['text'],
+      undefined,
+      `node ${node.id} must not have a text field`,
+    );
+  }
+});
+
+test('captureBlueprint: textLength is set from text content, not the content itself', () => {
+  const nodes: RawNode[] = [
+    rawNode({ id: 'n0', type: 'TEXT', text: 'Submit' }),              // ≤20 → label
+    rawNode({ id: 'n1', type: 'TEXT', text: 'Build better products' }), // 21 → phrase
+    rawNode({
+      id: 'n2',
+      type: 'TEXT',
+      text: 'Our platform helps thousands of designers and developers create stunning interfaces every day.',
+    }), // >80 → paragraph
+    rawNode({ id: 'n3', type: 'FRAME' }), // no text → no textLength
+  ];
+  const bp = captureBlueprint(nodes, '.component');
+  assert.equal(bp.nodes[0]?.textLength, 'label');
+  assert.equal(bp.nodes[1]?.textLength, 'phrase');
+  assert.equal(bp.nodes[2]?.textLength, 'paragraph');
+  assert.equal(bp.nodes[3]?.textLength, undefined);
+});
+
+test('captureBlueprint: no literal hex values in nodes', () => {
+  const nodes: RawNode[] = [
+    rawNode({
+      id: 'n0',
+      type: 'FRAME',
+      fill: { value: '#1A1A2E', token: null, authored: true },
+    }),
+    rawNode({
+      id: 'n1',
+      type: 'TEXT',
+      color: '#EEEEEE',
+      fill: { value: '#1A1A2E', token: null, inherited: true }, // inherited — not tracked
+    }),
+  ];
+  const bp = captureBlueprint(nodes, '.nav');
+  for (const node of bp.nodes) {
+    const n = node as unknown as Record<string, unknown>;
+    // fillRole and textRole are role strings, not hex
+    if (n['fillRole'] !== undefined) {
+      assert.ok(
+        ['bg', 'surface', 'fg', 'muted', 'accent'].includes(n['fillRole'] as string),
+        `fillRole must be a role, got ${n['fillRole']}`,
+      );
+    }
+    if (n['textRole'] !== undefined) {
+      assert.ok(
+        ['bg', 'surface', 'fg', 'muted', 'accent'].includes(n['textRole'] as string),
+        `textRole must be a role, got ${n['textRole']}`,
+      );
+    }
+    // There must be no field containing a bare hex string
+    for (const [key, val] of Object.entries(n)) {
+      if (key === 'id' || key === 'children') continue;
+      assert.ok(
+        typeof val !== 'string' || !/^#[0-9A-Fa-f]{6}$/.test(val),
+        `node ${node.id} field "${key}" contains a raw hex: ${val}`,
+      );
+    }
+  }
+});
+
+test('captureBlueprint: inherited fills do not contribute to color roles', () => {
+  // One authored fill on n0; n1 inherits it. The role map should only have one fill.
+  const nodes: RawNode[] = [
+    rawNode({
+      id: 'n0',
+      fill: { value: '#222222', token: null, authored: true },
+    }),
+    rawNode({
+      id: 'n1',
+      parent: 'n0',
+      fill: { value: '#222222', token: null, inherited: true }, // borrowed — must not appear twice
+    }),
+  ];
+  const bp = captureBlueprint(nodes, '.card');
+  const n0 = bp.nodes.find((n) => n.id === 'n0');
+  const n1 = bp.nodes.find((n) => n.id === 'n1');
+  assert.equal(n0?.fillRole, 'bg'); // only authored fill → becomes bg
+  assert.equal(n1?.fillRole, undefined); // inherited fill → no role
+});
+
+test('captureBlueprint: layout fields are stored from IR', () => {
+  const nodes: RawNode[] = [
+    rawNode({
+      id: 'n0',
+      layout: { mode: 'HORIZONTAL', gap: 16, padding: [8, 16, 8, 16] },
+    }),
+  ];
+  const bp = captureBlueprint(nodes, '.nav');
+  const n = bp.nodes[0]!;
+  assert.deepEqual(n.padding, [8, 16, 8, 16]);
+  assert.equal(n.gap, 16);
+  assert.equal(n.direction, 'HORIZONTAL');
+});
+
+test('captureBlueprint: motion fields are stored from IR', () => {
+  const nodes: RawNode[] = [
+    rawNode({
+      id: 'n0',
+      motion: { durations: [150, 300], animationNames: [], easings: ['ease-out', 'ease-in-out'] },
+    }),
+  ];
+  const bp = captureBlueprint(nodes, '.nav');
+  const n = bp.nodes[0]!;
+  assert.deepEqual(n.motionDurations, [150, 300]);
+  assert.deepEqual(n.motionEasings, ['ease-out', 'ease-in-out']);
+});
+
+test('captureBlueprint: selector and node count are recorded', () => {
+  const nodes: RawNode[] = [
+    rawNode({ id: 'n0' }),
+    rawNode({ id: 'n1', parent: 'n0' }),
+  ];
+  const bp = captureBlueprint(nodes, '.main-nav');
+  assert.equal(bp.selector, '.main-nav');
+  assert.equal(bp.nodes.length, 2);
+  assert.ok(typeof bp.capturedAt === 'string' && bp.capturedAt.length > 0);
+});
+
+// ── round-trip through saveRef / loadRefs ─────────────────────────────────────
+
+const baseInvariants = {
+  spacingLadder: [8, 16], radiusLadder: [4], elevationLevels: 1,
+  centeredRatio: 0, tokenCoverage: 1, paddingWeight: 8,
+  typeScale: [14, 21], fontFamilies: ['inter'], weightLadder: [400, 600],
+  motionDurations: [150], easingVocab: ['ease-out'], animatedShare: 0,
+  hoverCoverage: 0, focusCoverage: 0,
+  animatedProperties: [], hasReducedMotion: false, scrollChoreography: [],
+};
+
+const sampleBlueprint: Blueprint = {
+  selector: '.nav',
+  capturedAt: '2026-07-12T00:00:00.000Z',
+  nodes: [
+    {
+      id: 'n0',
+      role: 'container',
+      children: ['n1'],
+      box: { w: 1440, h: 72 },
+      padding: [0, 24, 0, 24],
+      gap: 16,
+      direction: 'HORIZONTAL',
+      fillRole: 'bg',
+    },
+    {
+      id: 'n1',
+      role: 'text',
+      children: [],
+      box: { w: 120, h: 20 },
+      fontSize: 14,
+      fontWeight: 600,
+      lineHeight: 1.4,
+      textRole: 'fg',
+      textLength: 'label',
+    },
+  ],
+};
+
+test('blueprint round-trips through saveRef and loadRefs intact', () => {
+  const dir = project();
+  const ref: Reference = {
+    source: 'https://linear.app',
+    component: 'nav-blueprint',
+    kind: 'component',
+    capturedAt: new Date().toISOString(),
+    selector: '.nav',
+    invariants: baseInvariants,
+    principles: ['Navigation uses HORIZONTAL layout with 24px horizontal padding.'],
+    blueprint: sampleBlueprint,
+  };
+  saveRef(dir, ref);
+  const [loaded] = loadRefs(dir);
+  assert.ok(loaded?.blueprint, 'blueprint must be present after round-trip');
+  assert.equal(loaded?.blueprint?.selector, '.nav');
+  assert.equal(loaded?.blueprint?.nodes.length, 2);
+  const n0 = loaded?.blueprint?.nodes[0];
+  assert.equal(n0?.role, 'container');
+  assert.equal(n0?.fillRole, 'bg');
+  assert.deepEqual(n0?.padding, [0, 24, 0, 24]);
+  const n1 = loaded?.blueprint?.nodes[1];
+  assert.equal(n1?.role, 'text');
+  assert.equal(n1?.textLength, 'label');
+  assert.equal(n1?.textRole, 'fg');
+  assert.equal(n1?.fontSize, 14);
+});
+
+test('loadRefs: record without blueprint field loads without blueprint (backward compat)', () => {
+  const dir = project();
+  // Write a record that predates the blueprint field — simulates a reference captured
+  // before --blueprint was introduced.
+  const old = {
+    source: 'https://stripe.com',
+    component: 'legacy-nav',
+    kind: 'component',
+    capturedAt: new Date().toISOString(),
+    selector: '.nav',
+    invariants: baseInvariants,
+    principles: [],
+  };
+  mkdirSync(join(dir, '.omd', 'refs'), { recursive: true });
+  writeFileSync(join(dir, '.omd', 'refs', 'stripe.com.legacy-nav.json'), `${JSON.stringify(old, null, 2)}\n`);
+  const [loaded] = loadRefs(dir);
+  assert.equal(loaded?.blueprint, undefined, 'absent blueprint must remain absent — treat as no blueprint');
+});
+
+test('saveRef/loadRefs preserves blueprint nodes with all optional fields', () => {
+  const dir = project();
+  const complexBlueprint: Blueprint = {
+    selector: '.card',
+    capturedAt: '2026-07-12T00:00:00.000Z',
+    nodes: [
+      {
+        id: 'n0',
+        role: 'container',
+        children: ['n1', 'n2'],
+        box: { w: 320, h: 200 },
+        padding: [16, 16, 16, 16],
+        gap: 12,
+        direction: 'VERTICAL',
+        fillRole: 'surface',
+        radius: 8,
+        hasShadow: true,
+      },
+      {
+        id: 'n1',
+        role: 'heading',
+        children: [],
+        box: { w: 288, h: 28 },
+        fontSize: 20,
+        fontWeight: 700,
+        lineHeight: 1.3,
+        textRole: 'fg',
+        textLength: 'phrase',
+        motionDurations: [160],
+        motionEasings: ['ease-out'],
+      },
+      {
+        id: 'n2',
+        role: 'interactive',
+        children: [],
+        box: { w: 120, h: 40 },
+        radius: 6,
+        fillRole: 'accent',
+        textRole: 'bg',
+        textLength: 'label',
+      },
+    ],
+  };
+  const ref: Reference = {
+    source: 'https://vercel.com',
+    component: 'feature-card',
+    kind: 'component',
+    capturedAt: new Date().toISOString(),
+    invariants: baseInvariants,
+    principles: [],
+    blueprint: complexBlueprint,
+  };
+  saveRef(dir, ref);
+  const [loaded] = loadRefs(dir);
+  const bp = loaded?.blueprint;
+  assert.ok(bp, 'blueprint must be present');
+  assert.equal(bp?.nodes.length, 3);
+  const container = bp?.nodes[0];
+  assert.equal(container?.radius, 8);
+  assert.equal(container?.hasShadow, true);
+  assert.equal(container?.fillRole, 'surface');
+  const heading = bp?.nodes[1];
+  assert.deepEqual(heading?.motionDurations, [160]);
+  assert.deepEqual(heading?.motionEasings, ['ease-out']);
+  const cta = bp?.nodes[2];
+  assert.equal(cta?.fillRole, 'accent');
+  assert.equal(cta?.textLength, 'label');
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -302,3 +302,152 @@ test('SLOP-PINK-ELEPHANT does not fire on legitimate negative-statement copy', (
     assert.ok(!v.some((x) => x.id === 'SLOP-PINK-ELEPHANT'), `unexpected SLOP-PINK-ELEPHANT for: ${text}`);
   }
 });
+
+// ── KO-KEEP-ALL ──────────────────────────────────────────────────────────────
+
+function makeKoreanIr(wordBreak?: string) {
+  const node: RawNode = {
+    id: 'ko1',
+    name: 'KoreanText',
+    type: 'TEXT',
+    path: 'Screen/KoreanText',
+    parent: null,
+    box: { x: 0, y: 0, w: 400, h: 24 },
+    children: [],
+    text: '동시접속 확인했어요',
+    ...(wordBreak !== undefined ? { wordBreak } : {}),
+  };
+  return normalize({ nodes: [node] });
+}
+
+test('KO-KEEP-ALL fires when a Hangul text node is missing word-break: keep-all', () => {
+  // no wordBreak field → computed value is not keep-all → rule fires
+  const v = check(makeKoreanIr(), builtin, { categories: ['a11y'] });
+  assert.ok(v.some((x) => x.id === 'KO-KEEP-ALL'), 'expected KO-KEEP-ALL when wordBreak absent');
+});
+
+test('KO-KEEP-ALL fires when wordBreak is normal (browser default)', () => {
+  const v = check(makeKoreanIr('normal'), builtin, { categories: ['a11y'] });
+  assert.ok(v.some((x) => x.id === 'KO-KEEP-ALL'), 'expected KO-KEEP-ALL for wordBreak:normal');
+});
+
+test('KO-KEEP-ALL does not fire when all Korean nodes have word-break: keep-all', () => {
+  const v = check(makeKoreanIr('keep-all'), builtin, { categories: ['a11y'] });
+  assert.ok(!v.some((x) => x.id === 'KO-KEEP-ALL'), 'unexpected KO-KEEP-ALL when wordBreak is keep-all');
+});
+
+test('KO-KEEP-ALL does not fire on a page with no Hangul text', () => {
+  const v = check(makeTextIr('Design is a decision, not a default.'), builtin, { categories: ['a11y'] });
+  assert.ok(!v.some((x) => x.id === 'KO-KEEP-ALL'), 'unexpected KO-KEEP-ALL on English-only page');
+});
+
+// ── SYS-TEXT-CLIP ─────────────────────────────────────────────────────────────
+
+function makeClipIr(overflowPx: number, parentOverflow?: string) {
+  const parentH = 100;
+  const textH = parentH + overflowPx;
+  const parent: RawNode = {
+    id: 'frame1',
+    name: 'HeroContainer',
+    type: 'FRAME',
+    path: 'Screen/HeroContainer',
+    parent: null,
+    box: { x: 0, y: 0, w: 600, h: parentH },
+    children: ['text1'],
+    ...(parentOverflow !== undefined ? { overflow: parentOverflow } : {}),
+  };
+  const textNode: RawNode = {
+    id: 'text1',
+    name: 'HeroHeading',
+    type: 'TEXT',
+    path: 'Screen/HeroContainer/HeroHeading',
+    parent: 'frame1',
+    box: { x: 0, y: 0, w: 580, h: textH },
+    children: [],
+    text: '다음 세대를 위한 디자인 도구',
+  };
+  return normalize({ nodes: [parent, textNode] });
+}
+
+test('SYS-TEXT-CLIP fires when text overflows a hidden-overflow parent by more than 4px', () => {
+  const v = check(makeClipIr(20, 'hidden'), builtin, { categories: ['system'] });
+  assert.ok(v.some((x) => x.id === 'SYS-TEXT-CLIP'), 'expected SYS-TEXT-CLIP for 20px overflow with hidden parent');
+});
+
+test('SYS-TEXT-CLIP does not fire when parent overflow is visible (default)', () => {
+  // visible → text bleeds intentionally, no clip
+  const v = check(makeClipIr(20), builtin, { categories: ['system'] }); // no overflow field = visible
+  assert.ok(!v.some((x) => x.id === 'SYS-TEXT-CLIP'), 'unexpected SYS-TEXT-CLIP when parent overflow is visible');
+});
+
+test('SYS-TEXT-CLIP does not fire when text fits within the parent (overflow within threshold)', () => {
+  const v = check(makeClipIr(3, 'hidden'), builtin, { categories: ['system'] });
+  assert.ok(!v.some((x) => x.id === 'SYS-TEXT-CLIP'), 'unexpected SYS-TEXT-CLIP for 3px overflow (within threshold)');
+});
+
+test('SYS-TEXT-CLIP does not fire when parent overflow is scroll', () => {
+  // scroll provides a scrollbar escape; content is not lost
+  const v = check(makeClipIr(20, 'scroll'), builtin, { categories: ['system'] });
+  assert.ok(!v.some((x) => x.id === 'SYS-TEXT-CLIP'), 'unexpected SYS-TEXT-CLIP when parent overflow is scroll');
+});
+
+// ── SLOP-KO-SIGNPOST ─────────────────────────────────────────────────────────
+
+test('SLOP-KO-SIGNPOST fires on 아래는 … 기록/내용/목록/정리 patterns', () => {
+  const positives = [
+    '아래는 그 기록이에요.',
+    '아래는 변경 내용입니다.',
+    '아래는 전체 목록이에요.',
+    '아래는 주요 정리입니다.',
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-KO-SIGNPOST'), `expected SLOP-KO-SIGNPOST for: ${text}`);
+  }
+});
+
+test('SLOP-KO-SIGNPOST fires on 다음은 … 입니다/이에요 patterns', () => {
+  const positives = [
+    '다음은 기능 목록입니다.',
+    '다음은 그 이유이에요.',
+    '다음은 주요 특징입니다.',
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-KO-SIGNPOST'), `expected SLOP-KO-SIGNPOST for: ${text}`);
+  }
+});
+
+test('SLOP-KO-SIGNPOST does not fire when 아래 is used as a spatial adverb (without 는)', () => {
+  const negatives = [
+    '아래 버튼을 누르세요.',        // spatial adverb, no topic marker
+    '아래에서 다운로드하세요.',      // 아래에서, not 아래는
+    '버튼은 아래에 있습니다.',      // 아래 embedded in sentence, not 아래는 opener
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-SIGNPOST'), `unexpected SLOP-KO-SIGNPOST for: ${text}`);
+  }
+});
+
+test('SLOP-KO-SIGNPOST does not fire when 다음 lacks the topic marker 은', () => {
+  const negatives = [
+    '다음에 다시 시도해주세요.',     // 다음에, not 다음은
+    '다음 단계로 이동하세요.',       // 다음 as a modifier, no topic marker
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-SIGNPOST'), `unexpected SLOP-KO-SIGNPOST for: ${text}`);
+  }
+});
+
+test('SLOP-KO-SIGNPOST does not fire on English-only copy', () => {
+  const negatives = [
+    'Below is the full changelog.',
+    'The following is a list of features.',
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-KO-SIGNPOST'), `unexpected SLOP-KO-SIGNPOST for: ${text}`);
+  }
+});


### PR DESCRIPTION
Four features on one branch:
- **Component blueprints** — `omd ref add --blueprint` keeps a component's measured node tree (colors as roles, no text) so the hand can transplant a part almost verbatim; max 3/board, clone guard unchanged
- **Korean line-breaking becomes law** — KO-KEEP-ALL, SYS-TEXT-CLIP, SLOP-KO-SIGNPOST (from user screenshots: '엽니\n다' mid-word breaks, clipped hero descender, '아래는 그 기록이에요' signposts)
- **React by default** for greenfield builds; plain HTML requires a written decision
- **Voice calibration** against a real human essay — measured diff table, over-correction findings (sentence-length variance, connective rate), genre-register rule

398→443 tests.