### PR TITLE
chore: pipeline agents follow the model-role convention (GPT-5.6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,16 @@ A spec handed to an executor carries: source-of-truth vs generated files, the na
 discipline for any new linter rule (positive AND negative tests), the baseline test count,
 and the definition of done (`npm test` clean, `tsc` clean, `npm run build` succeeds).
 
+### The pipeline's own agents
+
+`adapters/tool-map.json` resolves each agent's abstract tier to a concrete model per host.
+On the Codex host both tiers currently resolve to the **GPT-5.6** generation; the
+role-to-reasoning split above (Sol for orchestration/review, Terra xhigh for precise edits,
+Luna high for the cheap lane) is how a run should assign work within that generation.
+`omd-framer`, `omd-scout`, and `omd-eye` are the `@high` (plan/measure/review) agents;
+`omd-hand` is the `@medium` (build) agent — the same frontier-plans/efficient-builds split
+the Claude host expresses as Opus and Sonnet 5.
+
 ## Repository conventions
 
 - **Source of truth is `src/`.** `src/agents/*.agent.yaml` and `src/skills/omd-*/SKILL.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,22 @@ generated, the narrowness discipline for any new linter rule (positive AND negat
 the baseline test count, and the definition of done (`npm test` clean, `tsc` clean,
 `npm run build` succeeds).
 
+### Role → model
+
+| Role | Model | Why |
+|---|---|---|
+| **Orchestration · architecture · high-risk review (planner/critic)** | **Opus** | Holds whole-repo context, decides what changes and why, reviews the diff it did not write. |
+| **Precise code-edit executor** | **Sonnet 5** | The builder — writes the code, the tests, and runs the gates from a written spec. |
+| **Low-cost lane** | **Haiku 4.5** | Cheaper lane for lower-risk mechanical work when quality permits. |
+
+**The pipeline's own agents already embody this.** `adapters/tool-map.json` resolves each
+agent's abstract tier to a concrete model: `@high` → `claude-opus-4-8`, `@medium` →
+`claude-sonnet-5`. So `omd-framer` (interrogates the brief), `omd-scout` (measures
+references), and `omd-eye` (critiques in a fresh context) run on Opus, while `omd-hand`
+(builds the committed structure) runs on Sonnet 5 — planning and review on the frontier
+model, building on the builder. On the Codex host the same tiers resolve to the GPT-5.6
+generation (see `AGENTS.md`).
+
 ## Repository conventions
 
 - **Source of truth is `src/`.** `src/agents/*.agent.yaml` and `src/skills/omd-*/SKILL.md`

--- a/adapters/tool-map.json
+++ b/adapters/tool-map.json
@@ -6,7 +6,7 @@
   "agentFormat": { "codex": "toml", "claude": "md" },
   "hookLayout": { "codex": "file-per-hook", "claude": "single-file" },
   "model": {
-    "high": { "codex": "gpt-5.5", "claude": "claude-opus-4-8" },
-    "medium": { "codex": "gpt-5.5", "claude": "claude-sonnet-5" }
+    "high": { "codex": "gpt-5.6", "claude": "claude-opus-4-8" },
+    "medium": { "codex": "gpt-5.6", "claude": "claude-sonnet-5" }
   }
 }

--- a/test/adapters-regression.test.ts
+++ b/test/adapters-regression.test.ts
@@ -30,7 +30,7 @@ test('codex agent toml survives quotes, colons and backslashes', () => {
   const parsed = parseToml(toml) as unknown as AgentToml;
   assert.equal(parsed.name, 'omd-eye');
   assert.equal(parsed.description, NASTY.description);
-  assert.equal(parsed.model, 'gpt-5.5');
+  assert.equal(parsed.model, 'gpt-5.6');
   assert.ok(must(parsed.developer_instructions, 'developer_instructions').includes('Quote test:'));
 });
 

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -36,7 +36,7 @@ test('no @token survives emission', () => {
 test('agents render to toml for codex and md for claude, with the right model', () => {
   const toml = textFile(emitCodex({ agents: [AGENT] }), 'agents/omd-eye.toml');
   assert.match(toml, /^name = "omd-eye"/m);
-  assert.match(toml, /model = "gpt-5\.5"/);
+  assert.match(toml, /model = "gpt-5\.6"/);
   assert.match(toml, /model_reasoning_effort = "high"/);
   assert.match(toml, /developer_instructions = """/);
 


### PR DESCRIPTION
Codex host mapping bumped from gpt-5.5 to the GPT-5.6 generation. CLAUDE.md + AGENTS.md make explicit that framer/scout/eye run on the frontier model and hand on the builder — the pipeline already embodies plan-on-frontier / build-on-efficient.