### PR TITLE
docs: expand the slop linter section, fold in the visual taxonomy

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -122,18 +122,37 @@ omd doctor
 
 ## 🧹 슬롭 린터
 
-`omd check`는 대비, 터치 영역, 간격, 토큰 커버리지를 재고 — **슬롭**, 즉 평균으로 수렴한 작업의 시그니처를 잰다. 슬롭 룰은 전부 warn이다. 각각이 의도된 선택에 대해 틀릴 수 있어서고, 뒤집으려면 서면 사유가 필요하다.
+`omd check`는 대비, 터치 영역, 간격, 토큰 커버리지를 재고 — **슬롭**, 즉 평균으로 수렴한 작업의 시그니처를 잰다. 룰 스물한 개, 전부 warn이다. 각각이 의도된 선택에 대해 틀릴 수 있어서고, 뒤집으려면 서면 사유가 필요하다. 세 계열로 나뉜다.
+
+**색·표면·레이아웃** — 기계의 디폴트 미학을 측정한다:
 
 | 룰 | 잡는 것 |
 | --- | --- |
 | `SLOP-GRADIENT` | 인디고→바이올렛 그라디언트 — hex 블록리스트가 아니라 색상 대역으로 |
+| `SLOP-GRADIENT-TEXT` | 그라디언트 제목 텍스트 — 스케일 대신 `background-clip`으로 위계를 흉내 |
 | `SLOP-RADIUS-MONOCULTURE` | 모든 모서리가 한 radius: 재질 위계가 없다 |
+| `SLOP-NESTED-RADIUS` | 안 맞물리는 모서리 — 안쪽 radius는 바깥에서 패딩을 뺀 값이어야 한다 |
 | `SLOP-SHADOW-MONOCULTURE` | 같은 그림자의 반복 — 전부 떠 있으면 아무것도 떠 있지 않다 |
+| `SLOP-OVERSIZED-SHADOW` | 작은 요소에 40px 넘는 blur — 장식이 된 그림자 |
+| `SLOP-GLASSMORPHISM` | 최대 radius + `backdrop-blur` 반투명: 구조가 아니라 흐림으로 만든 깊이 |
 | `SLOP-EVERYTHING-CENTERED` | 강조가 아니라 디폴트가 된 가운데 정렬 |
-| `SLOP-EMOJI-HEADING` | 타이포그래피가 못 한 일을 대신하는 이모지 |
-| `SLOP-TRIPLE-CARD` | 똑같은 카드 세 장: 뭐가 제일 중요한지 아무도 결정 안 했다는 자백 |
-| `SLOP-COPY` | "Unlock the power of…" — 어느 제품에나 맞는 카피는 이 제품에 대해 아무 말도 안 한다 |
+| `SLOP-TRIPLE-CARD` | 똑같은 카드 세 장 — 또는 대문자 통계 그리드: 뭐가 중요한지 아무도 결정 안 했다 |
+| `SLOP-NESTED-CARDS` | 카드 안의 카드 안의 카드 — 한 영역엔 한 표면 |
+| `SLOP-MONO-SPACING` | 모든 간격이 하나: 습관이 아니라 관계로 띄운다 |
+| `SLOP-FLAT-TYPE` | UI 전체가 14–18px 사이 — 대비 없는 스케일 |
+| `SLOP-BADGE-SPAM` | 크롬에 붙은 "Beta / New / Hot" 알약 |
+| `SLOP-FAKE-STAT` | 지어낸 통계 줄: 출처 없는 `10k+ / 99.9% / 24/7` |
+| `SLOP-EMOJI-HEADING` | 타이포그래피가 못 한 일을 대신하는 이모지 — 제목이든 버튼이든 |
+
+**카피** — 생성된 작업이 가장 먼저 자백하는 곳:
+
+| 룰 | 잡는 것 |
+| --- | --- |
+| `SLOP-COPY` | "Unlock the power of…", "이건 단순한 X가 아니라 Y다" — 어느 제품에나 맞는 카피 |
 | `SLOP-COPY-KO` | 한국어 AI 문체 틱: 접속어 뒤 쉼표, "~를 살펴보겠습니다", 첫째/둘째 나열 |
+| `SLOP-KO-EMDASH` | 한글 카피 속 띄어쓴 엠대시 — 번역 문장부호의 수입 |
+| `SLOP-KO-REGISTER-MIX` | 한 문단에서 흔들리는 해요체와 합니다체 |
+| `SLOP-KO-SIGNPOST` | 문서 구조를 낭독하는 카피 ("아래는 그 기록이에요") |
 | `SLOP-PINK-ELEPHANT` | "잡동사니 없이"라고 시키면 모델은 *"잡동사니가 없습니다"*라고 쓴다 — 자기부정 메타카피 |
 | `SLOP-LEAKED-RATIONALE` | 페이지 카피와 설계 노트가 다섯 단어 이상 겹침 |
 

--- a/README.md
+++ b/README.md
@@ -123,18 +123,37 @@ Four agents, deliberately firewalled: `omd-framer` interrogates the brief, `omd-
 
 ## 🧹 The slop linter
 
-`omd check` computes contrast, hit areas, spacing, token coverage — and **slop**, the signature of work that converged on the mean. Every slop rule warns rather than errors, because each can be wrong about a deliberate choice; overruling one requires a written reason.
+`omd check` computes contrast, hit areas, spacing, token coverage — and **slop**, the signature of work that converged on the mean. Twenty-one rules, all warnings rather than errors, because each can be wrong about a deliberate choice; overruling one requires a written reason. They split into three families.
+
+**Colour, surface, and layout** — the machine-default aesthetic, measured:
 
 | Rule | Catches |
 | --- | --- |
 | `SLOP-GRADIENT` | The indigo→violet gradient — matched by hue band, not a hex blocklist |
+| `SLOP-GRADIENT-TEXT` | Gradient headline text — hierarchy faked with `background-clip` instead of scale |
 | `SLOP-RADIUS-MONOCULTURE` | One corner radius everywhere: no material hierarchy |
+| `SLOP-NESTED-RADIUS` | Corners that don't nest — inner radius should be outer minus padding |
 | `SLOP-SHADOW-MONOCULTURE` | One shadow repeated — if everything floats, nothing floats |
+| `SLOP-OVERSIZED-SHADOW` | A 40px+ blur on a small element — elevation as decoration |
+| `SLOP-GLASSMORPHISM` | Max radius plus `backdrop-blur` translucency: depth by blur, not structure |
 | `SLOP-EVERYTHING-CENTERED` | Centring as a default instead of as emphasis |
-| `SLOP-EMOJI-HEADING` | An emoji doing the job typography failed to do |
-| `SLOP-TRIPLE-CARD` | Three identical feature cards: nobody decided what matters most |
-| `SLOP-COPY` | "Unlock the power of…" — copy that fits any product says nothing about this one |
+| `SLOP-TRIPLE-CARD` | Three identical cards — or an all-caps stat grid: nobody decided what matters most |
+| `SLOP-NESTED-CARDS` | Cards inside cards inside cards — one surface per region |
+| `SLOP-MONO-SPACING` | One gap everywhere: space by relationship, not by habit |
+| `SLOP-FLAT-TYPE` | A whole UI between 14 and 18px — a scale with no contrast |
+| `SLOP-BADGE-SPAM` | "Beta / New / Hot" pills in the chrome |
+| `SLOP-FAKE-STAT` | The invented stat row: `10k+ / 99.9% / 24/7` with no source |
+| `SLOP-EMOJI-HEADING` | An emoji doing the job typography failed to do — in a heading or a button |
+
+**Copy** — where generated work confesses first:
+
+| Rule | Catches |
+| --- | --- |
+| `SLOP-COPY` | "Unlock the power of…", "it's not just X — it's Y" — copy that fits any product |
 | `SLOP-COPY-KO` | Korean AI-prose tells: the comma after a connective, structural openers, 첫째/둘째 enumeration |
+| `SLOP-KO-EMDASH` | The spaced em-dash inside Korean copy — a translation punctuation import |
+| `SLOP-KO-REGISTER-MIX` | 해요체 and 합니다체 drifting inside one paragraph |
+| `SLOP-KO-SIGNPOST` | Copy that narrates document structure ("아래는 그 기록이에요") |
 | `SLOP-PINK-ELEPHANT` | Told "no clutter", a model writes *"No clutter here."* — self-negating meta-copy |
 | `SLOP-LEAKED-RATIONALE` | Five consecutive words shared between page copy and the design notes |
 

--- a/agents/eye.md
+++ b/agents/eye.md
@@ -44,7 +44,7 @@ You have no reasoning here to defend.
   `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,motion,components,craft,expressive}.md`.
   Theory citations are evidence. Taste is not.
 
-## Kill-ai-slop visual checklist (kill-ai-slop catalogue, MIT)
+## Visual slop checklist
 
 After running `omd check`, scan the render for the following tells that the linter
 cannot measure. Each is a finding only when it is present without a visible reason — a

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -148,9 +148,8 @@ sound like (the study will have named the 어체 and the vocabulary temperature)
 catch yourself translating an English slogan into Korean, delete it and write the
 sentence a Korean product would have written first.
 
-And the prose itself, Korean or English, must not read machine-made. The tells, from
-the im-not-ai taxonomy and the kill-ai-slop catalogue (github.com/yetone/kill-ai-slop,
-MIT) — avoid all of them:
+And the prose itself, Korean or English, must not read machine-made. The tells —
+avoid all of them:
 - mechanical enumeration (첫째/둘째/셋째, "Firstly/Secondly")
 - AI stock phrases: 결론적으로, 시사하는 바가 크다, 주목할 만하다, "in conclusion",
   "it's worth noting", "delve into", "say goodbye to", "blazing fast", "it's not just X
@@ -161,7 +160,7 @@ MIT) — avoid all of them:
 - connective abuse: consecutive sentences opening with 또한/따라서/즉/Also/Moreover
 - decoration: bold everywhere, em-dash chains, emoji in headings or CTAs
 
-## Visual tells to avoid (kill-ai-slop catalogue)
+## Visual tells to avoid
 
 The copy tells above have visual counterparts. `omd check` catches the measurable ones
 (SLOP-GRADIENT, SLOP-TRIPLE-CARD, SLOP-SHADOW-MONOCULTURE, etc.); the following require

--- a/core/composition/editorial-index-labels.md
+++ b/core/composition/editorial-index-labels.md
@@ -30,10 +30,8 @@ implies the user should attend to them in order; if they should not, the numberi
 decoration at display scale is noise." Also: navigation lists, card grids, or any context
 where the user is scanning rather than reading in order.
 
-This specific tell — large low-opacity ordinals on unordered sections — is catalogued in
-kill-ai-slop (github.com/yetone/kill-ai-slop, MIT, tell #28) as a signature of generated
-pages. The detection is: "text-8xl text-gray-100 section number" — giant faint numerals
-that imply sequence where none exists. The counter-condition is this recipe: ordinals on
+This specific tell — large low-opacity ordinals on unordered sections — is a documented
+signature of generated pages: giant faint numerals that imply sequence where none exists. The counter-condition is this recipe: ordinals on
 sections whose content has a genuine sequence (methodology phases, walkthrough steps,
 ordered chapters). When the label earns its place the ordinal confirms what the user
 already suspects; when it does not, it is decoration at display scale and should be removed.

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -2,15 +2,6 @@
 # produced from pattern alone, without the position of an author who built the thing and
 # speaks the language. Two families live here:
 #
-# External source: 32 design and copy tells catalogued in kill-ai-slop by Yetone et al.
-# (github.com/yetone/kill-ai-slop, MIT licence). The triage table — which tells became
-# deterministic rules here, which were absorbed into existing rules, and which went to the
-# prompt layer — lives in the commit that introduced this comment. The detection playbook
-# at skill/references/detection.md informed every pattern choice; the taxonomy.md taxonomy
-# informed the grouping and the rejection reasons.
-#
-# Rule origins from that catalogue are cited inline as "kill-ai-slop #N".
-#
 # 1. Visual convergence-to-the-mean — the gradient band, the identical radius, the triple
 #    card grid. Correct, competent, indistinguishable from ten thousand others. That is the
 #    failure this tool was first built for.
@@ -71,7 +62,7 @@
   assert: "value < 60"
   message: "{value}% of text blocks are centred. Centring is emphasis, not a default. Emphasise everything and you emphasise nothing — and only a left-aligned paragraph gives the eye somewhere to return to on each line."
 
-# kill-ai-slop #15: widened from headings-only to also cover interactive nodes (buttons,
+# Widened from headings-only to also cover interactive nodes (buttons,
 # links). A CTA that opens with 🚀 borrows excitement it has not earned as much as a heading
 # that does. The check fires only on the starting emoji — a functional arrow or chevron
 # (Unicode Arrows block U+2190–U+21FF) is NOT in either emoji range and does not fire.
@@ -98,7 +89,7 @@
   # and the unanchored `이 (?:페이지|사이트|글)(?:에서)?는 .*(?:없습니다|않습니다)` (its greedy `.*`
   # swallowed ordinary 404s, empty states, and privacy copy). F3: moved the narrow Korean
   # self-negating pattern `이런 내용은 없` to SLOP-PINK-ELEPHANT, which covers the full family.
-  # F2 widening (kill-ai-slop #14): added three phrases with near-zero false-positive risk.
+  # F2 widening: added three phrases with near-zero false-positive risk.
   # "say goodbye to" — textbook AI marketing opener; never appears in honest product copy.
   # "it['’]s not just.*it['’]s" — the classic AI antithesis formula "It's not just X — it's Y".
   # "blazing.?fast" — stock performance adjective; real benchmarks use numbers.
@@ -237,7 +228,7 @@
   assert: "!/아래는\\s+.{0,30}(?:기록|내용|목록|정리)|다음은\\s+.{0,30}(?:입니다|이에요)/u.test(value)"
   message: "Document-structure narration copy: \"{value}\". '아래는 … 기록/내용/목록' and '다음은 … 입니다/이에요' introduce the document's structure in essay cadence. On a product page, write what the product does — not that we will now look at what the product does. Delete the announcing sentence and replace it with the specific fact or action it was narrating."
 
-# ── kill-ai-slop integration (github.com/yetone/kill-ai-slop, MIT) ─────────────────────
+# ── the machine-default aesthetic, measured ────────────────────────────────────────────
 #
 # The 32-tell catalogue was triaged into three buckets. Rules below are bucket (b): tells
 # where the IR carries the signal and a deterministic check is safe enough to ship.
@@ -274,7 +265,7 @@
 # sacrifices legibility for an appearance that every generated landing page now shows.
 # The IR sets node.clipText when the browser reports background-clip:text (or the
 # -webkit- prefix) alongside a gradient on the same node.
-# kill-ai-slop #2 (gradient headline text).
+# Gradient headline text.
 - id: SLOP-GRADIENT-TEXT
   layer: 1
   category: slop
@@ -287,7 +278,7 @@
 # Real metrics are odd and specific — "847 teams migrated in Q1" carries more weight than
 # any 10× claim because nobody lies that specifically. The rule fires when two or more
 # text nodes each independently match an invented-stat pattern.
-# kill-ai-slop #27 (the invented stat row).
+# The invented stat row.
 - id: SLOP-FAKE-STAT
   layer: 1
   category: slop
@@ -302,7 +293,7 @@
 # shadows have blur proportional to their step: a card 2dp high gets ~4px, not 40px.
 # Parsed from the computed box-shadow string: browser returns offsets in px order after
 # the colour (Chrome/Firefox: "rgba(…) Xpx Ypx BLURpx SPREADpx").
-# kill-ai-slop #20 (the oversized drop shadow).
+# The oversized drop shadow.
 - id: SLOP-OVERSIZED-SHADOW
   layer: 1
   category: slop
@@ -315,7 +306,7 @@
 # Card inside a card: a surfaced node (radius + shadow) whose nearest ancestor is also
 # surfaced. Every nested container adds material depth without information. The fix is
 # one surface per region; group related content with spacing and hairline dividers.
-# kill-ai-slop #29 (cards inside cards).
+# Cards inside cards.
 - id: SLOP-NESTED-CARDS
   layer: 1
   category: slop
@@ -331,7 +322,7 @@
 # 16px radius and 16px padding should hold children with radius 0 to ~12px, not 16px+.
 # Only fires when parent radius > 4px (not micro-radii) and parent has non-zero padding
 # (confirming the child is genuinely inset, not floating adjacent to the parent).
-# kill-ai-slop #21 (corners that don't nest).
+# Corners that don't nest.
 - id: SLOP-NESTED-RADIUS
   layer: 1
   category: slop
@@ -345,7 +336,7 @@
 # page. When proximity carries no information, nothing is grouped — the layout is a grid
 # of equidistant objects. Fires on pages with ≥20 non-zero spacing samples.
 # Zero is excluded: on a real page it represents ~80% of all values and is not a decision.
-# kill-ai-slop #30 (one gap everywhere).
+# One gap everywhere.
 - id: SLOP-MONO-SPACING
   layer: 1
   category: slop
@@ -359,7 +350,7 @@
 # 2021 Dribbble aesthetic. A single frosted-glass surface can be a deliberate choice;
 # applying it to every card is a pattern inherited from training data.
 # The IR captures node.backdropFilter when the computed backdrop-filter is not 'none'.
-# kill-ai-slop #19 (max radius + glassmorphism).
+# Max radius + glassmorphism.
 - id: SLOP-GLASSMORPHISM
   layer: 1
   category: slop
@@ -373,7 +364,7 @@
 # (New / Beta / Hot / Popular / Trending / Soon / Pro) with optional leading emoji.
 # Real badges carry time-bounded or count-backed information; decoration badges erode
 # trust by the third one. Gated to short text (≤30 chars) on small nodes (height ≤36px).
-# kill-ai-slop #22 (badge and pill spam).
+# Badge and pill spam.
 - id: SLOP-BADGE-SPAM
   layer: 1
   category: slop
@@ -388,7 +379,7 @@
 # rank headings from body copy when the sizes are too close to distinguish.
 # Fires at the page level; requires ≥3 distinct sizes (a two-size page may be intentionally
 # minimal). A scale of 14/18/24px or 12/16/28px passes; 13/14/15/17px fails.
-# kill-ai-slop #12 (the flat type hierarchy).
+# The flat type hierarchy.
 - id: SLOP-FLAT-TYPE
   layer: 1
   category: slop

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -52,7 +52,7 @@ instructions: |
     `${CLAUDE_PLUGIN_ROOT}/core/theory/{color,typography,layout,motion,components,craft,expressive}.md`.
     Theory citations are evidence. Taste is not.
 
-  ## Kill-ai-slop visual checklist (kill-ai-slop catalogue, MIT)
+  ## Visual slop checklist
 
   After running `omd check`, scan the render for the following tells that the linter
   cannot measure. Each is a finding only when it is present without a visible reason — a

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -150,9 +150,8 @@ instructions: |
   catch yourself translating an English slogan into Korean, delete it and write the
   sentence a Korean product would have written first.
 
-  And the prose itself, Korean or English, must not read machine-made. The tells, from
-  the im-not-ai taxonomy and the kill-ai-slop catalogue (github.com/yetone/kill-ai-slop,
-  MIT) — avoid all of them:
+  And the prose itself, Korean or English, must not read machine-made. The tells —
+  avoid all of them:
   - mechanical enumeration (첫째/둘째/셋째, "Firstly/Secondly")
   - AI stock phrases: 결론적으로, 시사하는 바가 크다, 주목할 만하다, "in conclusion",
     "it's worth noting", "delve into", "say goodbye to", "blazing fast", "it's not just X
@@ -163,7 +162,7 @@ instructions: |
   - connective abuse: consecutive sentences opening with 또한/따라서/즉/Also/Moreover
   - decoration: bold everywhere, em-dash chains, emoji in headings or CTAs
 
-  ## Visual tells to avoid (kill-ai-slop catalogue)
+  ## Visual tells to avoid
 
   The copy tells above have visual counterparts. `omd check` catches the measurable ones
   (SLOP-GRADIENT, SLOP-TRIPLE-CARD, SLOP-SHADOW-MONOCULTURE, etc.); the following require

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -452,7 +452,7 @@ test('SLOP-KO-SIGNPOST does not fire on English-only copy', () => {
   }
 });
 
-// ── kill-ai-slop integration tests ───────────────────────────────────────────
+// ── visual-tell rules ─────────────────────────────────────────────────────────
 
 // Helpers for structural slop tests
 function makeRootNode(overrides: Partial<RawNode> = {}): RawNode {


### PR DESCRIPTION
Removes external attribution (the taxonomy is the project's own), and rewrites both READMEs' slop-linter sections to document all 21 rules grouped into colour/surface/layout and copy families.