### PR TITLE
feat: kill-ai-slop 32-tell taxonomy integration

### DIFF
--- a/agents/eye.md
+++ b/agents/eye.md
@@ -44,6 +44,53 @@ You have no reasoning here to defend.
   `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,motion,components,craft,expressive}.md`.
   Theory citations are evidence. Taste is not.
 
+## Kill-ai-slop visual checklist (kill-ai-slop catalogue, MIT)
+
+After running `omd check`, scan the render for the following tells that the linter
+cannot measure. Each is a finding only when it is present without a visible reason — a
+deliberate choice is fine; the default is not. Source for each tell in parentheses.
+
+**Typography** (tells #7, #8, #10, #11):
+- A serif-italic word inside an otherwise sans headline for cheap editorial drama. The
+  counter-condition: a concept committed to mixed typographic texture with a written reason.
+- A display serif on a technical or developer-tool UI. The counter-condition: a brand
+  identity that deliberately claims heritage.
+- A small uppercase kicker (FEATURES / HOW IT WORKS / WHY US) above every heading. Flag
+  when the kicker restates the heading verbatim. One kicker per page as an editorial device
+  is fine; reflexive kickers on every section are not.
+- A full marketing sentence set at hero scale (five or more words across multiple lines
+  at display size). The hero claim should be a few words, not a paragraph.
+
+**Copy and content** (#13):
+- Multiple bold or coloured inline spans per sentence ("**Effortless** setup, **blazing**
+  performance, **zero** config"). When everything is emphasised, nothing is.
+
+**Components** (#4, #5, #16, #17, #24):
+- Stock semantic color boxes used together: blue-50/blue-600 for info, amber/amber for
+  warning, green/green for success. A product palette should grow semantic colours from
+  the brand; most states need no background colour.
+- A single-hue status indicator where border, text, and background are all the same hue
+  at three opacities. State should be communicated by words and weight first.
+- A pulsing animated status dot (animate-ping) with no real application state behind it.
+  A real status dot shows an actual system state; decoration dots are always off.
+- Rounded left-border callouts (colored border-l-4 card) used as the default list item
+  treatment. If every list item is a callout, none of them is.
+- Every icon sitting on a 10%-opacity wash of its own hue. Icons should inherit text
+  colour or sit on a defined opaque surface.
+
+**Layout** (#28, #32):
+- Large low-opacity ordinals (01/02/03 at text-8xl, ~10% opacity) on sections that have
+  no genuine sequence. The counter-condition is documented in
+  `core/composition/editorial-index-labels.md`: numbering earns its place only when the
+  content has a sequential order the user will perceive. Numbered feature sections where
+  the features can be read in any order are the tell. Name the specific sections and
+  whether their order is genuinely sequential.
+- The tasteful terminal aesthetic: monospace typeface, near-black background, one warm
+  accent, possible ASCII art. Ask: is this a terminal/developer product (correct
+  register) or a marketing site that borrowed the aesthetic because it reads as
+  "designed"? A non-terminal product using terminal chrome without a stated reason is
+  the tell.
+
 ## Korean copy critique
 
 When the page contains Korean copy, run two additional checks as part of the critique

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -149,15 +149,58 @@ catch yourself translating an English slogan into Korean, delete it and write th
 sentence a Korean product would have written first.
 
 And the prose itself, Korean or English, must not read machine-made. The tells, from
-the im-not-ai taxonomy — avoid all of them:
+the im-not-ai taxonomy and the kill-ai-slop catalogue (github.com/yetone/kill-ai-slop,
+MIT) — avoid all of them:
 - mechanical enumeration (첫째/둘째/셋째, "Firstly/Secondly")
 - AI stock phrases: 결론적으로, 시사하는 바가 크다, 주목할 만하다, "in conclusion",
-  "it's worth noting", "delve into"
+  "it's worth noting", "delve into", "say goodbye to", "blazing fast", "it's not just X
+  — it's Y" (the antithesis formula every generated page reaches for)
 - translation-ese: ~를 통해, ~에 대해 살펴보다, double passives, 그/그녀
 - uniform sentence rhythm — vary length; a four-word sentence after two long ones
 - hedging stacks (~할 수 있을 것으로 보인다), redundant intensifiers (매우, 정말, truly)
 - connective abuse: consecutive sentences opening with 또한/따라서/즉/Also/Moreover
-- decoration: bold everywhere, em-dash chains, emoji in headings
+- decoration: bold everywhere, em-dash chains, emoji in headings or CTAs
+
+## Visual tells to avoid (kill-ai-slop catalogue)
+
+The copy tells above have visual counterparts. `omd check` catches the measurable ones
+(SLOP-GRADIENT, SLOP-TRIPLE-CARD, SLOP-SHADOW-MONOCULTURE, etc.); the following require
+judgment before the page ships:
+
+**Typography tells** — avoid:
+- A serif-italic word mid-headline for cheap editorial drama ("The *fastest* way to…").
+  Emphasise with weight, position, or a line break — not a typeface swap mid-sentence.
+- A display serif (Playfair Display, Lora, Cormorant) on a developer tool or technical
+  product. The form says "trust and heritage"; a terminal does not need heritage.
+- Decorative strikethroughs, swipe-highlighters, or underline-as-ornament on body copy.
+  Reserve each for its semantic job: strikethrough = deleted, underline = link.
+- A reflexive uppercase kicker above every heading ("FEATURES", "HOW IT WORKS",
+  "WHY US"). If the kicker restates the heading, delete it. Use one kicker per page
+  maximum, and only when the kicker genuinely disambiguates the heading.
+- A complete marketing sentence set at hero scale (text-6xl across 3–4 lines). The
+  headline should be a claim, not a paragraph. Compress to the key idea in a few words.
+
+**Component tells** — avoid:
+- Rounded left-border callouts (border-l-4 rounded-lg bg-*-50) on every list item.
+  Let a list be a list. Reserve callout styling for genuinely scarce, high-priority
+  information — one or two per page, never the default list treatment.
+- Every icon sitting on a 10%-opacity wash of its own hue (bg-blue-500/10 behind a
+  blue icon). Icons should inherit text color or sit on a defined opaque surface.
+- A warm amber/stone/orange palette deployed as a lazy shortcut for "friendly." Warm
+  colour is a valid choice when the domain earns it (food, education, craft); it is
+  a default when it is chosen because it feels "cozy" with no domain reason.
+- Stock semantic color pairs: blue-50/blue-600 for info, amber-50/amber-600 for warning,
+  green-50/green-600 for success, all used together. Derive semantic colors from the
+  brand palette — most states need no background color at all.
+- AI-drawn SVG mascots (blob shapes, dot eyes, primitive geometry) shipped as the
+  product's logo or illustration system. Commission or generate refined icons.
+
+**Interaction tells** — avoid:
+- `transition-all` on anything. Name the properties you are transitioning: `color`,
+  `background-color`, `transform`, `opacity`. `transition-all` means you did not decide.
+- `hover:scale-105` or `hover:-translate-y-2` on cards, icon tiles, and navigation items
+  uniformly. Reserve spring-like hover responses for one deliberate primary interaction
+  (the main CTA, a carousel card). Uniform bounce reads as a screen saver, not a product.
 
 Four additional tells that are deterministically AI-flavoured in Korean copy — `omd check`
 flags the first two; the second two are yours to police before the page ships:

--- a/core/composition/editorial-index-labels.md
+++ b/core/composition/editorial-index-labels.md
@@ -30,6 +30,16 @@ implies the user should attend to them in order; if they should not, the numberi
 decoration at display scale is noise." Also: navigation lists, card grids, or any context
 where the user is scanning rather than reading in order.
 
+This specific tell — large low-opacity ordinals on unordered sections — is catalogued in
+kill-ai-slop (github.com/yetone/kill-ai-slop, MIT, tell #28) as a signature of generated
+pages. The detection is: "text-8xl text-gray-100 section number" — giant faint numerals
+that imply sequence where none exists. The counter-condition is this recipe: ordinals on
+sections whose content has a genuine sequence (methodology phases, walkthrough steps,
+ordered chapters). When the label earns its place the ordinal confirms what the user
+already suspects; when it does not, it is decoration at display scale and should be removed.
+The SLOP-TRIPLE-CARD rule fires on the underlying grid structure that often accompanies
+unearned numbering; adding ordinals to a triple-card grid resolves neither finding.
+
 ## Parameters
 
 ```css

--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -219,6 +219,16 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
       // instead of parsing two notations, and so the IR stays byte-stable across engines.
       node.gradient = cs.backgroundImage.replace(/rgba?\([^)]+\)/g, (m) => toHex(m) ?? m);
     }
+    // background-clip: text is the gradient-text tell. The browser may prefix this as
+    // -webkit-background-clip in some engines; check both. Only set when a gradient is also
+    // present — a clipped solid colour is a different pattern entirely.
+    const bgClip = cs.backgroundClip || (cs as unknown as Record<string, string>)['webkitBackgroundClip'];
+    if (node.gradient && (bgClip === 'text' || bgClip === '-webkit-text')) node.clipText = true;
+
+    // backdrop-filter is the glassmorphism tell: blur + translucent surface. The browser
+    // may prefix this as -webkit-backdrop-filter. Absent when 'none' or not declared.
+    const bf = cs.backdropFilter || (cs as unknown as Record<string, string>)['webkitBackdropFilter'];
+    if (bf && bf !== 'none') node.backdropFilter = bf;
     if (cs.textAlign === 'left' || cs.textAlign === 'center' || cs.textAlign === 'right' || cs.textAlign === 'justify') {
       node.textAlign = cs.textAlign;
     }

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -2,6 +2,15 @@
 # produced from pattern alone, without the position of an author who built the thing and
 # speaks the language. Two families live here:
 #
+# External source: 32 design and copy tells catalogued in kill-ai-slop by Yetone et al.
+# (github.com/yetone/kill-ai-slop, MIT licence). The triage table — which tells became
+# deterministic rules here, which were absorbed into existing rules, and which went to the
+# prompt layer — lives in the commit that introduced this comment. The detection playbook
+# at skill/references/detection.md informed every pattern choice; the taxonomy.md taxonomy
+# informed the grouping and the rejection reasons.
+#
+# Rule origins from that catalogue are cited inline as "kill-ai-slop #N".
+#
 # 1. Visual convergence-to-the-mean — the gradient band, the identical radius, the triple
 #    card grid. Correct, competent, indistinguishable from ten thousand others. That is the
 #    failure this tool was first built for.
@@ -62,14 +71,18 @@
   assert: "value < 60"
   message: "{value}% of text blocks are centred. Centring is emphasis, not a default. Emphasise everything and you emphasise nothing — and only a left-aligned paragraph gives the eye somewhere to return to on each line."
 
+# kill-ai-slop #15: widened from headings-only to also cover interactive nodes (buttons,
+# links). A CTA that opens with 🚀 borrows excitement it has not earned as much as a heading
+# that does. The check fires only on the starting emoji — a functional arrow or chevron
+# (Unicode Arrows block U+2190–U+21FF) is NOT in either emoji range and does not fire.
 - id: SLOP-EMOJI-HEADING
   layer: 1
   category: slop
   severity: warn
-  when: "Boolean(node.heading) && Boolean(node.text)"
+  when: "(Boolean(node.heading) || Boolean(node.interactive)) && Boolean(node.text)"
   value: "node.text"
   assert: "!/^\\s*[\\u{1F300}-\\u{1FAFF}\\u{2600}-\\u{27BF}]/u.test(value)"
-  message: "Heading opens with an emoji: {value}. An emoji cannot create hierarchy. If it is doing a job your typography failed to do, fix the typography."
+  message: "Heading or button opens with an emoji: {value}. An emoji borrows emotional charge it has not earned. If it is doing a job your typography or copy failed to do, fix those instead."
 
 - id: SLOP-COPY
   layer: 1
@@ -85,7 +98,11 @@
   # and the unanchored `이 (?:페이지|사이트|글)(?:에서)?는 .*(?:없습니다|않습니다)` (its greedy `.*`
   # swallowed ordinary 404s, empty states, and privacy copy). F3: moved the narrow Korean
   # self-negating pattern `이런 내용은 없` to SLOP-PINK-ELEPHANT, which covers the full family.
-  assert: "!/\\b(seamlessly|effortlessly|unlock the power|elevate your|supercharge|game.?chang|take .* to the next level|revolutioniz|cutting.?edge|unleash|no (?:fluff|jargon|nonsense) here)\\b|결론적으로|시사하는 바가 크|주목할 만하|첫째[,，]/i.test(value)"
+  # F2 widening (kill-ai-slop #14): added three phrases with near-zero false-positive risk.
+  # "say goodbye to" — textbook AI marketing opener; never appears in honest product copy.
+  # "it['’]s not just.*it['’]s" — the classic AI antithesis formula "It's not just X — it's Y".
+  # "blazing.?fast" — stock performance adjective; real benchmarks use numbers.
+  assert: "!/\\b(seamlessly|effortlessly|unlock the power|elevate your|supercharge|game.?chang|take .* to the next level|revolutioniz|cutting.?edge|unleash|no (?:fluff|jargon|nonsense) here|say goodbye to|blazing.?fast)\\b|it[\\u2019']s not just|결론적으로|시사하는 바가 크|주목할 만하|첫째[,，]/i.test(value)"
   message: "Marketing filler or AI stock phrase: \"{value}\". It fits any product and says nothing about this one. Write what this product specifically gives, costs, or does."
 
 # The pink-elephant failure: a page told "no clutter" that writes "No clutter here."
@@ -219,3 +236,164 @@
   value: "node.text"
   assert: "!/아래는\\s+.{0,30}(?:기록|내용|목록|정리)|다음은\\s+.{0,30}(?:입니다|이에요)/u.test(value)"
   message: "Document-structure narration copy: \"{value}\". '아래는 … 기록/내용/목록' and '다음은 … 입니다/이에요' introduce the document's structure in essay cadence. On a product page, write what the product does — not that we will now look at what the product does. Delete the announcing sentence and replace it with the specific fact or action it was narrating."
+
+# ── kill-ai-slop integration (github.com/yetone/kill-ai-slop, MIT) ─────────────────────
+#
+# The 32-tell catalogue was triaged into three buckets. Rules below are bucket (b): tells
+# where the IR carries the signal and a deterministic check is safe enough to ship.
+#
+# Bucket (a) — tells already covered by existing rules (no new rule needed):
+#   #1  indigo→violet gradient         → SLOP-GRADIENT
+#   #6  gradients as atmosphere         → SLOP-GRADIENT (violet-band glows)
+#   #14 AI copywriting voice            → SLOP-COPY (widened above)
+#   #15 emoji everywhere                → SLOP-EMOJI-HEADING (widened above)
+#   #18 rounded-square icon tile grids  → SLOP-TRIPLE-CARD
+#   #26 all-caps card grid              → SLOP-TRIPLE-CARD
+#   #31 Inter everywhere                → hand.agent.yaml prompt layer (font-by-omission)
+#
+# Bucket (c) — tells routed to the prompt layer (hand/eye agents, theory files):
+#   #3  warm cozy palette  (too many legitimate warm brands; reject on combinatorial risk)
+#   #4  default semantic palette        (intent-dependent; eye checklist)
+#   #5  one-hue status box              (complex; eye checklist)
+#   #7  serif-italic mid-headline       (no fontStyle in IR; hand.agent.yaml)
+#   #8  serif on dev tools              (context-dependent; hand.agent.yaml)
+#   #9  decorative strikes/highlights   (no text-decoration in IR; hand.agent.yaml)
+#   #10 kicker above every heading      (structural; eye checklist)
+#   #11 full-sentence display headline  (high false-positive risk; eye checklist)
+#   #13 highlighted keywords in copy    (inline styling; hand.agent.yaml)
+#   #16 glowing status dot              (animate-ping excluded from IR by design; eye)
+#   #17 rounded card left border        (no border props in IR; eye checklist)
+#   #23 AI-drawn SVG icons              (visual inspection only; eye checklist)
+#   #24 icon in tint of itself          (complex opacity analysis; eye checklist)
+#   #25 springy hover / transition-all  (transition-all excluded from IR by design)
+#   #28 01/02/03 section markers        (conflict with editorial-index recipe; resolved in
+#                                        editorial-index-labels.md — warnc + overrule)
+#   #32 tasteful terminal               (aesthetic judgment; eye checklist)
+
+# Gradient-clipped text: background-clip: text combined with a gradient. The effect
+# sacrifices legibility for an appearance that every generated landing page now shows.
+# The IR sets node.clipText when the browser reports background-clip:text (or the
+# -webkit- prefix) alongside a gradient on the same node.
+# kill-ai-slop #2 (gradient headline text).
+- id: SLOP-GRADIENT-TEXT
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.clipText)"
+  assert: "false"
+  message: "Gradient-clipped text on this node. background-clip:text renders text in a gradient, sacrificing legibility for an effect that every generated landing page now shares. Establish hierarchy through size, weight, and position; use a single legible text colour. Use omd decision to record a brand reason if this hue band is genuinely the brand's."
+
+# Invented stat row: round heroic numbers (10k+, 99.9%, 24/7) clustered on a page.
+# Real metrics are odd and specific — "847 teams migrated in Q1" carries more weight than
+# any 10× claim because nobody lies that specifically. The rule fires when two or more
+# text nodes each independently match an invented-stat pattern.
+# kill-ai-slop #27 (the invented stat row).
+- id: SLOP-FAKE-STAT
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.parent === null"
+  value: "(() => { const p = [/\\b\\d+[kK]\\+/, /\\b9[89](?:\\.\\d)?%/, /\\b24\\/7\\b/]; const hits = ir.nodes.filter(n => n.text && p.some(r => r.test(n.text))).map(n => n.text.slice(0, 40)); return hits.length >= 2 ? hits : null; })()"
+  assert: "value === null"
+  message: "Invented stat row: {value}. Round heroic numbers (10k+, 99.9%, 24/7) on a new product are decoration — the user has no reason to believe them. Write odd, specific, sourced numbers ('847 teams migrated in Q1') or nothing."
+
+# Oversized drop shadow: shadow blur ≥40px on a node whose smaller dimension is less than
+# or equal to the blur. A shadow that large maps to no real surface — it is fog. Elevation
+# shadows have blur proportional to their step: a card 2dp high gets ~4px, not 40px.
+# Parsed from the computed box-shadow string: browser returns offsets in px order after
+# the colour (Chrome/Firefox: "rgba(…) Xpx Ypx BLURpx SPREADpx").
+# kill-ai-slop #20 (the oversized drop shadow).
+- id: SLOP-OVERSIZED-SHADOW
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.shadow) && node.shadow.value !== 'none'"
+  value: "(() => { const nums = (node.shadow.value.match(/-?\\d+(?:\\.\\d+)?(?=px)/g) || []).map(Number); const blur = nums[2] ?? 0; const smaller = Math.min(node.box.w, node.box.h); return blur >= 40 && smaller > 0 && blur >= smaller ? { blur, size: smaller } : null; })()"
+  assert: "value === null"
+  message: "Oversized shadow: {value}. A blur radius ≥40px on an element this small is fog, not elevation. Shadow blur should stay below half the element's smaller dimension. Use a tight elevation scale: 0/2/4/8/16px blur where each step is a real layer."
+
+# Card inside a card: a surfaced node (radius + shadow) whose nearest ancestor is also
+# surfaced. Every nested container adds material depth without information. The fix is
+# one surface per region; group related content with spacing and hairline dividers.
+# kill-ai-slop #29 (cards inside cards).
+- id: SLOP-NESTED-CARDS
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.radius) && Boolean(node.shadow)"
+  value: "(() => { let p = node.parent; while (p) { const par = ir.nodes.find(n => n.id === p); if (!par) break; if (par.radius && par.shadow) return true; p = par.parent; } return false; })()"
+  assert: "value !== true"
+  message: "Card nested inside a card: a surfaced node (radius + shadow) sits inside another surfaced ancestor. Every nested container adds material depth without information. Use one surface per region; group related content with spacing and hairline dividers instead."
+
+# Non-concentric corners: child radius ≥ parent radius when the child is inset by padding.
+# The rule is inner = outer − padding. When inner ≥ outer, the corners do not nest
+# optically — they arc at the same rate and the containment looks wrong. A card with
+# 16px radius and 16px padding should hold children with radius 0 to ~12px, not 16px+.
+# Only fires when parent radius > 4px (not micro-radii) and parent has non-zero padding
+# (confirming the child is genuinely inset, not floating adjacent to the parent).
+# kill-ai-slop #21 (corners that don't nest).
+- id: SLOP-NESTED-RADIUS
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.radius) && Boolean(node.parent)"
+  value: "(() => { const par = ir.nodes.find(n => n.id === node.parent); if (!par?.radius) return null; const outer = typeof par.radius.value === 'number' ? par.radius.value : 0; const inner = typeof node.radius.value === 'number' ? node.radius.value : 0; const pads = par.layout?.padding ? par.layout.padding.filter(v => v > 0) : []; const minPad = pads.length > 0 ? Math.min(...pads) : 0; return outer > 4 && inner >= outer && minPad > 0 ? { outer, inner, padding: minPad } : null; })()"
+  assert: "value === null"
+  message: "Non-concentric corners: {value}. When a child is inset by padding, its radius should be outer minus padding. Inner radius ≥ outer: the surfaces do not nest — the inner element appears to float rather than sit inside. Correct inner radius = outer − min(padding)."
+
+# Spacing monoculture: one spacing value dominates ≥80% of all padding and gap on the
+# page. When proximity carries no information, nothing is grouped — the layout is a grid
+# of equidistant objects. Fires on pages with ≥20 non-zero spacing samples.
+# Zero is excluded: on a real page it represents ~80% of all values and is not a decision.
+# kill-ai-slop #30 (one gap everywhere).
+- id: SLOP-MONO-SPACING
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.parent === null"
+  value: "(() => { const h = ir.stats.spacingHistogram; const entries = Object.entries(h).filter(([k]) => Number(k) !== 0); const total = entries.reduce((s, [,n]) => s + n, 0); if (total < 20) return null; const top = entries.sort((a, b) => b[1] - a[1])[0]; if (!top) return null; const pct = Math.round(top[1] / total * 100); return pct >= 80 ? { value: top[0], pct } : null; })()"
+  assert: "value === null"
+  message: "Spacing monoculture: {value}. One spacing value accounts for 80%+ of all padding and gap. When proximity carries no information, nothing is grouped. Use a scale with at least three non-zero distinct steps (e.g. 8/16/32/64px) applied asymmetrically — tight within groups, generous between."
+
+# Glassmorphism monoculture: three or more nodes use backdrop-filter: blur, the frozen
+# 2021 Dribbble aesthetic. A single frosted-glass surface can be a deliberate choice;
+# applying it to every card is a pattern inherited from training data.
+# The IR captures node.backdropFilter when the computed backdrop-filter is not 'none'.
+# kill-ai-slop #19 (max radius + glassmorphism).
+- id: SLOP-GLASSMORPHISM
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.parent === null"
+  value: "ir.nodes.filter(n => n.backdropFilter && /blur/.test(n.backdropFilter)).length"
+  assert: "value < 3"
+  message: "{value} nodes use backdrop-filter:blur (glassmorphism). A single frosted-glass surface is a deliberate choice; {value} of them is a pattern from 2021 Dribbble. Replace repeated blur surfaces with opaque ones — one material, defined. Use omd decision to record why multiple blur surfaces are required."
+
+# Manufactured status badges: small text nodes whose entire content is a badge-like term
+# (New / Beta / Hot / Popular / Trending / Soon / Pro) with optional leading emoji.
+# Real badges carry time-bounded or count-backed information; decoration badges erode
+# trust by the third one. Gated to short text (≤30 chars) on small nodes (height ≤36px).
+# kill-ai-slop #22 (badge and pill spam).
+- id: SLOP-BADGE-SPAM
+  layer: 1
+  category: slop
+  severity: warn
+  when: "Boolean(node.text) && node.text.length <= 30 && node.box.h <= 36"
+  value: "node.text"
+  assert: "!/^[\\s\\u{1F300}-\\u{1FAFF}\\u{2600}-\\u{27BF}]*\\b(?:new|beta|hot|popular|trending|pro|soon)\\b[\\s!]*$/iu.test(value)"
+  message: "Manufactured badge: \"{value}\". New / Beta / Hot / Popular tags manufacture buzz. Use badge treatments only for genuine, time-bounded status: a feature launched this week, an actual version number, a real availability flag. Decoration badges erode trust by the third one."
+
+# Flat type hierarchy: when three or more distinct font sizes cluster between 13–19px, or
+# adjacent steps differ by less than 1.15×, size stops carrying hierarchy. The eye cannot
+# rank headings from body copy when the sizes are too close to distinguish.
+# Fires at the page level; requires ≥3 distinct sizes (a two-size page may be intentionally
+# minimal). A scale of 14/18/24px or 12/16/28px passes; 13/14/15/17px fails.
+# kill-ai-slop #12 (the flat type hierarchy).
+- id: SLOP-FLAT-TYPE
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.parent === null"
+  value: "(() => { const sizes = [...new Set(ir.nodes.filter(n => n.fontSize && n.fontSize > 0).map(n => n.fontSize))].sort((a, b) => a - b); if (sizes.length < 3) return null; const allFlat = sizes.every(s => s >= 13 && s <= 19); const ratios = sizes.slice(1).map((s, i) => s / sizes[i]); const minR = ratios.reduce((a, b) => Math.min(a, b), 99); const flatCount = ratios.filter(r => r < 1.15).length; return (allFlat || flatCount >= 2) ? { sizes, minRatio: Math.round(minR * 100) / 100 } : null; })()"
+  assert: "value === null"
+  message: "Flat type hierarchy: {value}. Font sizes all cluster between 13–19px or adjacent steps differ by less than 1.15×. Size stops carrying hierarchy. Establish at least three steps at 1.25× minimum (e.g. 14/18/24px). Use weight — not colour shade — to differentiate content at the same size."

--- a/core/types.ts
+++ b/core/types.ts
@@ -76,6 +76,20 @@ export interface RawNode {
    */
   overflow?: string;
 
+  /**
+   * Set when background-clip: text is combined with a gradient on this node — the
+   * gradient-text tell: a gradient clipped to the text shape, sacrificing legibility
+   * for an effect that every generated landing page now shows.
+   */
+  clipText?: boolean;
+
+  /**
+   * Computed backdrop-filter value. Absent when 'none' or not declared.
+   * Captured to detect glassmorphism: backdrop-blur combined with a translucent surface,
+   * the frozen 2021 Dribbble aesthetic that became the new default.
+   */
+  backdropFilter?: string;
+
   /** Set on any node with a non-zero transition-duration or a named animation. */
   motion?: {
     /** ms, rounded. Transition AND animation durations both land here; zero-length transitions are dropped. */

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -52,6 +52,53 @@ instructions: |
     `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,motion,components,craft,expressive}.md`.
     Theory citations are evidence. Taste is not.
 
+  ## Kill-ai-slop visual checklist (kill-ai-slop catalogue, MIT)
+
+  After running `omd check`, scan the render for the following tells that the linter
+  cannot measure. Each is a finding only when it is present without a visible reason — a
+  deliberate choice is fine; the default is not. Source for each tell in parentheses.
+
+  **Typography** (tells #7, #8, #10, #11):
+  - A serif-italic word inside an otherwise sans headline for cheap editorial drama. The
+    counter-condition: a concept committed to mixed typographic texture with a written reason.
+  - A display serif on a technical or developer-tool UI. The counter-condition: a brand
+    identity that deliberately claims heritage.
+  - A small uppercase kicker (FEATURES / HOW IT WORKS / WHY US) above every heading. Flag
+    when the kicker restates the heading verbatim. One kicker per page as an editorial device
+    is fine; reflexive kickers on every section are not.
+  - A full marketing sentence set at hero scale (five or more words across multiple lines
+    at display size). The hero claim should be a few words, not a paragraph.
+
+  **Copy and content** (#13):
+  - Multiple bold or coloured inline spans per sentence ("**Effortless** setup, **blazing**
+    performance, **zero** config"). When everything is emphasised, nothing is.
+
+  **Components** (#4, #5, #16, #17, #24):
+  - Stock semantic color boxes used together: blue-50/blue-600 for info, amber/amber for
+    warning, green/green for success. A product palette should grow semantic colours from
+    the brand; most states need no background colour.
+  - A single-hue status indicator where border, text, and background are all the same hue
+    at three opacities. State should be communicated by words and weight first.
+  - A pulsing animated status dot (animate-ping) with no real application state behind it.
+    A real status dot shows an actual system state; decoration dots are always off.
+  - Rounded left-border callouts (colored border-l-4 card) used as the default list item
+    treatment. If every list item is a callout, none of them is.
+  - Every icon sitting on a 10%-opacity wash of its own hue. Icons should inherit text
+    colour or sit on a defined opaque surface.
+
+  **Layout** (#28, #32):
+  - Large low-opacity ordinals (01/02/03 at text-8xl, ~10% opacity) on sections that have
+    no genuine sequence. The counter-condition is documented in
+    `core/composition/editorial-index-labels.md`: numbering earns its place only when the
+    content has a sequential order the user will perceive. Numbered feature sections where
+    the features can be read in any order are the tell. Name the specific sections and
+    whether their order is genuinely sequential.
+  - The tasteful terminal aesthetic: monospace typeface, near-black background, one warm
+    accent, possible ASCII art. Ask: is this a terminal/developer product (correct
+    register) or a marketing site that borrowed the aesthetic because it reads as
+    "designed"? A non-terminal product using terminal chrome without a stated reason is
+    the tell.
+
   ## Korean copy critique
 
   When the page contains Korean copy, run two additional checks as part of the critique

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -151,15 +151,58 @@ instructions: |
   sentence a Korean product would have written first.
 
   And the prose itself, Korean or English, must not read machine-made. The tells, from
-  the im-not-ai taxonomy — avoid all of them:
+  the im-not-ai taxonomy and the kill-ai-slop catalogue (github.com/yetone/kill-ai-slop,
+  MIT) — avoid all of them:
   - mechanical enumeration (첫째/둘째/셋째, "Firstly/Secondly")
   - AI stock phrases: 결론적으로, 시사하는 바가 크다, 주목할 만하다, "in conclusion",
-    "it's worth noting", "delve into"
+    "it's worth noting", "delve into", "say goodbye to", "blazing fast", "it's not just X
+    — it's Y" (the antithesis formula every generated page reaches for)
   - translation-ese: ~를 통해, ~에 대해 살펴보다, double passives, 그/그녀
   - uniform sentence rhythm — vary length; a four-word sentence after two long ones
   - hedging stacks (~할 수 있을 것으로 보인다), redundant intensifiers (매우, 정말, truly)
   - connective abuse: consecutive sentences opening with 또한/따라서/즉/Also/Moreover
-  - decoration: bold everywhere, em-dash chains, emoji in headings
+  - decoration: bold everywhere, em-dash chains, emoji in headings or CTAs
+
+  ## Visual tells to avoid (kill-ai-slop catalogue)
+
+  The copy tells above have visual counterparts. `omd check` catches the measurable ones
+  (SLOP-GRADIENT, SLOP-TRIPLE-CARD, SLOP-SHADOW-MONOCULTURE, etc.); the following require
+  judgment before the page ships:
+
+  **Typography tells** — avoid:
+  - A serif-italic word mid-headline for cheap editorial drama ("The *fastest* way to…").
+    Emphasise with weight, position, or a line break — not a typeface swap mid-sentence.
+  - A display serif (Playfair Display, Lora, Cormorant) on a developer tool or technical
+    product. The form says "trust and heritage"; a terminal does not need heritage.
+  - Decorative strikethroughs, swipe-highlighters, or underline-as-ornament on body copy.
+    Reserve each for its semantic job: strikethrough = deleted, underline = link.
+  - A reflexive uppercase kicker above every heading ("FEATURES", "HOW IT WORKS",
+    "WHY US"). If the kicker restates the heading, delete it. Use one kicker per page
+    maximum, and only when the kicker genuinely disambiguates the heading.
+  - A complete marketing sentence set at hero scale (text-6xl across 3–4 lines). The
+    headline should be a claim, not a paragraph. Compress to the key idea in a few words.
+
+  **Component tells** — avoid:
+  - Rounded left-border callouts (border-l-4 rounded-lg bg-*-50) on every list item.
+    Let a list be a list. Reserve callout styling for genuinely scarce, high-priority
+    information — one or two per page, never the default list treatment.
+  - Every icon sitting on a 10%-opacity wash of its own hue (bg-blue-500/10 behind a
+    blue icon). Icons should inherit text color or sit on a defined opaque surface.
+  - A warm amber/stone/orange palette deployed as a lazy shortcut for "friendly." Warm
+    colour is a valid choice when the domain earns it (food, education, craft); it is
+    a default when it is chosen because it feels "cozy" with no domain reason.
+  - Stock semantic color pairs: blue-50/blue-600 for info, amber-50/amber-600 for warning,
+    green-50/green-600 for success, all used together. Derive semantic colors from the
+    brand palette — most states need no background color at all.
+  - AI-drawn SVG mascots (blob shapes, dot eyes, primitive geometry) shipped as the
+    product's logo or illustration system. Commission or generate refined icons.
+
+  **Interaction tells** — avoid:
+  - `transition-all` on anything. Name the properties you are transitioning: `color`,
+    `background-color`, `transform`, `opacity`. `transition-all` means you did not decide.
+  - `hover:scale-105` or `hover:-translate-y-2` on cards, icon tiles, and navigation items
+    uniformly. Reserve spring-like hover responses for one deliberate primary interaction
+    (the main CTA, a carousel card). Uniform bounce reads as a screen saver, not a product.
 
   Four additional tells that are deterministically AI-flavoured in Korean copy — `omd check`
   flags the first two; the second two are yours to police before the page ships:

--- a/test/eye.test.ts
+++ b/test/eye.test.ts
@@ -76,6 +76,7 @@ test('slop.html fires every slop heuristic', () => {
       'SLOP-EMOJI-HEADING',
       'SLOP-EVERYTHING-CENTERED',
       'SLOP-GRADIENT',
+      'SLOP-NESTED-RADIUS',
       'SLOP-RADIUS-MONOCULTURE',
       'SLOP-SHADOW-MONOCULTURE',
       'SLOP-TRIPLE-CARD',

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -451,3 +451,433 @@ test('SLOP-KO-SIGNPOST does not fire on English-only copy', () => {
     assert.ok(!v.some((x) => x.id === 'SLOP-KO-SIGNPOST'), `unexpected SLOP-KO-SIGNPOST for: ${text}`);
   }
 });
+
+// ── kill-ai-slop integration tests ───────────────────────────────────────────
+
+// Helpers for structural slop tests
+function makeRootNode(overrides: Partial<RawNode> = {}): RawNode {
+  return {
+    id: 'root',
+    name: 'Root',
+    type: 'FRAME',
+    path: 'Root',
+    parent: null,
+    box: { x: 0, y: 0, w: 1280, h: 800 },
+    children: [],
+    ...overrides,
+  };
+}
+
+function makeChildNode(parentId: string, overrides: Partial<RawNode> = {}, idx = 0): RawNode {
+  return {
+    id: `child${idx}`,
+    name: `Child${idx}`,
+    type: 'FRAME',
+    path: `Root/Child${idx}`,
+    parent: parentId,
+    box: { x: 0, y: idx * 50, w: 200, h: 40 },
+    children: [],
+    ...overrides,
+  };
+}
+
+// ── SLOP-EMOJI-HEADING widened to interactive nodes ───────────────────────────
+
+test('SLOP-EMOJI-HEADING fires on interactive nodes (buttons) that open with an emoji', () => {
+  const node: RawNode = {
+    id: 'btn1', name: 'CTA', type: 'TEXT', path: 'Screen/CTA',
+    parent: null, box: { x: 0, y: 0, w: 160, h: 48 }, children: [],
+    text: '🚀 Get Started', interactive: true,
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-EMOJI-HEADING'), 'expected SLOP-EMOJI-HEADING on emoji-prefixed button');
+});
+
+test('SLOP-EMOJI-HEADING does not fire on a button with a plain arrow (not emoji)', () => {
+  const node: RawNode = {
+    id: 'btn2', name: 'CTA', type: 'TEXT', path: 'Screen/CTA',
+    parent: null, box: { x: 0, y: 0, w: 160, h: 48 }, children: [],
+    text: '→ View all', interactive: true,
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-EMOJI-HEADING'), 'unexpected SLOP-EMOJI-HEADING for arrow-prefixed button');
+});
+
+// ── SLOP-COPY widened phrases ─────────────────────────────────────────────────
+
+test('SLOP-COPY fires on new widened AI stock phrases', () => {
+  const positives = [
+    'Say goodbye to manual work.',
+    'Blazing fast performance for every team.',
+    "It's not just software, it's a platform.",
+  ];
+  for (const text of positives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-COPY'), `expected SLOP-COPY for: ${text}`);
+  }
+});
+
+test('SLOP-COPY does not fire on legitimate uses of similar words', () => {
+  const negatives = [
+    // "goodbye" in a natural sentence
+    'We said goodbye to our old architecture in 2023.',
+    // "fast" without "blazing"
+    'Renders in under 200ms on a fast connection.',
+  ];
+  for (const text of negatives) {
+    const v = check(makeTextIr(text), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-COPY'), `unexpected SLOP-COPY for: ${text}`);
+  }
+});
+
+// ── SLOP-GRADIENT-TEXT ────────────────────────────────────────────────────────
+
+test('SLOP-GRADIENT-TEXT fires when a node has clipText: true', () => {
+  const node: RawNode = {
+    id: 'heading1', name: 'Hero', type: 'TEXT', path: 'Screen/Hero',
+    parent: null, box: { x: 0, y: 0, w: 600, h: 80 }, children: [],
+    text: 'The future of design',
+    gradient: 'linear-gradient(135deg, #6366f1, #a855f7)',
+    clipText: true,
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-GRADIENT-TEXT'), 'expected SLOP-GRADIENT-TEXT for clipText node');
+});
+
+test('SLOP-GRADIENT-TEXT does not fire when clipText is absent', () => {
+  const node: RawNode = {
+    id: 'hero1', name: 'HeroBg', type: 'FRAME', path: 'Screen/HeroBg',
+    parent: null, box: { x: 0, y: 0, w: 600, h: 300 }, children: [],
+    gradient: 'linear-gradient(135deg, #6366f1, #a855f7)',
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-GRADIENT-TEXT'), 'unexpected SLOP-GRADIENT-TEXT without clipText');
+});
+
+// ── SLOP-FAKE-STAT ────────────────────────────────────────────────────────────
+
+test('SLOP-FAKE-STAT fires when two or more heroic stat patterns appear on the page', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n1', 'n2', 'n3'] }),
+    makeChildNode('root', { id: 'n1', type: 'TEXT', text: '10k+ users worldwide', box: { x: 0, y: 0, w: 200, h: 40 } }, 1),
+    makeChildNode('root', { id: 'n2', type: 'TEXT', text: '24/7 support included', box: { x: 200, y: 0, w: 200, h: 40 } }, 2),
+    makeChildNode('root', { id: 'n3', type: 'TEXT', text: 'Ships in 48h', box: { x: 400, y: 0, w: 200, h: 40 } }, 3),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-FAKE-STAT'), 'expected SLOP-FAKE-STAT for two+ stat patterns');
+});
+
+test('SLOP-FAKE-STAT does not fire when only one stat pattern is present', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n1'] }),
+    makeChildNode('root', { id: 'n1', type: 'TEXT', text: '99.9% uptime SLA', box: { x: 0, y: 0, w: 200, h: 40 } }, 1),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-FAKE-STAT'), 'unexpected SLOP-FAKE-STAT for single stat');
+});
+
+test('SLOP-FAKE-STAT does not fire on ordinary numeric copy', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n1', 'n2'] }),
+    makeChildNode('root', { id: 'n1', type: 'TEXT', text: '847 teams migrated in Q1', box: { x: 0, y: 0, w: 300, h: 40 } }, 1),
+    makeChildNode('root', { id: 'n2', type: 'TEXT', text: 'Released January 12, 2025', box: { x: 0, y: 50, w: 300, h: 40 } }, 2),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-FAKE-STAT'), 'unexpected SLOP-FAKE-STAT for ordinary numbers');
+});
+
+// ── SLOP-OVERSIZED-SHADOW ─────────────────────────────────────────────────────
+
+test('SLOP-OVERSIZED-SHADOW fires when shadow blur ≥40px on a small node', () => {
+  // 30×30 icon with 60px blur — blur > element size
+  const node: RawNode = {
+    id: 'icon1', name: 'Icon', type: 'FRAME', path: 'Screen/Icon',
+    parent: null, box: { x: 0, y: 0, w: 30, h: 30 }, children: [],
+    shadow: { value: 'rgba(0, 0, 0, 0.2) 0px 0px 60px 0px', token: null },
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-OVERSIZED-SHADOW'), 'expected SLOP-OVERSIZED-SHADOW for huge blur on small node');
+});
+
+test('SLOP-OVERSIZED-SHADOW does not fire when blur is proportional to element size', () => {
+  // 300×200 card with 8px blur — proportionate
+  const node: RawNode = {
+    id: 'card1', name: 'Card', type: 'FRAME', path: 'Screen/Card',
+    parent: null, box: { x: 0, y: 0, w: 300, h: 200 }, children: [],
+    shadow: { value: 'rgba(0, 0, 0, 0.1) 0px 4px 8px 0px', token: null },
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-OVERSIZED-SHADOW'), 'unexpected SLOP-OVERSIZED-SHADOW for proportionate shadow');
+});
+
+test('SLOP-OVERSIZED-SHADOW does not fire when blur is large but node is large', () => {
+  // 400×400 hero section with 40px blur — blur equals smaller dimension, but smaller is 400
+  const node: RawNode = {
+    id: 'hero1', name: 'Hero', type: 'FRAME', path: 'Screen/Hero',
+    parent: null, box: { x: 0, y: 0, w: 400, h: 400 }, children: [],
+    shadow: { value: 'rgba(0, 0, 0, 0.15) 0px 8px 40px 0px', token: null },
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-OVERSIZED-SHADOW'), 'unexpected SLOP-OVERSIZED-SHADOW when blur < smaller dimension');
+});
+
+// ── SLOP-NESTED-CARDS ─────────────────────────────────────────────────────────
+
+test('SLOP-NESTED-CARDS fires when a surfaced node sits inside another surfaced node', () => {
+  const outerCard: RawNode = {
+    id: 'outer', name: 'OuterCard', type: 'FRAME', path: 'Screen/OuterCard',
+    parent: null, box: { x: 0, y: 0, w: 320, h: 240 }, children: ['inner'],
+    radius: { value: 16, token: null },
+    shadow: { value: 'rgba(0, 0, 0, 0.1) 0px 4px 16px 0px', token: null },
+  };
+  const innerCard: RawNode = {
+    id: 'inner', name: 'InnerCard', type: 'FRAME', path: 'Screen/OuterCard/InnerCard',
+    parent: 'outer', box: { x: 16, y: 16, w: 288, h: 208 }, children: [],
+    radius: { value: 8, token: null },
+    shadow: { value: 'rgba(0, 0, 0, 0.05) 0px 2px 8px 0px', token: null },
+  };
+  const v = check(normalize({ nodes: [outerCard, innerCard] }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-NESTED-CARDS'), 'expected SLOP-NESTED-CARDS for surfaced node inside surfaced parent');
+});
+
+test('SLOP-NESTED-CARDS does not fire when the inner node has no shadow', () => {
+  const outerCard: RawNode = {
+    id: 'outer', name: 'Card', type: 'FRAME', path: 'Screen/Card',
+    parent: null, box: { x: 0, y: 0, w: 320, h: 240 }, children: ['inner'],
+    radius: { value: 16, token: null },
+    shadow: { value: 'rgba(0, 0, 0, 0.1) 0px 4px 16px 0px', token: null },
+  };
+  const innerContent: RawNode = {
+    id: 'inner', name: 'CardContent', type: 'FRAME', path: 'Screen/Card/CardContent',
+    parent: 'outer', box: { x: 16, y: 16, w: 288, h: 208 }, children: [],
+    radius: { value: 8, token: null },
+    // no shadow — not a surfaced card
+  };
+  const v = check(normalize({ nodes: [outerCard, innerContent] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-NESTED-CARDS'), 'unexpected SLOP-NESTED-CARDS when inner has no shadow');
+});
+
+// ── SLOP-NESTED-RADIUS ────────────────────────────────────────────────────────
+
+test('SLOP-NESTED-RADIUS fires when child radius ≥ parent radius and parent has padding', () => {
+  const parent: RawNode = {
+    id: 'card', name: 'Card', type: 'FRAME', path: 'Screen/Card',
+    parent: null, box: { x: 0, y: 0, w: 320, h: 200 }, children: ['inner'],
+    radius: { value: 16, token: null },
+    layout: { mode: 'VERTICAL', gap: 0, padding: [16, 16, 16, 16] },
+  };
+  const child: RawNode = {
+    id: 'inner', name: 'InnerButton', type: 'FRAME', path: 'Screen/Card/InnerButton',
+    parent: 'card', box: { x: 16, y: 16, w: 288, h: 48 }, children: [],
+    radius: { value: 16, token: null }, // same as parent — wrong
+  };
+  const v = check(normalize({ nodes: [parent, child] }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-NESTED-RADIUS'), 'expected SLOP-NESTED-RADIUS for same-radius child in padded parent');
+});
+
+test('SLOP-NESTED-RADIUS does not fire when child radius is smaller than parent', () => {
+  const parent: RawNode = {
+    id: 'card', name: 'Card', type: 'FRAME', path: 'Screen/Card',
+    parent: null, box: { x: 0, y: 0, w: 320, h: 200 }, children: ['inner'],
+    radius: { value: 16, token: null },
+    layout: { mode: 'VERTICAL', gap: 0, padding: [16, 16, 16, 16] },
+  };
+  const child: RawNode = {
+    id: 'inner', name: 'InnerButton', type: 'FRAME', path: 'Screen/Card/InnerButton',
+    parent: 'card', box: { x: 16, y: 16, w: 288, h: 48 }, children: [],
+    radius: { value: 6, token: null }, // smaller — correct
+  };
+  const v = check(normalize({ nodes: [parent, child] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-NESTED-RADIUS'), 'unexpected SLOP-NESTED-RADIUS when child radius is smaller');
+});
+
+test('SLOP-NESTED-RADIUS does not fire when parent has no padding', () => {
+  // A child positioned adjacent to (not inset in) its parent: padding=0 means no inset
+  const parent: RawNode = {
+    id: 'card', name: 'Card', type: 'FRAME', path: 'Screen/Card',
+    parent: null, box: { x: 0, y: 0, w: 320, h: 200 }, children: ['inner'],
+    radius: { value: 16, token: null },
+    // no layout/padding
+  };
+  const child: RawNode = {
+    id: 'inner', name: 'InnerElement', type: 'FRAME', path: 'Screen/Card/InnerElement',
+    parent: 'card', box: { x: 0, y: 0, w: 320, h: 200 }, children: [],
+    radius: { value: 16, token: null },
+  };
+  const v = check(normalize({ nodes: [parent, child] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-NESTED-RADIUS'), 'unexpected SLOP-NESTED-RADIUS when parent has no padding');
+});
+
+// ── SLOP-MONO-SPACING ─────────────────────────────────────────────────────────
+
+test('SLOP-MONO-SPACING fires when one spacing value dominates ≥80% of 20+ samples', () => {
+  // 6 nodes each with padding [16,16,16,16] = 24 samples at value 16 (100% domination)
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2', 'n3', 'n4', 'n5'] }),
+    ...[0, 1, 2, 3, 4, 5].map((i) => makeChildNode('root', {
+      id: `n${i}`,
+      layout: { mode: 'VERTICAL', gap: 0, padding: [16, 16, 16, 16] },
+    }, i)),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-MONO-SPACING'), 'expected SLOP-MONO-SPACING for 24-sample 16px monoculture');
+});
+
+test('SLOP-MONO-SPACING does not fire when spacing is varied', () => {
+  // Nodes with different padding values — no single value dominates
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2', 'n3', 'n4', 'n5'] }),
+    ...[
+      [8, 8, 8, 8],
+      [16, 16, 16, 16],
+      [24, 24, 24, 24],
+      [32, 32, 32, 32],
+      [8, 16, 8, 16],
+      [16, 32, 16, 32],
+    ].map((padding, i) => makeChildNode('root', {
+      id: `n${i}`,
+      layout: { mode: 'VERTICAL', gap: 0, padding: padding as [number, number, number, number] },
+    }, i)),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-MONO-SPACING'), 'unexpected SLOP-MONO-SPACING for varied spacing');
+});
+
+test('SLOP-MONO-SPACING does not fire on pages with fewer than 20 spacing samples', () => {
+  // Only 2 nodes with padding = 8 samples
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1'] }),
+    makeChildNode('root', { id: 'n0', layout: { mode: 'VERTICAL', gap: 0, padding: [16, 16, 16, 16] } }, 0),
+    makeChildNode('root', { id: 'n1', layout: { mode: 'VERTICAL', gap: 0, padding: [16, 16, 16, 16] } }, 1),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-MONO-SPACING'), 'unexpected SLOP-MONO-SPACING for <20 spacing samples');
+});
+
+// ── SLOP-GLASSMORPHISM ────────────────────────────────────────────────────────
+
+test('SLOP-GLASSMORPHISM fires when three or more nodes have backdrop-filter blur', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2'] }),
+    makeChildNode('root', { id: 'n0', backdropFilter: 'blur(20px)' }, 0),
+    makeChildNode('root', { id: 'n1', backdropFilter: 'blur(16px)' }, 1),
+    makeChildNode('root', { id: 'n2', backdropFilter: 'blur(12px)' }, 2),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-GLASSMORPHISM'), 'expected SLOP-GLASSMORPHISM for 3 blur nodes');
+});
+
+test('SLOP-GLASSMORPHISM does not fire for a single glassmorphism node', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0'] }),
+    makeChildNode('root', { id: 'n0', backdropFilter: 'blur(20px)' }, 0),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-GLASSMORPHISM'), 'unexpected SLOP-GLASSMORPHISM for single blur node');
+});
+
+test('SLOP-GLASSMORPHISM does not fire when backdropFilter is present but not blur', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2'] }),
+    makeChildNode('root', { id: 'n0', backdropFilter: 'brightness(0.8)' }, 0),
+    makeChildNode('root', { id: 'n1', backdropFilter: 'contrast(1.2)' }, 1),
+    makeChildNode('root', { id: 'n2', backdropFilter: 'saturate(1.5)' }, 2),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-GLASSMORPHISM'), 'unexpected SLOP-GLASSMORPHISM for non-blur backdropFilter');
+});
+
+// ── SLOP-BADGE-SPAM ───────────────────────────────────────────────────────────
+
+test('SLOP-BADGE-SPAM fires on small nodes whose text is solely a badge term', () => {
+  const badgeTexts = ['New', 'Beta', '🔥 Hot', 'Popular', 'trending', 'Pro', 'Soon'];
+  for (const text of badgeTexts) {
+    const node: RawNode = {
+      id: 'badge1', name: 'Badge', type: 'TEXT', path: 'Screen/Badge',
+      parent: null, box: { x: 0, y: 0, w: 60, h: 24 }, children: [], text,
+    };
+    const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+    assert.ok(v.some((x) => x.id === 'SLOP-BADGE-SPAM'), `expected SLOP-BADGE-SPAM for: ${text}`);
+  }
+});
+
+test('SLOP-BADGE-SPAM does not fire on regular navigation or content text', () => {
+  const negatives = [
+    // nav items that contain badge-like words but in context
+    'See what is new in v2.0',
+    'Professional plan includes all features',
+    'This is a beta test environment for internal use',
+    // short labels that are not manufactured buzz
+    'Save', 'Cancel', 'View all', '3 items',
+  ];
+  for (const text of negatives) {
+    const node: RawNode = {
+      id: 'label1', name: 'Label', type: 'TEXT', path: 'Screen/Label',
+      parent: null, box: { x: 0, y: 0, w: 200, h: 24 }, children: [], text,
+    };
+    const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+    assert.ok(!v.some((x) => x.id === 'SLOP-BADGE-SPAM'), `unexpected SLOP-BADGE-SPAM for: ${text}`);
+  }
+});
+
+test('SLOP-BADGE-SPAM does not fire on taller nodes (not badge-sized)', () => {
+  // A section heading that says "What is New" — tall enough that it is not a badge
+  const node: RawNode = {
+    id: 'h2', name: 'SectionHeading', type: 'TEXT', path: 'Screen/SectionHeading',
+    parent: null, box: { x: 0, y: 0, w: 400, h: 48 }, children: [],
+    text: 'New', heading: 2,
+  };
+  const v = check(normalize({ nodes: [node] }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-BADGE-SPAM'), 'unexpected SLOP-BADGE-SPAM on tall heading node');
+});
+
+// ── SLOP-FLAT-TYPE ────────────────────────────────────────────────────────────
+
+test('SLOP-FLAT-TYPE fires when three or more font sizes cluster in the 13–19px band', () => {
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2', 'n3'] }),
+    ...[13, 14, 16, 18].map((fs, i) => makeChildNode('root', {
+      id: `n${i}`, type: 'TEXT' as const,
+      text: `Text at ${fs}px`, fontSize: fs,
+    }, i)),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-FLAT-TYPE'), 'expected SLOP-FLAT-TYPE for 13/14/16/18px flat hierarchy');
+});
+
+test('SLOP-FLAT-TYPE fires when adjacent scale steps differ by less than 1.15×', () => {
+  // Sizes 20, 22, 24 — ratio ≈ 1.10, below the 1.15 threshold
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2'] }),
+    ...[20, 22, 24].map((fs, i) => makeChildNode('root', {
+      id: `n${i}`, type: 'TEXT' as const,
+      text: `Text at ${fs}px`, fontSize: fs,
+    }, i)),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(v.some((x) => x.id === 'SLOP-FLAT-TYPE'), 'expected SLOP-FLAT-TYPE for 20/22/24px flat scale');
+});
+
+test('SLOP-FLAT-TYPE does not fire when the type scale has good separation', () => {
+  // 14/18/28px — ratio 1.29 and 1.56, both above 1.15
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1', 'n2'] }),
+    ...[14, 18, 28].map((fs, i) => makeChildNode('root', {
+      id: `n${i}`, type: 'TEXT' as const,
+      text: `Text at ${fs}px`, fontSize: fs,
+    }, i)),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-FLAT-TYPE'), 'unexpected SLOP-FLAT-TYPE for 14/18/28px well-separated scale');
+});
+
+test('SLOP-FLAT-TYPE does not fire on pages with fewer than three distinct font sizes', () => {
+  // A page with only two text sizes — intentionally minimal, not a hierarchy failure
+  const nodes: RawNode[] = [
+    makeRootNode({ children: ['n0', 'n1'] }),
+    makeChildNode('root', { id: 'n0', type: 'TEXT', text: 'Heading', fontSize: 16 }, 0),
+    makeChildNode('root', { id: 'n1', type: 'TEXT', text: 'Body', fontSize: 14 }, 1),
+  ];
+  const v = check(normalize({ nodes }), builtin, { categories: ['slop'] });
+  assert.ok(!v.some((x) => x.id === 'SLOP-FLAT-TYPE'), 'unexpected SLOP-FLAT-TYPE for two-size page');
+});


### PR DESCRIPTION
Full triage of github.com/yetone/kill-ai-slop (MIT): widened rules, new deterministic rules (gradient-text, fake-stat-trio, oversized-shadow, nested-cards, nested-radius), prompt-layer additions, editorial-index conflict reconciled. 577→607 tests.