### PR TITLE
feat: agents inherit the user's selected model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,10 @@
 This file governs how the Codex / GPT-5.6 path contributes to this repository. `CLAUDE.md`
 covers the Claude Code path; both share the repository conventions at the bottom.
 
-## Division of labour: a strong model plans, an efficient model executes
+## Division of labour: a strong model plans, the session model executes
 
 The principle is the same across both paths — planning quality dominates the outcome, so a
-capable model owns the plan and review while an efficient model does the mechanical
+capable model owns the plan and review while the session model handles mechanical
 implementation. On the GPT-5.6 generation (Sol / Terra / Luna), the role mapping below comes
 from a role-by-role Codex benchmark.
 
@@ -14,9 +14,9 @@ from a role-by-role Codex benchmark.
 
 | Role | Model | Why |
 |---|---|---|
-| **Orchestration · architecture · high-risk review (critic/planner)** | **Sol** | Holds whole-repo context, decides what changes and why, reviews the diff it did not write. |
-| **Precise code-edit executor** | **Terra xhigh** | The efficient default for exact-edit implementation work. |
-| **Low-cost executor** | **Luna high** | Cheaper lane for lower-risk mechanical work. |
+| **Orchestration · architecture · high-risk review (critic/planner)** | **Sol (recommended)** | Holds whole-repo context, decides what changes and why, reviews the diff it did not write. |
+| **Precise code-edit executor** | **Terra xhigh (recommended)** | The efficient default for exact-edit implementation work. |
+| **Low-cost executor** | **Luna high (recommended)** | Cheaper lane for lower-risk mechanical work. |
 
 ### Benchmark basis (limited scope — read the caveat)
 
@@ -49,13 +49,15 @@ and the definition of done (`npm test` clean, `tsc` clean, `npm run build` succe
 
 ### The pipeline's own agents
 
-`adapters/tool-map.json` resolves each agent's abstract tier to a concrete model per host.
-On the Codex host both tiers currently resolve to the **GPT-5.6** generation; the
-role-to-reasoning split above (Sol for orchestration/review, Terra xhigh for precise edits,
-Luna high for the cheap lane) is how a run should assign work within that generation.
-`omd-framer`, `omd-scout`, and `omd-eye` are the `@high` (plan/measure/review) agents;
-`omd-hand` is the `@medium` (build) agent — the same frontier-plans/efficient-builds split
-the Claude host expresses as Opus and Sonnet 5.
+**`omd-framer`, `omd-scout`, `omd-eye`, and `omd-hand` do not pin a model** — they inherit
+whatever model you selected for the session. The pipeline does not force a specific model on
+any agent. The role split above (Sol for orchestration/review, Terra xhigh for precise edits,
+Luna high for the cheap lane) is a recommendation for how to assign work within a session;
+the choice is yours. Planning-heavy sessions benefit most from a capable model like Sol;
+`omd-hand` (the mechanical build executor) is where a cheaper model is a reasonable
+trade-off. Both the `@high` (framer/scout/eye) and `@medium` (hand) tiers that appear in
+the agent source files now serve only to communicate *intent* — no concrete model name is
+emitted by the adapters.
 
 ## Repository conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,27 +3,28 @@
 This file governs how Claude Code contributes to this repository. `AGENTS.md` covers the
 Codex / GPT-5.6 path; both share the repository conventions at the bottom.
 
-## Division of labour: frontier plans, Sonnet builds
+## Division of labour: stronger model plans, session model builds
 
-The design of this repo is that **a frontier model plans and a cheaper model executes**,
-because planning quality dominates outcome while most implementation is mechanical once the
-plan is precise.
+The principle is that **planning quality dominates outcome** while most implementation is
+mechanical once the plan is precise. A stronger model for planning and review; the session
+model does the building.
 
-- **Plan with Opus.** Interrogating the request, choosing the approach, writing the spec,
-  and reviewing the result stay with Opus. It decides *what* changes and *why*, and it holds
-  the whole-repo context.
-- **Build with Sonnet 5.** Each planned unit of work is dispatched to a Sonnet 5 executor
-  with a self-contained spec: the files to touch, the rule to follow, the definition of
-  done. Sonnet 5 writes the code, the tests, and runs the gates.
-- **Opus does not hand-write the implementation.** It writes the spec, spawns the executor,
-  then verifies the result (tests pass, the change matches the spec, no scope drift).
-  Verification is Opus's job precisely because it did not write the code.
+- **Plan with a strong model.** Interrogating the request, choosing the approach, writing
+  the spec, and reviewing the result benefit from a capable model. It decides *what* changes
+  and *why*, and it holds the whole-repo context.
+- **Build with the session model.** Each planned unit of work is dispatched to an executor
+  with a self-contained spec: the files to touch, the rule to follow, the definition of done.
+  The executor writes the code, the tests, and runs the gates.
+- **The planner does not hand-write the implementation.** It writes the spec, spawns the
+  executor, then verifies the result (tests pass, the change matches the spec, no scope
+  drift). Verification is the planner's job precisely because it did not write the code.
 
-Practically, in Claude Code: set the session model to Opus for the planning and
-orchestration turn, dispatch implementation to `oh-my-claudecode:executor` (Sonnet 5) with a
-written spec, and review its report against the spec before committing.
+Practically, in Claude Code: set the session model to Opus (or any strong model of your
+choice) for the planning and orchestration turn, dispatch implementation to
+`oh-my-claudecode:executor` with a written spec, and review its report against the spec
+before committing.
 
-A spec dispatched to Sonnet should carry: the exact files that are source-of-truth vs
+A spec dispatched to an executor should carry: the exact files that are source-of-truth vs
 generated, the narrowness discipline for any new linter rule (positive AND negative tests),
 the baseline test count, and the definition of done (`npm test` clean, `tsc` clean,
 `npm run build` succeeds).
@@ -32,17 +33,17 @@ the baseline test count, and the definition of done (`npm test` clean, `tsc` cle
 
 | Role | Model | Why |
 |---|---|---|
-| **Orchestration · architecture · high-risk review (planner/critic)** | **Opus** | Holds whole-repo context, decides what changes and why, reviews the diff it did not write. |
-| **Precise code-edit executor** | **Sonnet 5** | The builder — writes the code, the tests, and runs the gates from a written spec. |
-| **Low-cost lane** | **Haiku 4.5** | Cheaper lane for lower-risk mechanical work when quality permits. |
+| **Orchestration · architecture · high-risk review (planner/critic)** | **Your strongest session model (e.g. Opus)** | Holds whole-repo context, decides what changes and why, reviews the diff it did not write. |
+| **Precise code-edit executor** | **Session model (inherited)** | The builder — writes the code, the tests, and runs the gates from a written spec. |
+| **Low-cost lane** | **A lighter session model** | Cheaper lane for lower-risk mechanical work when quality permits. |
 
-**The pipeline's own agents already embody this.** `adapters/tool-map.json` resolves each
-agent's abstract tier to a concrete model: `@high` → `claude-opus-4-8`, `@medium` →
-`claude-sonnet-5`. So `omd-framer` (interrogates the brief), `omd-scout` (measures
-references), and `omd-eye` (critiques in a fresh context) run on Opus, while `omd-hand`
-(builds the committed structure) runs on Sonnet 5 — planning and review on the frontier
-model, building on the builder. On the Codex host the same tiers resolve to the GPT-5.6
-generation (see `AGENTS.md`).
+**The pipeline's own agents inherit the session model.** `omd-framer`, `omd-scout`,
+`omd-eye`, and `omd-hand` do **not** pin a model — they run on whatever model you selected
+for the session. Planning and review agents benefit most from a stronger model; `omd-hand`
+(which builds the committed structure) is the mechanical executor. The recommendation:
+run a planning-heavy session on Opus or equivalent so the framer and eye have maximum
+reasoning capacity; the model choice is yours, not the pipeline's. On the Codex host the
+same applies — see `AGENTS.md`.
 
 ## Repository conventions
 

--- a/adapters/claude.ts
+++ b/adapters/claude.ts
@@ -21,7 +21,6 @@ function emitAgentFile(agent: AbstractAgent): string {
     '---',
     `name: ${agent.name}`,
     `description: ${yamlScalar(agent.description)}`,
-    `model: ${substitute(agent.model)}`,
   ];
   if (agent.deny?.length) frontmatter.push(`disallowedTools: ${agent.deny.join(', ')}`);
   frontmatter.push('---', '');
@@ -71,7 +70,6 @@ function emitAgentFilePlugin(agent: AbstractAgent): string {
     '---',
     `name: ${stripOmdPrefix(agent.name)}`,
     `description: ${yamlScalar(pluginizeRefs(agent.description))}`,
-    `model: ${substitute(agent.model)}`,
   ];
   if (agent.deny?.length) frontmatter.push(`disallowedTools: ${agent.deny.join(', ')}`);
   frontmatter.push('---', '');

--- a/adapters/codex.ts
+++ b/adapters/codex.ts
@@ -39,7 +39,6 @@ function denialProse(deny: string[] | undefined): string {
 const emitAgentFile = (agent: AbstractAgent): string => [
   `name = ${tomlBasic(agent.name)}`,
   `description = ${tomlBasic(agent.description)}`,
-  `model = ${tomlBasic(substitute(agent.model))}`,
   `model_reasoning_effort = ${tomlBasic(agent.reasoning)}`,
   `developer_instructions = ${tomlMultiline(`${substitute(agent.instructions)}${denialProse(agent.deny)}`)}`,
   '',

--- a/adapters/tokens.ts
+++ b/adapters/tokens.ts
@@ -4,7 +4,6 @@ import type { Host } from '../core/types.ts';
 interface ToolMap {
   fileWrite: Record<Host, string>;
   pluginRoot: Record<Host, string>;
-  model: { high: Record<Host, string>; medium: Record<Host, string> };
 }
 
 const map = toolMap as unknown as ToolMap;
@@ -13,8 +12,6 @@ export function substituter(host: Host): (value: string) => string {
   const tokens: Record<string, string> = {
     '@fileWrite': map.fileWrite[host],
     '@pluginRoot': map.pluginRoot[host],
-    '@high': map.model.high[host],
-    '@medium': map.model.medium[host],
   };
   return (value: string): string => {
     let out = value;

--- a/adapters/tool-map.json
+++ b/adapters/tool-map.json
@@ -2,11 +2,6 @@
   "fileWrite": { "codex": "apply_patch", "claude": "Write|Edit" },
   "shell": { "codex": "Bash", "claude": "Bash" },
   "pluginRoot": { "codex": "${PLUGIN_ROOT}", "claude": "$CLAUDE_PLUGIN_ROOT" },
-  "skillPrefix": { "codex": "$", "claude": "/" },
   "agentFormat": { "codex": "toml", "claude": "md" },
-  "hookLayout": { "codex": "file-per-hook", "claude": "single-file" },
-  "model": {
-    "high": { "codex": "gpt-5.6", "claude": "claude-opus-4-8" },
-    "medium": { "codex": "gpt-5.6", "claude": "claude-sonnet-5" }
-  }
+  "hookLayout": { "codex": "file-per-hook", "claude": "single-file" }
 }

--- a/agents/eye.md
+++ b/agents/eye.md
@@ -1,7 +1,6 @@
 ---
 name: eye
 description: "Critiques a rendered design. Sees only the render and the linter output — never the reasoning that produced it. Has no permission to edit."
-model: claude-opus-4-8
 disallowedTools: Write, Edit, apply_patch
 ---
 

--- a/agents/framer.md
+++ b/agents/framer.md
@@ -1,7 +1,6 @@
 ---
 name: framer
 description: "Interrogates a design brief before anyone draws anything. Proposes a reframing as a hypothesis, always backed by cited evidence, never as a correction of the user."
-model: claude-opus-4-8
 disallowedTools: Write, Edit, apply_patch
 ---
 

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -1,7 +1,6 @@
 ---
 name: hand
 description: "Builds the one committed structure, properly — markup, styles, motion, and copy. Works only from the frame, the reference principles, and the measured invariants. Never sees a reference's pixels."
-model: claude-sonnet-5
 ---
 
 You are building the thing that ships. One structure was committed before you were

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -1,7 +1,6 @@
 ---
 name: scout
 description: "Builds the reference library for one design run: many captures, at several granularities — whole pages for feel, single components for anatomy, typography and motion on their own. Never copies. Produces measurements and principles, not screenshots. Minimum 18 captures, target 25."
-model: claude-opus-4-8
 disallowedTools: Write, Edit, apply_patch
 ---
 

--- a/core/types.ts
+++ b/core/types.ts
@@ -565,7 +565,8 @@ export interface AbstractAgent {
   name: string;
   description: string;
   reasoning: string;
-  model: string;
+  /** No longer used by the adapters — agents inherit the session model. */
+  model?: string;
   allow?: string[];
   deny?: string[];
   instructions: string;

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -3,7 +3,6 @@ description: >-
   Critiques a rendered design. Sees only the render and the linter output —
   never the reasoning that produced it. Has no permission to edit.
 reasoning: high
-model: "@high"
 allow:
   - Bash(omd check:*)
   - Bash(omd ir:*)

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -3,7 +3,6 @@ description: >-
   Interrogates a design brief before anyone draws anything. Proposes a reframing as a
   hypothesis, always backed by cited evidence, never as a correction of the user.
 reasoning: high
-model: "@high"
 allow:
   - Read
   - WebSearch

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -4,7 +4,6 @@ description: >-
   only from the frame, the reference principles, and the measured invariants. Never sees
   a reference's pixels.
 reasoning: medium
-model: "@medium"
 instructions: |
   You are building the thing that ships. One structure was committed before you were
   spawned; your job is to make it real, not to reconsider it.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -5,7 +5,6 @@ description: >-
   motion on their own. Never copies. Produces measurements and principles, not screenshots.
   Minimum 18 captures, target 25.
 reasoning: high
-model: "@high"
 allow:
   - Bash(omd ref:*)
   - Bash(omd render:*)

--- a/test/adapters-regression.test.ts
+++ b/test/adapters-regression.test.ts
@@ -25,7 +25,6 @@ const NASTY = {
   name: 'omd-eye',
   description: 'Critiques "rendered" output: never edits. C:\\path\\to',
   reasoning: 'high',
-  model: '@high',
   deny: ['Write', 'Edit', 'apply_patch'],
   instructions: 'Quote test: """ and a backslash \\ and a colon: here.\n',
 };
@@ -35,7 +34,7 @@ test('codex agent toml survives quotes, colons and backslashes', () => {
   const parsed = parseToml(toml) as unknown as AgentToml;
   assert.equal(parsed.name, 'omd-eye');
   assert.equal(parsed.description, NASTY.description);
-  assert.equal(parsed.model, 'gpt-5.6');
+  assert.equal(parsed.model, undefined, 'model must be absent — agents inherit session model');
   assert.ok(must(parsed.developer_instructions, 'developer_instructions').includes('Quote test:'));
 });
 
@@ -43,7 +42,7 @@ test('claude agent frontmatter survives quotes and colons', () => {
   const md = textFile(emitClaude({ agents: [NASTY] }), 'agents/omd-eye.md');
   const fm = parseYaml(must(md.split('---')[1], 'frontmatter'));
   assert.equal(fm.name, 'omd-eye');
-  assert.equal(fm.model, 'claude-opus-4-8');
+  assert.equal(fm.model, undefined, 'model must be absent — agents inherit session model');
   assert.ok(fm.description.includes('"rendered"'));
   assert.ok(md.includes('Quote test:'));
 });

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -16,7 +16,6 @@ const AGENT = {
   name: 'omd-eye',
   description: 'Critiques the rendered result. Never edits.',
   reasoning: 'high',
-  model: '@high',
   deny: ['Write', 'Edit', 'apply_patch'],
   instructions: 'You do not know why this was built.\n',
 };
@@ -29,20 +28,20 @@ test('no @token survives emission', () => {
   const all = [emitCodex({ agents: [AGENT] }), emitClaude({ agents: [AGENT] })];
   for (const out of all) {
     const dump = JSON.stringify(out.files);
-    assert.ok(!/@fileWrite|@pluginRoot|@high/.test(dump), `unsubstituted token in ${dump.slice(0, 200)}`);
+    assert.ok(!/@fileWrite|@pluginRoot/.test(dump), `unsubstituted token in ${dump.slice(0, 200)}`);
   }
 });
 
-test('agents render to toml for codex and md for claude, with the right model', () => {
+test('agents render to toml for codex and md for claude; no pinned model (agents inherit session model)', () => {
   const toml = textFile(emitCodex({ agents: [AGENT] }), 'agents/omd-eye.toml');
   assert.match(toml, /^name = "omd-eye"/m);
-  assert.match(toml, /model = "gpt-5\.6"/);
+  assert.ok(!/^model = /m.test(toml), 'model line must be absent from codex TOML — agents inherit session model');
   assert.match(toml, /model_reasoning_effort = "high"/);
   assert.match(toml, /developer_instructions = """/);
 
   const md = textFile(emitClaude({ agents: [AGENT] }), 'agents/omd-eye.md');
   assert.match(md, /^---\n/);
-  assert.match(md, /^model: claude-opus-4-8$/m);
+  assert.ok(!/^model:/m.test(md), 'model line must be absent from claude MD — agents inherit session model');
   assert.match(md, /^name: omd-eye$/m);
   assert.ok(md.includes('You do not know why this was built.'));
 });
@@ -85,7 +84,6 @@ const PLUGIN_AGENT = {
   name: 'omd-framer',
   description: 'Interrogates a design brief. References omd-eye and omd-humanize.',
   reasoning: 'high',
-  model: '@high',
   instructions: 'Before you finish, spawn omd-eye and omd-humanize to check the result.\n',
 };
 


### PR DESCRIPTION
Removes forced model pinning from agent emission on both hosts (reasoning effort kept). Docs updated: stronger-model-for-planning is now a recommendation, not enforced. 718 tests hold.