### PR TITLE
fix: release notes list real PRs + Codex README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2   # need HEAD~1 to detect the version change
+          fetch-depth: 0    # full history so git log can resolve any tag date
+          fetch-tags: true  # fetch all tags (needed by release-notes tag-date lookup)
 
       - uses: actions/setup-node@v4
         with:

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,14 @@ Claude Code에서:
 
 스킬은 `omd:ultradesign`, `omd:scout`처럼 네임스페이스가 붙는다. Node 22.18 이상 필요. 첫 `omd render`가 Playwright로 headless Chromium을 알아서 설치한다.
 
+### Codex
+
+같은 플러그인이 Codex(GPT-5.6 세대)에서도 동작한다. 에이전트는 TOML 파일(`dist/codex/agents/`)로, 스킬은 `dist/codex/skills/` 아래로 배포되며, `.mcp.json`이 chrome-devtools 서버를 연결한다. `omd` CLI는 두 호스트에서 동일하다 — `omd check`, `omd render`, `omd pack` 등 모든 명령이 세션이 어디서 실행되든 같은 방식으로 작동한다.
+
+Codex에서 스킬 접두사는 `/` 대신 `$`다: `$omd:ultradesign`, `$omd:scout`, `$omd:critique`, `$omd:humanize`, `$omd:coach`. 에이전트 — `omd-framer`, `omd-scout`, `omd-hand`, `omd-eye` — 는 `adapters/tool-map.json`을 통해 GPT-5.6 세대로 해석된다(오케스트레이션·리뷰는 Sol, 정밀 편집은 Terra xhigh).
+
+**Codex 설치.** `omd install` CLI는 파일을 `~/.codex/agents/`와 `~/.codex/skills/`에 직접 복사하고 `~/.codex/config.toml`을 패치한다 — Claude와 동일한 단일 명령 설치 경로다. 아직 검증되지 않은 부분은 Codex 마켓플레이스 흐름이다: 마켓플레이스가 실제 세션에서 `dist/codex/.codex-plugin/plugin.json`, `skills/`, `agents/`를 어떻게 발견하고 로드하는지는 실제 마켓플레이스 인스턴스에서 테스트된 바 없다. 직접 복사 설치 경로(`omd install`)는 검증됐고, 마켓플레이스 경로는 실 환경 검증이 남아 있다.
+
 ### 설치 확인
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ In Claude Code:
 
 Skills appear namespaced as `omd:ultradesign`, `omd:scout`, and so on. Requires Node ≥ 22.18; the first `omd render` installs headless Chromium via Playwright on its own.
 
+### Codex
+
+The same plugin runs on Codex (GPT-5.6 generation). Agents ship as TOML files (`dist/codex/agents/`) and skills under `dist/codex/skills/`; an `.mcp.json` wires up the chrome-devtools server. The `omd` CLI is identical on both hosts — `omd check`, `omd render`, `omd pack`, and so on behave the same way regardless of where the session runs.
+
+Skills on Codex use `$` rather than `/` as their prefix: `$omd:ultradesign`, `$omd:scout`, `$omd:critique`, `$omd:humanize`, `$omd:coach`. The agents — `omd-framer`, `omd-scout`, `omd-hand`, `omd-eye` — resolve to the GPT-5.6 generation (Sol for orchestration and review, Terra xhigh for precise edits) via `adapters/tool-map.json`.
+
+**Installing on Codex.** The `omd install` CLI copies files directly into `~/.codex/agents/` and `~/.codex/skills/` and patches `~/.codex/config.toml` — the same one-command install path as Claude. What remains unverified end-to-end is the Codex marketplace flow: how the marketplace discovers and loads `dist/codex/.codex-plugin/plugin.json`, `skills/`, and `agents/` during a live session has not been tested against a running marketplace instance. The direct-copy install path (`omd install`) has been verified; the marketplace path is pending live validation.
+
 ### Verify it worked
 
 ```bash

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -14,6 +14,7 @@ import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const REPO = 'https://github.com/3x-haust/oh-my-design';
+const OWNER_REPO = '3x-haust/oh-my-design';
 
 export interface PrEntry {
   number: number;
@@ -91,10 +92,34 @@ function getPrevTag(explicit: string | undefined): string {
   return tag || 'v0.0.0';
 }
 
+function resolveTagDate(prevTag: string): string {
+  // Primary: local git history (works with full-depth clones and local runs)
+  const gitDate = exec('git', ['log', '-1', '--format=%aI', prevTag]);
+  if (gitDate) return gitDate;
+
+  // Fallback: GitHub releases API (works in CI even when git history is
+  // shallow, as long as the tag corresponds to a published release)
+  const releaseDate = exec('gh', [
+    'api', `repos/${OWNER_REPO}/releases/tags/${prevTag}`,
+    '--jq', '.published_at',
+  ]);
+  if (releaseDate && releaseDate !== 'null') return releaseDate;
+
+  // Both paths failed — error visibly rather than returning an empty PR list
+  process.stderr.write(
+    `error: could not resolve a commit date for tag ${prevTag}.\n` +
+    `  Tried: git log -1 --format=%aI ${prevTag}  (returned empty)\n` +
+    `  Tried: gh api repos/${OWNER_REPO}/releases/tags/${prevTag}  (returned empty)\n` +
+    `Ensure the tag exists locally (fetch-depth: 0 + fetch-tags: true) or\n` +
+    `that the tag corresponds to a published GitHub release.\n`,
+  );
+  process.exit(1);
+}
+
 function getMergedPrsSince(prevTag: string): PrEntry[] {
-  // Resolve the tag to a commit date so we can filter PRs merged after it
-  const tagDate = exec('git', ['log', '-1', '--format=%aI', prevTag]);
-  if (!tagDate) return [];
+  // Resolve the tag to a commit date so we can filter PRs merged after it.
+  // resolveTagDate() either returns a valid ISO-8601 date string or exits.
+  const tagDate = resolveTagDate(prevTag);
 
   const raw = exec('gh', [
     'pr', 'list',


### PR DESCRIPTION
Root-causes the empty release notes (shallow checkout broke tag-date resolution) and documents the now-first-class Codex flavor in both READMEs.