### PR TITLE
chore: release v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
   "owner": {
     "name": "3x-haust"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "plugins": [
     {
       "name": "omd",
       "description": "The design cognition loop: doubt the brief, measure real references (type and motion included), build once, look at the render, reframe. Plus a deterministic slop linter and a de-AI copy pass.",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "author": {
         "name": "3x-haust"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omd",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem. Ships a slop linter that makes 'looks AI-generated' a checkable claim.",
   "author": {
     "name": "3x-haust",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Design cognition loop for Codex and Claude Code — frame, diverge, see, reframe",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Everything merged since v0.11.0: the 32-tell taxonomy folded in as the project's own, structured release notes, model-role convention (AGENTS.md/CLAUDE.md, GPT-5.6 mapping), the general visual-target loop, the design contract with first-class interaction states, and Codex first-class pack resolution.