### PR TITLE
feat: general visual-target loop (RE-C)

### DIFF
--- a/agents/hand.md
+++ b/agents/hand.md
@@ -540,6 +540,33 @@ the rest was executed.
 Fix your own findings — a11y, system, slop, and any leak — before the eye ever sees the
 page. Never estimate a contrast ratio, a padding value, or a duration. Run the command.
 
+## Visual target convergence — when a target is registered
+
+When `.omd/target/manifest.json` exists in the project, the user has provided a visual
+reference (a mockup, a screenshot) that the build should converge toward. Run
+`omd target diff` after each build iteration and before handing off to the eye.
+
+**Why this loop exists**: an LLM judges spatial layout poorly by eye. Asking "does the
+padding look right?" requires estimating pixel distances from a render that was never
+measured. `omd target diff` replaces that eyeballing with a similarity score and a 6×6
+grid that names the worst-mismatch cells — so each iteration targets a specific region
+of the layout instead of re-guessing the whole page.
+
+Iteration protocol, ceiling 4:
+1. Run `omd target diff <page> --json` (or `--target <name>` if multiple targets exist).
+2. If `pass: true` — the build meets the threshold. Stop iterating.
+3. If `pass: false` — read `cells` sorted by `mismatch`. The top cells name which region
+   diverges most from the target. Focus the next fix on that region only.
+4. Apply the targeted fix and run the diff again. Repeat up to 4 total iterations.
+5. After 4 iterations, report the final score and the remaining worst cells to the eye
+   even if the threshold was not met — the diff data belongs in the handoff.
+
+The slop linter still runs regardless. If the ORIGINAL target image fires slop findings
+when you inspect the page, report them; do not silently "improve" beyond what the user
+provided — the user's reference is the specification, not an invitation to redesign.
+
+    omd target diff <page> --json
+
 ## What you do not do
 
 You do not critique your own work; a separate agent does that precisely because it has

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -40,10 +40,12 @@ interface Opts {
   blueprint?: boolean;
   /** Directory of pages for cross-page site consistency check (`omd check --site <dir>`). */
   site?: string;
-  /** Similarity threshold for `omd figma diff` (0–1, default 0.97). */
+  /** Similarity threshold for `omd figma diff` / `omd target diff` (0–1, default 0.97). */
   threshold?: string;
   /** Force re-export even when a cached Figma export exists (`omd figma diff --fresh`). */
   fresh?: boolean;
+  /** Named visual target to diff against (`omd target diff --target <name>`). */
+  target?: string;
 }
 
 const FLAGS = new Set(['json', 'no-log', 'image', 'filmstrip', 'from-user', 'blueprint', 'fresh']);
@@ -922,6 +924,140 @@ async function cmdDoctor(): Promise<never> {
   process.exit(allPass ? 0 : 1);
 }
 
+// ── Target commands ──────────────────────────────────────────────────────────
+
+/**
+ * `omd target set <image-path-or-url> --as <name>`
+ *
+ * Download or copy the reference image into `.omd/target/<name>.png` and record
+ * its dimensions (the intended render viewport). Multiple named targets allowed.
+ * Accepts local file paths and HTTP/HTTPS URLs; no new dependencies — uses the
+ * built-in `fetch` for URL downloads and the in-repo decodePng for dimensions.
+ */
+async function cmdTargetSet(opts: Opts): Promise<never> {
+  const source = opts._[0];
+  if (!source || !opts.as) {
+    console.error('usage: omd target set <image-path-or-url> --as <name>');
+    process.exit(1);
+  }
+
+  let buf: Buffer;
+  if (/^https?:\/\//.test(source)) {
+    const res = await fetch(source);
+    if (!res.ok) {
+      console.error(`failed to download target image (${res.status}): ${source}`);
+      process.exit(1);
+    }
+    buf = Buffer.from(await res.arrayBuffer());
+  } else {
+    const absPath = resolve(source);
+    if (!existsSync(absPath)) {
+      console.error(`file not found: ${source}`);
+      process.exit(1);
+    }
+    buf = readFileSync(absPath);
+  }
+
+  const { registerTarget } = await import('../core/target/index.ts');
+  const entry = registerTarget(process.cwd(), opts.as, source, buf);
+
+  console.log(
+    `target "${entry.name}" registered  ${entry.viewport.width}×${entry.viewport.height}  ${entry.path}`,
+  );
+  process.exit(0);
+}
+
+/**
+ * `omd target diff <page> [--target <name>] [--viewport WxH] [--threshold N] [--json]`
+ *
+ * Renders the build page at the target's stored viewport dimensions, decodes both
+ * PNGs with the in-repo decoder, and compares them using the same algorithm and
+ * contract as `omd figma diff`. Exits 1 when the similarity score falls below the
+ * threshold (default 0.97). `--json` emits the stable DiffResult for a fix loop.
+ */
+async function cmdTargetDiff(opts: Opts): Promise<never> {
+  const page = opts._[0];
+  if (!page) {
+    console.error('usage: omd target diff <page> [--target <name>] [--viewport WxH] [--threshold N] [--json]');
+    process.exit(1);
+  }
+
+  const threshold =
+    opts.threshold !== undefined ? parseFloat(opts.threshold) : 0.97;
+  if (isNaN(threshold) || threshold < 0 || threshold > 1) {
+    console.error('--threshold must be a number between 0 and 1');
+    process.exit(1);
+  }
+
+  const jsonOut = opts.json === true;
+
+  const { listTargets, findTarget, compareAgainstTarget, formatDiffReport } = await import('../core/target/index.ts');
+  const { renderPage, parseViewport } = await import('../core/render/index.ts');
+
+  // Resolve target entry
+  let entry;
+  if (opts.target) {
+    entry = findTarget(process.cwd(), opts.target);
+    if (!entry) {
+      console.error(`target "${opts.target}" not found. Run \`omd target list\` to see registered targets.`);
+      process.exit(1);
+    }
+  } else {
+    const all = listTargets(process.cwd());
+    if (all.length === 0) {
+      console.error('no targets registered. Run `omd target set <image> --as <name>` first.');
+      process.exit(1);
+    }
+    entry = all[0]!;
+    if (!jsonOut) console.log(`using target "${entry.name}" (first registered)`);
+  }
+
+  // Render viewport: --viewport flag overrides the target's stored dimensions
+  const viewport = opts.viewport
+    ? parseViewport(opts.viewport)
+    : { width: entry.viewport.width, height: entry.viewport.height };
+
+  // Render the build
+  const rendersDir = join(process.cwd(), '.omd', 'target', '.renders');
+  mkdirSync(rendersDir, { recursive: true });
+  const safeTarget = entry.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const renderPath = join(rendersDir, `${safeTarget}.png`);
+
+  if (!jsonOut) {
+    console.log(`rendering ${page} at ${viewport.width}×${viewport.height} …`);
+  }
+  await renderPage(page, { viewport, out: renderPath });
+
+  // Compare
+  const targetBuf = readFileSync(entry.path);
+  const buildBuf = readFileSync(renderPath);
+  const result = compareAgainstTarget(targetBuf, buildBuf, threshold);
+
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log('\n' + formatDiffReport(result));
+  }
+
+  process.exit(result.pass ? 0 : 1);
+}
+
+/** `omd target list` — show all registered visual targets. */
+async function cmdTargetList(): Promise<never> {
+  const { listTargets } = await import('../core/target/index.ts');
+  const targets = listTargets(process.cwd());
+  if (targets.length === 0) {
+    console.log('No targets registered. Run `omd target set <image> --as <name>`.');
+    process.exit(0);
+  }
+  for (const t of targets) {
+    console.log(
+      `${t.name}  ${t.viewport.width}×${t.viewport.height}  source: ${t.source}  registered: ${t.registeredAt.slice(0, 10)}`,
+    );
+  }
+  process.exit(0);
+}
+
 function usage(): never {
   console.error(
     'usage: omd <command>\n\n'
@@ -954,7 +1090,12 @@ function usage(): never {
   + '\n'
   + '  figma pull <file-url>                        fetch Figma file -> .omd/figma/snapshot.json\n'
   + '  figma system                                 synthesize design system from snapshot\n'
-  + '  figma diff <frame-id> <page-or-url>          pixel diff: Figma export vs build render',
+  + '  figma diff <frame-id> <page-or-url>          pixel diff: Figma export vs build render\n'
+  + '\n'
+  + '  target set <image-path-or-url> --as <name>  register a visual target (mockup / screenshot)\n'
+  + '  target list                                  show registered targets\n'
+  + '  target diff <page> [--target <name>] [--viewport WxH] [--threshold N] [--json]\n'
+  + '                                               pixel diff: target vs build render (exit 1 below threshold)',
   );
   process.exit(1);
 }
@@ -1022,6 +1163,14 @@ async function main(): Promise<never> {
     if (sub === 'pull') return cmdFigmaPull(args[2]);
     if (sub === 'system') return cmdFigmaSystem();
     if (sub === 'diff') return cmdFigmaDiff(parseArgs(args.slice(2)));
+    return usage();
+  }
+
+  if (cmd === 'target') {
+    const opts = parseArgs(args.slice(2));
+    if (sub === 'set') return cmdTargetSet(opts);
+    if (sub === 'list') return cmdTargetList();
+    if (sub === 'diff') return cmdTargetDiff(opts);
     return usage();
   }
 

--- a/core/target/index.ts
+++ b/core/target/index.ts
@@ -1,0 +1,183 @@
+/**
+ * Visual target loop — RE-C (일반 시각 타깃 루프).
+ *
+ * Generalises the Figma pixel-diff loop to work against ANY image reference —
+ * a mockup, a screenshot, a live-URL render — so "make it look like this picture"
+ * becomes a measured convergence loop.
+ *
+ * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────────
+ *
+ * An LLM judges spatial layout poorly by eye. Telling a model "make the hero taller"
+ * or "the padding looks off" requires the model to estimate pixel distances from
+ * a render it has never measured. The pixel diff replaces that eyeballing with
+ * numbers: a score (0–1), a pass/fail decision at a threshold, and a 6×6 grid
+ * that names the worst-mismatch cells so each iteration targets a specific region
+ * rather than re-guessing the whole layout.
+ *
+ * ── REUSE ───────────────────────────────────────────────────────────────────────
+ *
+ * This module reuses two existing in-repo primitives:
+ *
+ *   - `compareImages` from `core/figma/diff.ts`   — diff math + grid logic
+ *   - `formatDiffReport` from `core/figma/diff.ts` — human-readable grid report
+ *   - `decodePng` from `core/motion/energy.ts`     — PNG decoder (no new dep)
+ *
+ * The `DiffResult` / `DiffCell` types are re-exported so callers never depend on
+ * the figma module path directly.
+ *
+ * ── JSON CONTRACT ────────────────────────────────────────────────────────────────
+ *
+ * `compareAgainstTarget` returns the same `DiffResult` shape as `compareImages`
+ * so `--json` output and loop drivers work identically for both figma diff and
+ * target diff:
+ *
+ *   {
+ *     score:     number,          // 0–1, fraction of "same" pixels
+ *     threshold: number,
+ *     pass:      boolean,
+ *     cells: [{ row, col, x, y, width, height, mismatch }],
+ *     dimMismatch?: { refWidth, refHeight, buildWidth, buildHeight,
+ *                     overlapWidth, overlapHeight }
+ *   }
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { decodePng } from '../motion/energy.ts';
+import { compareImages, formatDiffReport } from '../figma/diff.ts';
+
+// ── Re-exports (stable contract) ─────────────────────────────────────────────
+
+export type { DiffResult, DiffCell } from '../figma/diff.ts';
+export { compareImages, formatDiffReport } from '../figma/diff.ts';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface TargetViewport {
+  width: number;
+  height: number;
+}
+
+/** One entry in the target manifest. */
+export interface TargetEntry {
+  /** Human-readable name used with `--target <name>`. */
+  name: string;
+  /** Original source: a file path or a URL. */
+  source: string;
+  /** Absolute path to the stored PNG inside `.omd/target/`. */
+  path: string;
+  /** Dimensions decoded from the target PNG — used as the render viewport. */
+  viewport: TargetViewport;
+  registeredAt: string;
+}
+
+interface TargetManifest {
+  targets: TargetEntry[];
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function targetDir(cwd: string): string {
+  return join(cwd, '.omd', 'target');
+}
+
+function manifestPath(cwd: string): string {
+  return join(targetDir(cwd), 'manifest.json');
+}
+
+function loadManifest(cwd: string): TargetManifest {
+  const p = manifestPath(cwd);
+  if (!existsSync(p)) return { targets: [] };
+  return JSON.parse(readFileSync(p, 'utf8')) as TargetManifest;
+}
+
+function saveManifest(cwd: string, manifest: TargetManifest): void {
+  mkdirSync(targetDir(cwd), { recursive: true });
+  writeFileSync(manifestPath(cwd), JSON.stringify(manifest, null, 2));
+}
+
+/** Sanitise a target name into a safe file basename. */
+export function safeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Register a PNG buffer as a named visual target.
+ *
+ * Decodes the buffer to read its dimensions (the intended render viewport),
+ * writes the PNG to `.omd/target/<safeName>.png`, and upserts the manifest.
+ *
+ * @param cwd    Project working directory (`.omd/` is created here).
+ * @param name   Human-readable target name (used with `--target <name>`).
+ * @param source Original source identifier (URL or file path) — stored for reference.
+ * @param buf    Valid PNG buffer.
+ */
+export function registerTarget(
+  cwd: string,
+  name: string,
+  source: string,
+  buf: Buffer,
+): TargetEntry {
+  const dir = targetDir(cwd);
+  mkdirSync(dir, { recursive: true });
+
+  const pngPath = join(dir, `${safeName(name)}.png`);
+  writeFileSync(pngPath, buf);
+
+  // Decode to get dimensions — decodePng from core/motion/energy.ts, no new dep.
+  const { width, height } = decodePng(buf);
+
+  const entry: TargetEntry = {
+    name,
+    source,
+    path: pngPath,
+    viewport: { width, height },
+    registeredAt: new Date().toISOString(),
+  };
+
+  const manifest = loadManifest(cwd);
+  const idx = manifest.targets.findIndex((t) => t.name === name);
+  if (idx >= 0) {
+    manifest.targets[idx] = entry;
+  } else {
+    manifest.targets.push(entry);
+  }
+  saveManifest(cwd, manifest);
+
+  return entry;
+}
+
+/** Return all registered targets for the project at `cwd`. */
+export function listTargets(cwd: string): TargetEntry[] {
+  return loadManifest(cwd).targets;
+}
+
+/**
+ * Look up one registered target by name.
+ * Returns `undefined` when no target with that name has been registered.
+ */
+export function findTarget(cwd: string, name: string): TargetEntry | undefined {
+  return loadManifest(cwd).targets.find((t) => t.name === name);
+}
+
+/**
+ * Compare a build PNG buffer against a target PNG buffer.
+ *
+ * Pure wrapper around `compareImages` from `core/figma/diff.ts` — same
+ * algorithm, same JSON contract, same tolerance constants. The `DiffResult`
+ * returned here is bitwise-identical to what `omd figma diff` would produce
+ * for the same pair of images.
+ *
+ * @param targetBuf  Reference PNG (the registered visual target).
+ * @param buildBuf   Build render PNG (the "actual" to be improved).
+ * @param threshold  Pass/fail threshold (0–1, default 0.97).
+ */
+export function compareAgainstTarget(
+  targetBuf: Buffer,
+  buildBuf: Buffer,
+  threshold = 0.97,
+): ReturnType<typeof compareImages> {
+  return compareImages(targetBuf, buildBuf, threshold);
+}

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -230,6 +230,26 @@ If you cannot name it, the concept has no position yet. Name it before you open 
 **This is the step that separates design from decoration, and the one you will be most
 tempted to skip.** A designer with a concept goes and looks at what already exists.
 
+**Before the scout runs**, check whether the brief contains any image file paths or image
+URLs (file extensions `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, or any direct image URL).
+If it does, register them as visual targets immediately:
+
+```bash
+omd target set <image-path-or-url> --as mockup
+# Multiple targets are allowed: register desktop and mobile mockups separately.
+omd target list
+```
+
+This does nothing to the reference board. It stores the image as a pixel target the build
+will converge toward in step 5. The convergence loop replaces eyeballing: an LLM judges
+spatial layout poorly by eye, so `omd target diff` measures the gap with a score and a
+6×6 cell grid that names the worst-mismatch regions — no estimation required.
+
+If the registered target itself fires slop findings (≥2 violations), report it plainly:
+> "The mockup you provided shows N slop signals (IDs) — I'll build toward the layout but
+> flag the patterns so you can decide whether to keep them."
+Do not silently "improve" beyond the linter output; the user's mockup is the specification.
+
 Before spawning the scout, extract every URL the user included in the brief. Pass them to
 the scout verbatim — the scout captures them first, with `--from-user`, before running any
 of its own searches. User-provided URLs are exempt from the famous-site quota; the user
@@ -423,6 +443,21 @@ You did not make what you think you made.
 Render at both viewports, then hand **both** screenshots to the eye. A clamp that works at
 1280px can collapse to nothing at 375px; a margin-note that floats correctly on desktop can
 cover body text on mobile. One render is a blind spot.
+
+**If visual targets were registered in step 3**, run the target diff loop before rendering
+for the eye. This loop converges the build toward the user's mockup using pixel-level
+measurement — ceiling 4 iterations:
+
+```bash
+omd target diff <page> --json          # uses first target; --target <name> if multiple
+# If pass: false — read cells[], fix the worst-mismatch region, build again, re-diff.
+# If pass: true — proceed. Maximum 4 iterations total.
+```
+
+The diff exits 0 on pass, 1 on fail. The `--json` output names the worst cells by
+row/column and pixel coordinate so each iteration has a specific region to improve, not a
+vague "make it look more like the mockup" instruction. After 4 iterations, proceed
+regardless and include the final score in the eye's brief.
 
 ```bash
 omd render <page> -o .omd/.cache/build-desktop.png --viewport 1280x800

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -542,6 +542,33 @@ instructions: |
   Fix your own findings — a11y, system, slop, and any leak — before the eye ever sees the
   page. Never estimate a contrast ratio, a padding value, or a duration. Run the command.
 
+  ## Visual target convergence — when a target is registered
+
+  When `.omd/target/manifest.json` exists in the project, the user has provided a visual
+  reference (a mockup, a screenshot) that the build should converge toward. Run
+  `omd target diff` after each build iteration and before handing off to the eye.
+
+  **Why this loop exists**: an LLM judges spatial layout poorly by eye. Asking "does the
+  padding look right?" requires estimating pixel distances from a render that was never
+  measured. `omd target diff` replaces that eyeballing with a similarity score and a 6×6
+  grid that names the worst-mismatch cells — so each iteration targets a specific region
+  of the layout instead of re-guessing the whole page.
+
+  Iteration protocol, ceiling 4:
+  1. Run `omd target diff <page> --json` (or `--target <name>` if multiple targets exist).
+  2. If `pass: true` — the build meets the threshold. Stop iterating.
+  3. If `pass: false` — read `cells` sorted by `mismatch`. The top cells name which region
+     diverges most from the target. Focus the next fix on that region only.
+  4. Apply the targeted fix and run the diff again. Repeat up to 4 total iterations.
+  5. After 4 iterations, report the final score and the remaining worst cells to the eye
+     even if the threshold was not met — the diff data belongs in the handoff.
+
+  The slop linter still runs regardless. If the ORIGINAL target image fires slop findings
+  when you inspect the page, report them; do not silently "improve" beyond what the user
+  provided — the user's reference is the specification, not an invitation to redesign.
+
+      omd target diff <page> --json
+
   ## What you do not do
 
   You do not critique your own work; a separate agent does that precisely because it has

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -230,6 +230,26 @@ If you cannot name it, the concept has no position yet. Name it before you open 
 **This is the step that separates design from decoration, and the one you will be most
 tempted to skip.** A designer with a concept goes and looks at what already exists.
 
+**Before the scout runs**, check whether the brief contains any image file paths or image
+URLs (file extensions `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, or any direct image URL).
+If it does, register them as visual targets immediately:
+
+```bash
+omd target set <image-path-or-url> --as mockup
+# Multiple targets are allowed: register desktop and mobile mockups separately.
+omd target list
+```
+
+This does nothing to the reference board. It stores the image as a pixel target the build
+will converge toward in step 5. The convergence loop replaces eyeballing: an LLM judges
+spatial layout poorly by eye, so `omd target diff` measures the gap with a score and a
+6×6 cell grid that names the worst-mismatch regions — no estimation required.
+
+If the registered target itself fires slop findings (≥2 violations), report it plainly:
+> "The mockup you provided shows N slop signals (IDs) — I'll build toward the layout but
+> flag the patterns so you can decide whether to keep them."
+Do not silently "improve" beyond the linter output; the user's mockup is the specification.
+
 Before spawning the scout, extract every URL the user included in the brief. Pass them to
 the scout verbatim — the scout captures them first, with `--from-user`, before running any
 of its own searches. User-provided URLs are exempt from the famous-site quota; the user
@@ -423,6 +443,21 @@ You did not make what you think you made.
 Render at both viewports, then hand **both** screenshots to the eye. A clamp that works at
 1280px can collapse to nothing at 375px; a margin-note that floats correctly on desktop can
 cover body text on mobile. One render is a blind spot.
+
+**If visual targets were registered in step 3**, run the target diff loop before rendering
+for the eye. This loop converges the build toward the user's mockup using pixel-level
+measurement — ceiling 4 iterations:
+
+```bash
+omd target diff <page> --json          # uses first target; --target <name> if multiple
+# If pass: false — read cells[], fix the worst-mismatch region, build again, re-diff.
+# If pass: true — proceed. Maximum 4 iterations total.
+```
+
+The diff exits 0 on pass, 1 on fail. The `--json` output names the worst cells by
+row/column and pixel coordinate so each iteration has a specific region to improve, not a
+vague "make it look more like the mockup" instruction. After 4 iterations, proceed
+regardless and include the final score in the eye's brief.
 
 ```bash
 omd render <page> -o .omd/.cache/build-desktop.png --viewport 1280x800

--- a/test/target.test.ts
+++ b/test/target.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for core/target/index.ts — RE-C visual target loop.
+ *
+ * All comparison tests use synthetic PNG buffers built with the same helpers
+ * as test/figma-diff.test.ts and test/motion-energy.test.ts.
+ * No network, no browser, no filesystem side-effects in pure comparison tests.
+ *
+ * The plumbing tests (register / list / find) write to a temp directory inside
+ * the test scratchpad; they clean up on exit.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deflateSync, crc32 } from 'node:zlib';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  compareAgainstTarget,
+  formatDiffReport,
+  compareImages,
+  registerTarget,
+  listTargets,
+  findTarget,
+  safeName,
+} from '../core/target/index.ts';
+
+// ── PNG creation helpers (mirrors test/figma-diff.test.ts) ────────────────────
+
+function uint32BE(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(n >>> 0, 0);
+  return b;
+}
+
+function makePngChunk(type: string, data: Buffer): Buffer {
+  const typeBytes = Buffer.from(type, 'ascii');
+  const checksum = crc32(Buffer.concat([typeBytes, data]));
+  return Buffer.concat([uint32BE(data.length), typeBytes, data, uint32BE(checksum >>> 0)]);
+}
+
+function makePng(width: number, height: number, rgb: Uint8Array): Buffer {
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 2; // RGB
+  ihdr[10] = 0; ihdr[11] = 0; ihdr[12] = 0;
+  const stride = width * 3;
+  const rawRows = Buffer.alloc((stride + 1) * height);
+  for (let y = 0; y < height; y++) {
+    rawRows[y * (stride + 1)] = 0;
+    for (let x = 0; x < stride; x++) {
+      rawRows[y * (stride + 1) + 1 + x] = rgb[y * stride + x]!;
+    }
+  }
+  return Buffer.concat([
+    signature,
+    makePngChunk('IHDR', ihdr),
+    makePngChunk('IDAT', deflateSync(rawRows)),
+    makePngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+function uniformRgb(width: number, height: number, r: number, g: number, b: number): Buffer {
+  const pixels = new Uint8Array(width * height * 3);
+  for (let i = 0; i < width * height; i++) {
+    pixels[i * 3] = r;
+    pixels[i * 3 + 1] = g;
+    pixels[i * 3 + 2] = b;
+  }
+  return makePng(width, height, pixels);
+}
+
+function splitRgb(
+  width: number,
+  height: number,
+  topHeight: number,
+  topRgb: [number, number, number],
+  botRgb: [number, number, number],
+): Buffer {
+  const pixels = new Uint8Array(width * height * 3);
+  for (let y = 0; y < height; y++) {
+    const [r, g, b] = y < topHeight ? topRgb : botRgb;
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 3;
+      pixels[i] = r!; pixels[i + 1] = g!; pixels[i + 2] = b!;
+    }
+  }
+  return makePng(width, height, pixels);
+}
+
+// ── compareAgainstTarget: pure comparison delegation ──────────────────────────
+
+test('compareAgainstTarget: identical images → score 1, pass true', () => {
+  const img = uniformRgb(60, 60, 100, 150, 200);
+  const result = compareAgainstTarget(img, img);
+  assert.equal(result.score, 1);
+  assert.equal(result.pass, true);
+  assert.equal(result.threshold, 0.97);
+});
+
+test('compareAgainstTarget: completely different images → score 0, pass false', () => {
+  const target = uniformRgb(60, 60, 0, 0, 0);
+  const build = uniformRgb(60, 60, 255, 255, 255);
+  const result = compareAgainstTarget(target, build);
+  assert.equal(result.score, 0);
+  assert.equal(result.pass, false);
+});
+
+test('compareAgainstTarget: top half changed → score ≈ 0.5', () => {
+  const size = 60;
+  const target = uniformRgb(size, size, 0, 0, 0);
+  const build = splitRgb(size, size, size / 2, [200, 200, 200], [0, 0, 0]);
+  const result = compareAgainstTarget(target, build);
+  assert.ok(result.score >= 0.49 && result.score <= 0.51, `expected ~0.5, got ${result.score}`);
+  assert.equal(result.pass, false);
+});
+
+test('compareAgainstTarget: custom threshold respected', () => {
+  const target = uniformRgb(60, 60, 0, 0, 0);
+  const build = splitRgb(60, 60, 3, [200, 200, 200], [0, 0, 0]);
+  // 3/60 = 5% changed → score ≈ 0.95
+  const at95 = compareAgainstTarget(target, build, 0.95);
+  const at97 = compareAgainstTarget(target, build, 0.97);
+  assert.equal(at95.pass, true,  `score=${at95.score} should pass at 0.95`);
+  assert.equal(at97.pass, false, `score=${at97.score} should fail at 0.97`);
+});
+
+test('compareAgainstTarget: threshold stored in result', () => {
+  const img = uniformRgb(10, 10, 0, 0, 0);
+  const result = compareAgainstTarget(img, img, 0.85);
+  assert.equal(result.threshold, 0.85);
+});
+
+test('compareAgainstTarget: dimension mismatch → dimMismatch reported', () => {
+  const target = uniformRgb(60, 60, 0, 0, 0);
+  const build = uniformRgb(80, 80, 0, 0, 0);
+  const result = compareAgainstTarget(target, build);
+  assert.ok(result.dimMismatch !== undefined);
+  assert.equal(result.dimMismatch!.refWidth, 60);
+  assert.equal(result.dimMismatch!.buildWidth, 80);
+});
+
+test('compareAgainstTarget: result has stable JSON contract fields', () => {
+  const img = uniformRgb(60, 60, 100, 100, 100);
+  const result = compareAgainstTarget(img, img);
+  assert.equal(typeof result.score, 'number');
+  assert.equal(typeof result.threshold, 'number');
+  assert.equal(typeof result.pass, 'boolean');
+  assert.ok(Array.isArray(result.cells));
+  const cell = result.cells[0]!;
+  assert.equal(typeof cell.row, 'number');
+  assert.equal(typeof cell.col, 'number');
+  assert.equal(typeof cell.x, 'number');
+  assert.equal(typeof cell.y, 'number');
+  assert.equal(typeof cell.width, 'number');
+  assert.equal(typeof cell.height, 'number');
+  assert.equal(typeof cell.mismatch, 'number');
+});
+
+// ── compareAgainstTarget vs compareImages: identical behaviour ─────────────────
+
+test('compareAgainstTarget gives bit-identical result to compareImages', () => {
+  const target = uniformRgb(60, 60, 0, 0, 0);
+  const build = splitRgb(60, 60, 10, [255, 255, 255], [0, 0, 0]);
+  const via_target = compareAgainstTarget(target, build, 0.97);
+  const via_images = compareImages(target, build, 0.97);
+  assert.equal(via_target.score, via_images.score);
+  assert.equal(via_target.pass, via_images.pass);
+  assert.equal(via_target.cells.length, via_images.cells.length);
+  for (let i = 0; i < via_target.cells.length; i++) {
+    assert.equal(via_target.cells[i]!.mismatch, via_images.cells[i]!.mismatch);
+  }
+});
+
+test('compareAgainstTarget: identical images → all cell mismatches are 0', () => {
+  const img = uniformRgb(60, 60, 200, 100, 50);
+  const result = compareAgainstTarget(img, img);
+  for (const cell of result.cells) {
+    assert.equal(cell.mismatch, 0, `cell r${cell.row}c${cell.col} should be 0`);
+  }
+});
+
+test('compareAgainstTarget: completely different → all cell mismatches are 1', () => {
+  const target = uniformRgb(60, 60, 0, 0, 0);
+  const build = uniformRgb(60, 60, 255, 255, 255);
+  const result = compareAgainstTarget(target, build);
+  for (const cell of result.cells) {
+    assert.equal(cell.mismatch, 1, `cell r${cell.row}c${cell.col} should be 1`);
+  }
+});
+
+// ── formatDiffReport (re-exported from figma/diff.ts) ─────────────────────────
+
+test('formatDiffReport re-export: shows PASS for passing result', () => {
+  const img = uniformRgb(60, 60, 100, 100, 100);
+  const result = compareAgainstTarget(img, img);
+  const report = formatDiffReport(result);
+  assert.match(report, /PASS/);
+});
+
+test('formatDiffReport re-export: shows FAIL for failing result', () => {
+  const target = uniformRgb(60, 60, 0, 0, 0);
+  const build = uniformRgb(60, 60, 255, 255, 255);
+  const result = compareAgainstTarget(target, build);
+  const report = formatDiffReport(result);
+  assert.match(report, /FAIL/);
+  assert.match(report, /r\d+c\d+/);
+});
+
+// ── safeName ──────────────────────────────────────────────────────────────────
+
+test('safeName: alphanumeric name passes through unchanged', () => {
+  assert.equal(safeName('hero'), 'hero');
+  assert.equal(safeName('hero-v2'), 'hero-v2');
+  assert.equal(safeName('hero.png'), 'hero.png');
+});
+
+test('safeName: special characters are replaced with underscores', () => {
+  assert.equal(safeName('hero image'), 'hero_image');
+  assert.equal(safeName('hero/mockup'), 'hero_mockup');
+  assert.equal(safeName('hero@2x'), 'hero_2x');
+});
+
+// ── registerTarget / listTargets / findTarget plumbing ────────────────────────
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'omd-target-test-'));
+}
+
+test('registerTarget: creates .omd/target/<name>.png and manifest', () => {
+  const cwd = makeTempDir();
+  try {
+    const img = uniformRgb(120, 80, 255, 0, 0);
+    const entry = registerTarget(cwd, 'hero', 'file:///mock.png', img);
+
+    assert.equal(entry.name, 'hero');
+    assert.equal(entry.source, 'file:///mock.png');
+    assert.equal(entry.viewport.width, 120);
+    assert.equal(entry.viewport.height, 80);
+    assert.ok(entry.path.endsWith('hero.png'));
+    assert.ok(entry.registeredAt.length > 0);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('registerTarget: decodes viewport dimensions from the PNG', () => {
+  const cwd = makeTempDir();
+  try {
+    const img = uniformRgb(1280, 800, 0, 128, 255);
+    const entry = registerTarget(cwd, 'desktop', 'https://example.com/mock.png', img);
+    assert.equal(entry.viewport.width, 1280);
+    assert.equal(entry.viewport.height, 800);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('registerTarget: upserts when same name registered twice', () => {
+  const cwd = makeTempDir();
+  try {
+    const img1 = uniformRgb(100, 100, 255, 0, 0);
+    const img2 = uniformRgb(200, 150, 0, 255, 0);
+    registerTarget(cwd, 'hero', 'source1.png', img1);
+    registerTarget(cwd, 'hero', 'source2.png', img2);
+
+    const targets = listTargets(cwd);
+    assert.equal(targets.length, 1, 'upsert should not create a duplicate');
+    assert.equal(targets[0]!.source, 'source2.png', 'second register should overwrite');
+    assert.equal(targets[0]!.viewport.width, 200);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('listTargets: returns empty array when no manifest exists', () => {
+  const cwd = makeTempDir();
+  try {
+    const targets = listTargets(cwd);
+    assert.deepEqual(targets, []);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('listTargets: returns all registered targets in insertion order', () => {
+  const cwd = makeTempDir();
+  try {
+    registerTarget(cwd, 'hero', 'a.png', uniformRgb(10, 10, 255, 0, 0));
+    registerTarget(cwd, 'mobile', 'b.png', uniformRgb(20, 20, 0, 255, 0));
+    registerTarget(cwd, 'tablet', 'c.png', uniformRgb(30, 30, 0, 0, 255));
+
+    const targets = listTargets(cwd);
+    assert.equal(targets.length, 3);
+    assert.equal(targets[0]!.name, 'hero');
+    assert.equal(targets[1]!.name, 'mobile');
+    assert.equal(targets[2]!.name, 'tablet');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('findTarget: returns the matching entry by name', () => {
+  const cwd = makeTempDir();
+  try {
+    registerTarget(cwd, 'hero', 'a.png', uniformRgb(10, 10, 255, 0, 0));
+    registerTarget(cwd, 'mobile', 'b.png', uniformRgb(20, 20, 0, 255, 0));
+
+    const found = findTarget(cwd, 'mobile');
+    assert.ok(found !== undefined);
+    assert.equal(found!.name, 'mobile');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('findTarget: returns undefined when name not found', () => {
+  const cwd = makeTempDir();
+  try {
+    registerTarget(cwd, 'hero', 'a.png', uniformRgb(10, 10, 0, 0, 0));
+    const found = findTarget(cwd, 'nonexistent');
+    assert.equal(found, undefined);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('registerTarget: name with special chars uses safe filename but preserves name field', () => {
+  const cwd = makeTempDir();
+  try {
+    const img = uniformRgb(100, 100, 0, 0, 0);
+    const entry = registerTarget(cwd, 'hero mockup', 'a.png', img);
+    assert.equal(entry.name, 'hero mockup', 'name field preserves original');
+    assert.ok(entry.path.includes('hero_mockup'), 'file path uses safe name');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+// ── threshold / exit-code semantics (via compareAgainstTarget) ────────────────
+
+test('compareAgainstTarget: default threshold is 0.97', () => {
+  const img = uniformRgb(10, 10, 0, 0, 0);
+  const result = compareAgainstTarget(img, img);
+  assert.equal(result.threshold, 0.97);
+});
+
+test('compareAgainstTarget: score 1 passes any threshold ≤ 1', () => {
+  const img = uniformRgb(10, 10, 128, 128, 128);
+  for (const t of [0.0, 0.5, 0.97, 1.0]) {
+    const r = compareAgainstTarget(img, img, t);
+    assert.equal(r.pass, true, `score 1 should pass at threshold ${t}`);
+  }
+});
+
+test('compareAgainstTarget: score 0 fails any threshold > 0', () => {
+  const target = uniformRgb(10, 10, 0, 0, 0);
+  const build = uniformRgb(10, 10, 255, 255, 255);
+  for (const t of [0.01, 0.5, 0.97, 1.0]) {
+    const r = compareAgainstTarget(target, build, t);
+    assert.equal(r.pass, false, `score 0 should fail at threshold ${t}`);
+  }
+});
+
+test('compareAgainstTarget: boundary — failing every threshold scores 0', () => {
+  const target = uniformRgb(4, 4, 0, 0, 0);
+  const build = uniformRgb(4, 4, 255, 0, 0); // max diff on one channel
+  const r = compareAgainstTarget(target, build);
+  assert.equal(r.score, 0);
+  assert.equal(r.pass, false);
+});


### PR DESCRIPTION
Plan v4 RE-C. omd target set/diff/list generalizes the Figma pixel loop to any image reference. 623→649 tests.