### PR TITLE
feat: UX harness — extractor widening, below-fold + keyboard rules, frame UX artifact

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -157,8 +157,8 @@ omd doctor
 | 계열 | 잡는 것 |
 | --- | --- |
 | `MOTION-*` | `prefers-reduced-motion` 없는 애니메이션, 레이아웃 속성 스래시, 균일한 500ms ease-in-out 시그니처, 스펙이 약속했는데 렌더에 없는 모션 |
-| `UX-*` | 한 화면에서 두 버튼이 동시에 최상위를 주장 |
-| `DESIGN-*` | 필수 섹션이 빠진 `.omd/design.md`, 에러 상태 어포던스가 없는 폼 |
+| `UX-*` | 한 화면에서 두 버튼이 동시에 최상위를 주장; 모바일 뷰포트에서 인터랙티브 컨트롤 전체가 폴드 아래에 있음; 모든 인터랙티브 요소에 `tabindex="-1"` (키보드 경로 없음); 프레임 UX 심문 미완료 (`FRAME-UX-INCOMPLETE`) |
+| `DESIGN-*` | 필수 섹션이 빠진 `.omd/design.md`, 에러 상태 어포던스가 없는 폼 (클래스명, 텍스트 카피, `role=alert`, `aria-invalid`) |
 | `ATTR-*` | `.omd/attribution.md`에 출처 없이 실린 토큰 그룹 |
 | `SITE-*` | 페이지 간 드리프트. 한 페이지는 4단 타입 스케일, 다른 페이지는 6단 (`omd check --site`) |
 | `FOCUS-*` | 눈에 보이는 포커스 표시가 없는 탭 스톱. 라이브로 프로브 |

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Beyond slop, the same engine audits what a prompt alone cannot enforce:
 | Family | Catches |
 | --- | --- |
 | `MOTION-*` | Animation with no `prefers-reduced-motion`, layout-property thrash, the uniform 500ms-ease-in-out signature, a spec that promises motion the render never shows |
-| `UX-*` | Two buttons both claiming top billing on one screen |
-| `DESIGN-*` | A `.omd/design.md` missing required sections; a form with no error-state affordance |
+| `UX-*` | Two buttons both claiming top billing on one screen; the only interactive control is entirely below the fold at mobile viewport; every interactive element has `tabindex="-1"` (no keyboard path); frame not UX-interrogated (`FRAME-UX-INCOMPLETE`) |
+| `DESIGN-*` | A `.omd/design.md` missing required sections; a form with no error-state affordance (class name, text copy, `role=alert`, or `aria-invalid`) |
 | `ATTR-*` | Token groups shipped without a source in `.omd/attribution.md` |
 | `SITE-*` | Cross-page drift: one page on a 4-step type scale, another on 6 (`omd check --site`) |
 | `FOCUS-*` | Tab stops with no visible focus indicator, probed live |

--- a/agents/framer.md
+++ b/agents/framer.md
@@ -51,7 +51,17 @@ A reframing that costs nothing is not a reframing; it is a restatement.
 
 ## How you finish
 
-    omd frame set --problem "..." --reframe "..." --why "<citation>"
+    omd frame set \
+      --problem "..." \
+      --reframe "..." \
+      --why "<citation>" \
+      --task "<one sentence: what task the user arrives with>" \
+      --frequent-action "<one sentence: most frequent action on the primary screen>" \
+      --costliest-error "<one sentence: costliest error and the recovery path>"
+
+All six flags are required. The three UX flags become structured fields in the frame
+record; `omd check` will emit FRAME-UX-INCOMPLETE if any of them is missing. An answer
+of "unknown — open question" is acceptable and honest; silence is not.
 
 Write the record in English, whatever language the brief arrived in. Everything under
 `.omd/` is an engineering artifact read by later runs and later tools; the user's

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -12,6 +12,7 @@ import { checkAttribution } from '../core/rules/attribution.ts';
 import { checkMotionSpec } from '../core/rules/motion-spec.ts';
 import { discoverEvidence, generateDesignMd, validateDesignMd } from '../core/design/index.ts';
 import { checkInteractionStates } from '../core/design/interaction-states.ts';
+import { checkFrameUx } from '../core/frame/check-ux.ts';
 import type { Category, EnergyCurve, Layer, RawIr, Violation } from '../core/types.ts';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -50,10 +51,22 @@ interface Opts {
   target?: string;
   /** Validate design.md sections rather than discover/generate (`omd design --check`). */
   check?: boolean;
+  /** UX anchor: what task does the user arrive with? (`omd frame set --task "..."`) */
+  task?: string;
+  /** UX anchor: most frequent action on the primary screen. (`omd frame set --frequent-action "..."`) */
+  frequentAction?: string;
+  /** UX anchor: costliest error and its recovery path. (`omd frame set --costliest-error "..."`) */
+  costliestError?: string;
 }
 
 const FLAGS = new Set(['json', 'no-log', 'image', 'filmstrip', 'from-user', 'blueprint', 'fresh', 'check']);
-const ALIASES: Record<string, keyof Opts> = { o: 'out', 'no-log': 'noLog', 'from-user': 'fromUser' };
+const ALIASES: Record<string, keyof Opts> = {
+  o: 'out',
+  'no-log': 'noLog',
+  'from-user': 'fromUser',
+  'frequent-action': 'frequentAction',
+  'costliest-error': 'costliestError',
+};
 
 function parseArgs(args: string[]): Opts {
   const opts: Opts = { _: [] };
@@ -293,11 +306,24 @@ async function cmdCheck(opts: Opts): Promise<never> {
   const interactionViolations: Violation[] = checkInteractionStates(ir)
     .filter((v) => (!categories || categories.includes(v.category)) && (!layers || layers.includes(v.layer)));
 
+  // Frame UX audit: only active when .omd/frame.md exists. Checks that the three UX
+  // anchor questions (task, frequent-action, costliest-error) have been answered.
+  // A bare project without frame.md is not nagged — but a frame that skipped the
+  // interrogation is flagged with FRAME-UX-INCOMPLETE.
+  const frameUxViolations: Violation[] = [];
+  const frameMdPath = join(process.cwd(), '.omd', 'frame.md');
+  if (existsSync(frameMdPath)) {
+    frameUxViolations.push(
+      ...checkFrameUx(process.cwd())
+        .filter((v) => (!categories || categories.includes(v.category)) && (!layers || layers.includes(v.layer))),
+    );
+  }
+
   // Code-unit order, not localeCompare — same determinism guarantee as check() itself.
   const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
   const combined: Violation[] = [
     ...violations, ...leaks, ...attrViolations, ...motionSpecViolations,
-    ...designViolations, ...interactionViolations,
+    ...designViolations, ...interactionViolations, ...frameUxViolations,
   ].sort((a, b) => cmp(a.path, b.path) || cmp(a.id, b.id));
 
   if (opts.json) process.stdout.write(JSON.stringify(combined));
@@ -1227,6 +1253,7 @@ function usage(): never {
     + '\n'
     + '  frame show\n'
     + '  frame set --problem P --reframe R --why EVIDENCE\n'
+    + '            [--task T --frequent-action A --costliest-error E]\n'
     + '  frame reframe --to "..." --because "what the render revealed"\n'
     + '  frame generator --set "metaphor"\n'
     + '\n'
@@ -1287,6 +1314,9 @@ async function main(): Promise<never> {
         problem: opts.problem ?? '',
         reframe: opts.reframe ?? '',
         ...(opts.why ? { why: opts.why } : {}),
+        ...(opts.task ? { uxTask: opts.task } : {}),
+        ...(opts.frequentAction ? { uxFrequentAction: opts.frequentAction } : {}),
+        ...(opts.costliestError ? { uxCostliestError: opts.costliestError } : {}),
       });
       console.log(path);
       process.exit(0);

--- a/core/design/interaction-states.ts
+++ b/core/design/interaction-states.ts
@@ -1,4 +1,4 @@
-import type { Ir, Violation } from '../types.ts';
+import type { Ir, Node, Violation } from '../types.ts';
 
 /**
  * Deterministic interaction-state rules over the IR.
@@ -24,11 +24,17 @@ import type { Ir, Violation } from '../types.ts';
  *   Detection signals for error affordance (OR — any one suffices):
  *     - A node whose name contains ".error" or ".invalid" (class name evidence)
  *     - A text node whose text contains "error" / "오류" / "잘못" (copy evidence)
+ *     - A node with role="alert" (ARIA error container — the canonical accessible pattern)
+ *     - A node with aria-invalid="true" (ARIA field-level error signal)
  *
  *   False-positive mitigation: the rule fires only when form inputs are present AND
  *   no error affordance exists at all — not when an affordance exists but looks wrong.
  *   A div.error-state with empty text still counts as present; we are checking
  *   structure, not copy quality.
+ *
+ *   The ARIA signals (role=alert, aria-invalid) improve precision over class-name-only
+ *   detection: a page that correctly implements ARIA error patterns without ".error"
+ *   class names no longer produces a false positive.
  *
  * ── What stays prompt-only and why ───────────────────────────────────────────
  *
@@ -86,13 +92,23 @@ function isFormInput(name: string, interactive: boolean): boolean {
 
 /**
  * Returns true when a node carries a structural signal that an error state exists:
- *   - Class name contains "error" or "invalid" (structural evidence: the designer
- *     created an error-styled element, even if currently hidden or empty)
- *   - Text content contains common error vocabulary (copy evidence: error message text)
+ *   - Class name contains "error" or "invalid" (structural evidence)
+ *   - Text content contains common error vocabulary (copy evidence)
+ *   - node.role === 'alert' (ARIA error container — the canonical accessible pattern)
+ *   - node.ariaInvalid === true (ARIA field-level error signal)
  *
  * This is an OR check — any one signal suffices to suppress the violation.
+ * The ARIA signals were added to reduce false positives: pages that correctly use
+ * role=alert or aria-invalid without ".error" class names no longer trigger.
  */
-function hasErrorAffordance(name: string, text: string | undefined): boolean {
+function hasErrorAffordance(node: Node): boolean {
+  const { name, text, role, ariaInvalid } = node;
+
+  // ARIA evidence: role=alert is the canonical container for live error messages;
+  // aria-invalid=true is the field-level signal that a value failed validation.
+  if (role === 'alert' || role === 'alertdialog') return true;
+  if (ariaInvalid === true) return true;
+
   // Class-name evidence: "div.error", "span.invalid", "p.error-message", "input.is-invalid"
   const lower = name.toLowerCase();
   if (
@@ -146,7 +162,7 @@ export function checkInteractionStates(ir: Ir): Violation[] {
   const formInputs = ir.nodes.filter((n) => isFormInput(n.name, n.interactive === true));
 
   if (formInputs.length > 0) {
-    const anyError = ir.nodes.some((n) => hasErrorAffordance(n.name, n.text));
+    const anyError = ir.nodes.some((n) => hasErrorAffordance(n));
 
     if (!anyError) {
       // Report against the first input node's path for location context.

--- a/core/frame/check-ux.ts
+++ b/core/frame/check-ux.ts
@@ -1,0 +1,68 @@
+import type { Violation } from '../types.ts';
+import { readFrame } from './index.ts';
+
+/**
+ * Validate that the frame artifact has been fully UX-interrogated.
+ *
+ * FRAME-UX-INCOMPLETE warns when `.omd/frame.md` exists but any of the three
+ * UX anchor questions is unanswered:
+ *   1. uxTask          — what task does the user arrive with?
+ *   2. uxFrequentAction — what is the most frequent action on the primary screen?
+ *   3. uxCostliestError — what is the costliest error, and what is the recovery path?
+ *
+ * These map to the three questions in theory/ux.md §Task-first framing and in
+ * src/agents/framer.agent.yaml. The framer is expected to answer all three and
+ * emit them via `omd frame set --task ... --frequent-action ... --costliest-error ...`.
+ *
+ * ── Scope boundary ───────────────────────────────────────────────────────────
+ * This validator checks that the frame ARTIFACT is complete — that someone answered
+ * the three questions before building. It does NOT verify that the rendered build
+ * actually serves the named task: "does the page fulfil the user's task?" is a fuzzy
+ * semantic judgment that requires the eye agent's task-first walk, not a string check.
+ * Determining task-fulfillment from the IR alone would require reading the page copy,
+ * understanding the user's domain context, and evaluating whether the named task is
+ * achievable — all beyond deterministic measurement.
+ *
+ * What IS deterministic: whether the three fields are present and non-empty in the
+ * frame's YAML frontmatter. A field absent or set to an empty string is a signal that
+ * the framer skipped the question — which theory/ux.md §Task-first framing identifies
+ * as the frame not being done.
+ *
+ * Only called when `.omd/frame.md` exists (the caller guards that).
+ */
+export function checkFrameUx(cwd: string): Violation[] {
+  const frame = readFrame(cwd);
+  if (!frame) return [];
+
+  const missing: string[] = [];
+
+  if (!frame.uxTask || String(frame.uxTask).trim().length === 0) {
+    missing.push('uxTask (--task)');
+  }
+  if (!frame.uxFrequentAction || String(frame.uxFrequentAction).trim().length === 0) {
+    missing.push('uxFrequentAction (--frequent-action)');
+  }
+  if (!frame.uxCostliestError || String(frame.uxCostliestError).trim().length === 0) {
+    missing.push('uxCostliestError (--costliest-error)');
+  }
+
+  if (missing.length === 0) return [];
+
+  return [
+    {
+      id: 'FRAME-UX-INCOMPLETE',
+      severity: 'warn',
+      layer: 1,
+      category: 'ux',
+      nodeId: 'page',
+      path: 'frame',
+      value: missing.join(', '),
+      message:
+        `The frame exists but the following UX anchor question${missing.length === 1 ? ' is' : 's are'} unanswered: `
+        + `${missing.join('; ')}. `
+        + 'A frame that cannot name the costliest error has not been interrogated. '
+        + 'Run `omd frame set --task "..." --frequent-action "..." --costliest-error "..."` to complete it. '
+        + 'See theory/ux.md §Task-first framing.',
+    },
+  ];
+}

--- a/core/frame/write.ts
+++ b/core/frame/write.ts
@@ -14,8 +14,20 @@ export function writeFrame(cwd: string, frontmatter: Record<string, unknown>, bo
 /**
  * Nobody signs this. The `--why` requirement is not a gate on the human — it is a gate on
  * the agent, which will otherwise reframe a brief on a hunch and call the hunch insight.
+ *
+ * The three UX anchor fields (uxTask, uxFrequentAction, uxCostliestError) are optional
+ * here for backward compatibility — old callers that do not supply them produce a frame
+ * that FRAME-UX-INCOMPLETE will flag. The framer.agent.yaml is expected to always supply
+ * all three after answering the UX interrogation questions from theory/ux.md.
  */
-export function writeFrameRecord(cwd: string, opts: { problem: string; reframe: string; why?: string }): string {
+export function writeFrameRecord(cwd: string, opts: {
+  problem: string;
+  reframe: string;
+  why?: string;
+  uxTask?: string;
+  uxFrequentAction?: string;
+  uxCostliestError?: string;
+}): string {
   if (!opts.why || opts.why.trim().length < 10) {
     throw new Error(
       'A reframing without a cited observation is a guess. Pass --why with the review, '
@@ -28,7 +40,12 @@ export function writeFrameRecord(cwd: string, opts: { problem: string; reframe: 
     '## Evidence', '', opts.why.trim(),
   ].join('\n');
 
-  writeFrame(cwd, { why: opts.why.trim(), writtenAt: new Date().toISOString() }, body);
+  const frontmatter: Record<string, unknown> = { why: opts.why.trim(), writtenAt: new Date().toISOString() };
+  if (opts.uxTask?.trim()) frontmatter['uxTask'] = opts.uxTask.trim();
+  if (opts.uxFrequentAction?.trim()) frontmatter['uxFrequentAction'] = opts.uxFrequentAction.trim();
+  if (opts.uxCostliestError?.trim()) frontmatter['uxCostliestError'] = opts.uxCostliestError.trim();
+
+  writeFrame(cwd, frontmatter, body);
   return join(designDir(cwd), 'frame.md');
 }
 

--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -66,6 +66,30 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
   const isInteractive = (el: Element): boolean =>
     INTERACTIVE.has(el.tagName) || el.getAttribute('role') === 'button' || el.hasAttribute('onclick');
 
+  // NATIVELY_FOCUSABLE: elements whose default tabIndex is 0 (in tab order by spec).
+  // <a> without href is NOT focusable by default; <a href="..."> is. We check tabIndex
+  // directly rather than duplicating the browser's focusability rules.
+  const NATIVELY_FOCUSABLE = new Set(['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'SUMMARY', 'DETAILS']);
+
+  /**
+   * Returns the focusable state for an element:
+   *   true  — in the tab order (tabIndex >= 0, either natively or via tabindex attr)
+   *   false — interactive but explicitly removed with tabindex="-1"
+   *   null  — static element, no focusability data to record
+   *
+   * Cannot capture: dynamic tabindex mutations via JS, focus() calls, or CSS :focus-visible
+   * ring visibility (that is measured by the interaction probe in core/render/).
+   */
+  const focusableState = (el: Element): boolean | null => {
+    const htmlEl = el as HTMLElement;
+    const tabIdx = htmlEl.tabIndex;
+    if (tabIdx >= 0) return true;
+    // tabIndex < 0 — only flag as false when the element is otherwise interactive,
+    // so we don't record false on every non-interactive div that has no tabindex.
+    if (isInteractive(el) || NATIVELY_FOCUSABLE.has(el.tagName)) return false;
+    return null;
+  };
+
   const hasOwnText = (el: Element): boolean =>
     Array.from(el.childNodes).some((n) => n.nodeType === 3 && (n.textContent ?? '').trim().length > 0);
 
@@ -128,6 +152,19 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
     if (radius > 0) node.radius = { value: radius, token: nameOf(String(radius)) };
     if (isInteractive(el)) node.interactive = true;
     if (cs.display === 'inline') node.inline = true;
+
+    // Focusability — tab-order membership, one DOM read per node.
+    const fs = focusableState(el);
+    if (fs !== null) node.focusable = fs;
+
+    // Explicit ARIA role attribute. Only the declared attribute value — implicit roles
+    // derived from tag semantics (e.g. <input> → role='textbox') are NOT captured here.
+    const explicitRole = el.getAttribute('role');
+    if (explicitRole) node.role = explicitRole;
+
+    // aria-invalid: present and not "false" → field is in an error state per ARIA spec.
+    const ariaInvalid = el.getAttribute('aria-invalid');
+    if (ariaInvalid && ariaInvalid !== 'false') node.ariaInvalid = true;
 
     if (isText) {
       const family = cs.fontFamily.split(',')[0]?.trim().replace(/^["']|["']$/g, '').toLowerCase();
@@ -287,5 +324,20 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
     }
   }
 
-  return { meta: { source: 'dom', url: location.href }, tokens: tokenByValue, nodes };
+  // Page-level scroll/viewport dimensions. scrollHeight is the total scrollable height
+  // of the document (including content below the fold). viewportHeight is the current
+  // window inner height — together they let rules determine whether elements are above
+  // or below the fold without needing to know the URL or viewport preset.
+  //
+  // Cannot capture: viewport dimensions when the page is rendered inside an iframe
+  // (window.innerHeight reflects the frame, not the outer viewport). The capture is
+  // correct for top-level documents, which is the only case omd check operates on.
+  const scrollHeight = document.documentElement.scrollHeight;
+  const viewportHeight = window.innerHeight;
+
+  return {
+    meta: { source: 'dom', url: location.href, scrollHeight, viewportHeight },
+    tokens: tokenByValue,
+    nodes,
+  };
 }

--- a/core/rules/builtin/ux.yaml
+++ b/core/rules/builtin/ux.yaml
@@ -30,6 +30,79 @@
 # Material Design and Carbon Design System both specify single primary-per-view as an
 # explicit constraint, not a preference.
 
+# UX-ACTION-BELOW-FOLD
+#
+# Fires on the root node when the page has interactive controls but NONE of them are
+# within the first viewport at mobile dimensions. "Within the first viewport" means the
+# element's top edge (box.y) is less than viewportHeight — at least the top of the
+# control is visible without scrolling.
+#
+# Revived from the candidate-dropped list now that dom.ts captures scrollHeight and
+# viewportHeight in ir.meta. The earlier drop reason ("viewport height undefined,
+# threshold unanchored") is eliminated: viewportHeight is the actual window height
+# measured at capture time, so the fold is the real browser fold, not an assumed constant.
+#
+# False-positive guard: "long content pages legitimately push a CTA down."
+# The rule fires ONLY when there is NO interactive element within the first viewport.
+# A page with a nav link at y=20 and a CTA at y=1200 does not fire (nav is interactive
+# and within fold). Only a page where every control — including nav items — is below
+# the fold triggers the rule. That condition is never a deliberate choice; it is always
+# a layout bug or a missed mobile viewport regression.
+#
+# Positive test:  one interactive element at box.y=900 with viewportHeight=812 → fires
+# Negative tests:
+#   — interactive element at box.y=100 (within fold at 812) → silent
+#   — no interactive elements at all                         → silent (when guard)
+#   — interactive at y=900 AND nav at y=0 (two elements)    → silent (nav is in fold)
+#
+# The rule reads ir.meta.viewportHeight (set by dom.ts). On IRs captured without it
+# (before dom.ts was updated) the when condition is false and the rule is silent —
+# backward compatible.
+- id: UX-ACTION-BELOW-FOLD
+  layer: 1
+  category: ux
+  severity: warn
+  when: "node.parent === null && typeof (ir.meta && ir.meta.viewportHeight) === 'number' && ir.nodes.some(n => n.computed.isInteractive)"
+  value: "(() => { const vh = Number(ir.meta.viewportHeight); return ir.nodes.filter(n => n.computed.isInteractive && n.box.y < vh).length; })()"
+  assert: "value > 0"
+  message: "No interactive element is visible within the first viewport (viewportHeight={value}px measured at capture). The primary action is entirely below the fold. Place at least one interactive control — a primary button, a nav item, or a search field — within the first screen of content. See theory/ux.md §Task-first framing."
+
+# UX-NO-KEYBOARD-PATH
+#
+# Fires on the root node when the page has interactive controls but every one of them
+# has been explicitly removed from the tab order with tabindex="-1". A page in this
+# state is not keyboard-navigable: no interactive element is reachable by pressing Tab.
+#
+# Data source: node.focusable captured by dom.ts from el.tabIndex per node.
+#   true  — element is in the tab order (tabIndex >= 0)
+#   false — element is interactive but carries tabindex="-1" (removed)
+#   absent — static element, no focusability data
+#
+# Guard on when: the rule fires only when at least one interactive node has a recorded
+# focusable field. On pages where no focusable data was captured at all (old IRs, or
+# pages where the extractor produced no interactive nodes with focusable set), the when
+# condition is false and the rule is silent — preventing false positives from missing data.
+#
+# Deliberate exemption: pages that implement custom focus management (e.g., a single-page
+# app routed with a focus trap) will use tabindex="-1" on most elements intentionally.
+# This rule fires a warning; override with `omd decision` and document the focus management
+# strategy. A page with zero keyboard-reachable interactive controls is always worth
+# flagging even if the custom management turns out to be correctly implemented.
+#
+# Positive test:  button with focusable:false (tabindex="-1"), no other interactive nodes → fires
+# Negative tests:
+#   — button with focusable:true → silent
+#   — no interactive elements at all → silent (when guard)
+#   — mix: one focusable:false, one focusable:true → silent (one keyboard path exists)
+- id: UX-NO-KEYBOARD-PATH
+  layer: 1
+  category: ux
+  severity: warn
+  when: "node.parent === null && ir.nodes.some(n => n.computed.isInteractive && typeof n.focusable === 'boolean')"
+  value: "ir.nodes.filter(n => n.computed.isInteractive && n.focusable !== false).length"
+  assert: "value > 0"
+  message: "Every interactive control on this page has been removed from the keyboard tab order (tabindex=\"-1\"). Users who navigate by keyboard cannot reach any interactive element. Either remove the tabindex=\"-1\" attribute to restore native focus, or implement and document a custom keyboard focus strategy. WCAG 2.1 §2.1.1 requires all functionality to be keyboard-operable. See theory/ux.md §Accessibility as a UX floor."
+
 # UX-TWO-PRIMARIES
 #
 # Fires on the root node when any parent container has 2+ interactive, button-sized

--- a/core/theory/ux.md
+++ b/core/theory/ux.md
@@ -406,3 +406,71 @@ failure must be a deliberate choice with a recorded reason.
 
 10. **Help when needed**: When the product requires documentation, is it available in
     context at the moment the user needs it — not in a separate page they must find?
+
+---
+
+## Harness enforcement status
+
+The following principles from this file have been converted into deterministic harness
+checks that `omd check` runs on every build. Principles not listed here remain advisory
+— they require human or eye-agent judgment and cannot be reliably measured from the IR.
+
+**Enforced — fires a violation on measurable evidence:**
+
+- §Task-first framing → `UX-TWO-PRIMARIES` (slop): two or more interactive buttons sharing
+  the same authored fill in one container cancel the hierarchy signal. Measurable from
+  node.fill.authored + node.computed.isInteractive + node.box.h + node.parent grouping.
+
+- §Task-first framing → `UX-ACTION-BELOW-FOLD` (ux): the only interactive controls are
+  entirely below the fold at the capture viewport. Measurable from node.box.y vs
+  ir.meta.viewportHeight (recorded by dom.ts at capture time). Guard: silent when any
+  interactive element is within the first viewport, so long-scroll pages with a visible
+  nav do not fire.
+
+- §Accessibility as a UX floor → `UX-NO-KEYBOARD-PATH` (ux): every interactive control has
+  tabindex="-1", making the page unreachable by keyboard. Measurable from node.focusable
+  (recorded by dom.ts from el.tabIndex per node). WCAG 2.1 §2.1.1.
+
+- §Task-first framing (the three anchor questions) → `FRAME-UX-INCOMPLETE` (ux): the frame
+  artifact exists but does not record what task the user arrives with, the most frequent
+  action, or the costliest error. Measurable as field presence in the frame's YAML
+  frontmatter. Scope: artifact completeness only — the harness cannot verify the build
+  serves the named task (that requires the eye agent's task-first walk).
+
+- §Forms: error recovery → `DESIGN-FORM-NO-ERROR` (system): the page has form inputs but
+  no visible error-state affordance. Measurable from node.name class patterns, node.text
+  error vocabulary, node.role === 'alert', and node.ariaInvalid. Strengthened to detect
+  ARIA-correct implementations (role=alert, aria-invalid) that do not use class-name
+  conventions.
+
+**Still advisory — requires human or eye-agent judgment:**
+
+- §Navigation and information architecture: whether a navigation structure matches the
+  user's mental model for the domain. Requires domain knowledge the IR does not contain.
+
+- §Flows: dead ends: whether every reachable state has an exit. Requires simulating user
+  flows across states, not reading the resting DOM.
+
+- §Flows: defaults chosen for the frequent case. Requires knowing the user population's
+  preferences, not the rendered page's current value.
+
+- §Feedback and system status (Doherty Threshold, 400ms): whether every interactive
+  element changes state within 400ms. Requires timing measurements under interaction,
+  not a static IR snapshot.
+
+- §Cognitive load and progressive disclosure: whether secondary actions are visually
+  subordinate to the primary action. Requires semantic understanding of the hierarchy
+  intent, not structural measurement alone.
+
+- §First-run experience and empty states: whether empty states are designed. Requires
+  rendering the page in its empty data state, which the static IR cannot do.
+
+- §The peak-end rule: whether the end of each flow is deliberately designed. Requires
+  task simulation and emotional salience evaluation, not structural measurement.
+
+- §Korean market specifics: whether hover-first patterns are avoided on mobile. Partially
+  covered by WCAG touch-target rules (hit-area.yaml) but interaction-pattern analysis
+  requires the eye agent's task walk.
+
+- Nielsen heuristics 2, 4, 7, 8, 10 (real-world match, consistency, efficiency, minimalism,
+  help): all require semantic content understanding that the IR does not provide.

--- a/core/types.ts
+++ b/core/types.ts
@@ -84,6 +84,40 @@ export interface RawNode {
   clipText?: boolean;
 
   /**
+   * Whether this element is in the document tab order.
+   *
+   * true  — natively focusable tag (a[href], button, input, select, textarea, summary)
+   *         OR tabindex >= 0 — element is reachable by keyboard navigation.
+   * false — element is interactive (has role=button, onclick, or an INTERACTIVE tag) but
+   *         carries tabindex="-1", explicitly removing it from the tab order.
+   * absent — static non-interactive element with no tabindex attribute.
+   *
+   * Cannot capture: dynamic tabindex mutations via JS, focus management via .focus() calls,
+   * CSS :focus-visible visibility (measured separately by the interaction probe in render/).
+   */
+  focusable?: boolean;
+
+  /**
+   * Explicit ARIA role attribute value. Absent when no role="" attribute is set.
+   * Values of interest for rules: 'alert' (error message container), 'alertdialog',
+   * 'button' (non-button element acting as a button).
+   *
+   * Cannot capture: implicit/computed ARIA roles derived from HTML semantics (e.g.
+   * <input type="checkbox"> has an implicit role of 'checkbox'). Only explicit role=
+   * attribute values are recorded here.
+   */
+  role?: string;
+
+  /**
+   * True when aria-invalid is present and not "false". Absent otherwise.
+   * Signals a field that has failed validation per ARIA spec.
+   *
+   * Cannot capture: HTML5 constraint-validation state set via the Constraint Validation
+   * API (:invalid pseudo-class) without a corresponding aria-invalid attribute.
+   */
+  ariaInvalid?: boolean;
+
+  /**
    * Computed backdrop-filter value. Absent when 'none' or not declared.
    * Captured to detect glassmorphism: backdrop-blur combined with a translucent surface,
    * the frozen 2021 Dribbble aesthetic that became the new default.
@@ -171,8 +205,11 @@ export type Layer = 1 | 2;
  * `motion` covers craft defects in animation execution: missing reduced-motion support,
  * layout thrash, uniform rhythm. Separate from `slop` because these are implementation
  * correctness issues, not design-mean convergence failures.
+ * `ux` covers structural UX violations: primary action buried below the fold, no keyboard
+ * path into the interactive controls, frame not interrogated. These are correctness issues
+ * about task structure, not visual mean-convergence, which is why they are their own family.
  */
-export type Category = 'a11y' | 'system' | 'slop' | 'motion';
+export type Category = 'a11y' | 'system' | 'slop' | 'motion' | 'ux';
 
 export interface Rule {
   id: string;
@@ -210,6 +247,20 @@ export interface Frame {
   writtenAt?: string;
   reframedAt?: string;
   body: string;
+
+  /**
+   * UX interrogation answers. Set by `omd frame set --task --frequent-action --costliest-error`.
+   * Backward compatible: frames written before these fields were introduced load without them
+   * (absence is treated as incomplete by FRAME-UX-INCOMPLETE, not as an error).
+   *
+   * Scope boundary: these fields validate that the frame ARTIFACT is complete — that the
+   * three UX questions were answered before building. The harness cannot verify whether the
+   * rendered build actually serves the named task; that requires a human or the eye agent.
+   */
+  uxTask?: string;
+  uxFrequentAction?: string;
+  uxCostliestError?: string;
+
   [key: string]: unknown;
 }
 

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -59,7 +59,17 @@ instructions: |
 
   ## How you finish
 
-      omd frame set --problem "..." --reframe "..." --why "<citation>"
+      omd frame set \
+        --problem "..." \
+        --reframe "..." \
+        --why "<citation>" \
+        --task "<one sentence: what task the user arrives with>" \
+        --frequent-action "<one sentence: most frequent action on the primary screen>" \
+        --costliest-error "<one sentence: costliest error and the recovery path>"
+
+  All six flags are required. The three UX flags become structured fields in the frame
+  record; `omd check` will emit FRAME-UX-INCOMPLETE if any of them is missing. An answer
+  of "unknown — open question" is acceptable and honest; silence is not.
 
   Write the record in English, whatever language the brief arrived in. Everything under
   `.omd/` is an engineering artifact read by later runs and later tools; the user's

--- a/test/design.test.ts
+++ b/test/design.test.ts
@@ -370,6 +370,62 @@ test('non-interactive input-like nodes do not trigger DESIGN-FORM-NO-ERROR', () 
   assert.equal(violations.filter((v) => v.id === 'DESIGN-FORM-NO-ERROR').length, 0);
 });
 
+// ── DESIGN-FORM-NO-ERROR — ARIA signal strengthening ─────────────────────────
+
+test('DESIGN-FORM-NO-ERROR does not fire when role=alert element is present', () => {
+  // role=alert is the canonical ARIA pattern for error message containers;
+  // it should suppress the violation even without a ".error" class name.
+  const input: RawNode = {
+    id: 'n0', name: 'input.email', type: 'FRAME',
+    path: 'form/input.email', parent: null,
+    box: { x: 0, y: 0, w: 300, h: 44 }, children: [], interactive: true,
+  };
+  const alertEl: RawNode = {
+    id: 'n1', name: 'div.live-region', type: 'FRAME',
+    path: 'form/div.live-region', parent: null,
+    box: { x: 0, y: 50, w: 300, h: 24 }, children: [],
+    role: 'alert',
+  };
+  const ir = normalize({ nodes: [input, alertEl] } as RawIr);
+  const violations = checkInteractionStates(ir);
+  assert.equal(violations.filter((v) => v.id === 'DESIGN-FORM-NO-ERROR').length, 0,
+    'role=alert should suppress DESIGN-FORM-NO-ERROR');
+});
+
+test('DESIGN-FORM-NO-ERROR does not fire when ariaInvalid:true is present on a field', () => {
+  // aria-invalid=true signals a field in an error state per ARIA spec;
+  // this pattern should suppress the violation.
+  const input: RawNode = {
+    id: 'n0', name: 'input.email', type: 'FRAME',
+    path: 'form/input.email', parent: null,
+    box: { x: 0, y: 0, w: 300, h: 44 }, children: [], interactive: true,
+    ariaInvalid: true,
+  };
+  const ir = normalize({ nodes: [input] } as RawIr);
+  const violations = checkInteractionStates(ir);
+  assert.equal(violations.filter((v) => v.id === 'DESIGN-FORM-NO-ERROR').length, 0,
+    'ariaInvalid:true on an input should suppress DESIGN-FORM-NO-ERROR');
+});
+
+test('DESIGN-FORM-NO-ERROR fires when form has inputs but only role=button (not alert)', () => {
+  // role=button is not an error affordance signal — only role=alert/alertdialog suppresses
+  const input: RawNode = {
+    id: 'n0', name: 'input.email', type: 'FRAME',
+    path: 'form/input.email', parent: null,
+    box: { x: 0, y: 0, w: 300, h: 44 }, children: [], interactive: true,
+  };
+  const btnEl: RawNode = {
+    id: 'n1', name: 'div.cta', type: 'FRAME',
+    path: 'form/div.cta', parent: null,
+    box: { x: 0, y: 60, w: 120, h: 44 }, children: [],
+    role: 'button',
+  };
+  const ir = normalize({ nodes: [input, btnEl] } as RawIr);
+  const violations = checkInteractionStates(ir);
+  assert.ok(violations.some((v) => v.id === 'DESIGN-FORM-NO-ERROR'),
+    'role=button should not suppress DESIGN-FORM-NO-ERROR');
+});
+
 // ── CLI integration ───────────────────────────────────────────────────────────
 
 test('CLI: omd design creates .omd/design.md in a bare project', () => {

--- a/test/frame-ux.test.ts
+++ b/test/frame-ux.test.ts
@@ -1,0 +1,123 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { stringify } from 'yaml';
+import { checkFrameUx } from '../core/frame/check-ux.ts';
+import { writeFrameRecord } from '../core/frame/write.ts';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-frame-ux-'));
+
+/** Write a frame.md with arbitrary frontmatter directly, bypassing writeFrameRecord
+ *  so we can test incomplete frames (which writeFrameRecord would not produce). */
+function writeRawFrame(cwd: string, frontmatter: Record<string, unknown>, body = 'test body'): void {
+  const omd = join(cwd, '.omd');
+  mkdirSync(omd, { recursive: true });
+  writeFileSync(join(omd, 'frame.md'), `---\n${stringify(frontmatter).trimEnd()}\n---\n\n${body}\n`);
+}
+
+// ── FRAME-UX-INCOMPLETE ───────────────────────────────────────────────────────
+
+test('FRAME-UX-INCOMPLETE does not fire when frame.md does not exist', () => {
+  const cwd = project();
+  const violations = checkFrameUx(cwd);
+  assert.equal(violations.length, 0, 'no frame.md — no violation');
+});
+
+test('FRAME-UX-INCOMPLETE fires when all three UX fields are missing', () => {
+  const cwd = project();
+  writeRawFrame(cwd, { why: 'test evidence here', writtenAt: new Date().toISOString() });
+  const violations = checkFrameUx(cwd);
+  assert.ok(violations.some((v) => v.id === 'FRAME-UX-INCOMPLETE'), 'expected FRAME-UX-INCOMPLETE');
+  const v = violations.find((x) => x.id === 'FRAME-UX-INCOMPLETE')!;
+  // All three fields should be listed in the value
+  assert.ok(String(v.value).includes('uxTask'), 'value should mention uxTask');
+  assert.ok(String(v.value).includes('uxFrequentAction'), 'value should mention uxFrequentAction');
+  assert.ok(String(v.value).includes('uxCostliestError'), 'value should mention uxCostliestError');
+});
+
+test('FRAME-UX-INCOMPLETE fires for each individual missing field', () => {
+  const cwd = project();
+  // Only uxTask is present; the other two are missing
+  writeRawFrame(cwd, {
+    why: 'test evidence here',
+    writtenAt: new Date().toISOString(),
+    uxTask: 'User wants to book a flight',
+  });
+  const violations = checkFrameUx(cwd);
+  assert.ok(violations.some((v) => v.id === 'FRAME-UX-INCOMPLETE'));
+  const v = violations.find((x) => x.id === 'FRAME-UX-INCOMPLETE')!;
+  assert.ok(!String(v.value).includes('uxTask'), 'uxTask is present — should not be in the missing list');
+  assert.ok(String(v.value).includes('uxFrequentAction'), 'uxFrequentAction should be listed as missing');
+  assert.ok(String(v.value).includes('uxCostliestError'), 'uxCostliestError should be listed as missing');
+});
+
+test('FRAME-UX-INCOMPLETE does not fire when all three UX fields are present', () => {
+  const cwd = project();
+  writeRawFrame(cwd, {
+    why: 'test evidence here',
+    writtenAt: new Date().toISOString(),
+    uxTask: 'User wants to book a flight',
+    uxFrequentAction: 'Search for available routes',
+    uxCostliestError: 'Double booking — recovery path: 24h free cancellation',
+  });
+  const violations = checkFrameUx(cwd);
+  assert.equal(violations.length, 0, 'all three fields present — no violation');
+});
+
+test('FRAME-UX-INCOMPLETE fires when a field is present but empty', () => {
+  const cwd = project();
+  writeRawFrame(cwd, {
+    why: 'test evidence here',
+    writtenAt: new Date().toISOString(),
+    uxTask: '   ', // whitespace-only counts as empty
+    uxFrequentAction: 'Search for routes',
+    uxCostliestError: 'Double booking',
+  });
+  const violations = checkFrameUx(cwd);
+  assert.ok(violations.some((v) => v.id === 'FRAME-UX-INCOMPLETE'), 'whitespace-only task should fire');
+  const v = violations.find((x) => x.id === 'FRAME-UX-INCOMPLETE')!;
+  assert.ok(String(v.value).includes('uxTask'), 'whitespace-only uxTask should be listed as missing');
+});
+
+test('writeFrameRecord stores UX fields in frontmatter', () => {
+  const cwd = project();
+  mkdirSync(join(cwd, '.omd'), { recursive: true });
+  writeFrameRecord(cwd, {
+    problem: 'Users cannot find the checkout button',
+    reframe: 'This is a visual hierarchy problem, not a discovery problem',
+    why: 'Support tickets show 40% of users ask "where do I pay" (Zendesk Q3)',
+    uxTask: 'Complete a purchase',
+    uxFrequentAction: 'Add item to cart',
+    uxCostliestError: 'Checkout with wrong address — recovery requires order cancellation',
+  });
+  // After writing, checkFrameUx should find all fields complete
+  const violations = checkFrameUx(cwd);
+  assert.equal(violations.length, 0, 'UX fields written by writeFrameRecord should satisfy the check');
+});
+
+test('FRAME-UX-INCOMPLETE has category ux and severity warn', () => {
+  const cwd = project();
+  writeRawFrame(cwd, { why: 'test evidence here', writtenAt: new Date().toISOString() });
+  const violations = checkFrameUx(cwd);
+  const v = violations.find((x) => x.id === 'FRAME-UX-INCOMPLETE');
+  assert.ok(v, 'violation should exist');
+  assert.equal(v!.category, 'ux');
+  assert.equal(v!.severity, 'warn');
+});
+
+test('FRAME-UX-INCOMPLETE backward compat: old frame without UX fields fires the check', () => {
+  // A frame written before uxTask/uxFrequentAction/uxCostliestError were introduced
+  // should fire FRAME-UX-INCOMPLETE, not throw or silently pass.
+  const cwd = project();
+  writeRawFrame(cwd, {
+    why: 'old evidence from before the UX fields were added',
+    writtenAt: '2024-01-01T00:00:00.000Z',
+    // No uxTask, uxFrequentAction, uxCostliestError
+  });
+  const violations = checkFrameUx(cwd);
+  assert.ok(violations.some((v) => v.id === 'FRAME-UX-INCOMPLETE'), 'old frame without UX fields should fire');
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -16,7 +16,7 @@ test('loadRules reads every builtin rule and validates required fields', () => {
     }
     assert.ok(['error', 'warn'].includes(r.severity));
     assert.ok([1, 2].includes(r.layer));
-    assert.ok(['a11y', 'system', 'slop', 'motion'].includes(r.category));
+    assert.ok(['a11y', 'system', 'slop', 'motion', 'ux'].includes(r.category));
   }
 });
 

--- a/test/ux.test.ts
+++ b/test/ux.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
 import { normalize } from '../core/ir/normalize.ts';
 import { loadRules, check } from '../core/rules/engine.ts';
-import type { RawIr, RawNode } from '../core/types.ts';
+import type { RawIr, RawNode, Ir } from '../core/types.ts';
 
 const BUILTIN_DIR = fileURLToPath(new URL('../core/rules/builtin/', import.meta.url)).replace(/\/$/, '');
 
@@ -133,6 +133,132 @@ test('UX-TWO-PRIMARIES does not fire when one button has no fill (text/ghost but
   ]);
   const v = check(ir, uxRules);
   assert.ok(!v.some((x) => x.id === 'UX-TWO-PRIMARIES'), 'a ghost button (no fill) alongside a primary should not fire');
+});
+
+// ── UX-ACTION-BELOW-FOLD ──────────────────────────────────────────────────────
+
+/** Build a normalised IR with viewportHeight in meta and given node list. */
+function makeIrWithViewport(viewportHeight: number, nodes: Partial<RawNode>[]): Ir {
+  const full = nodes.map((n, i) => ({
+    id: `n${i}`,
+    name: 'div',
+    type: 'FRAME' as const,
+    path: `body/div${i}`,
+    parent: null as string | null,
+    box: { x: 0, y: 0, w: 100, h: 50 },
+    children: [] as string[],
+    ...n,
+  }));
+  const raw: RawIr = {
+    meta: { source: 'dom', url: 'http://test', scrollHeight: viewportHeight * 2, viewportHeight },
+    nodes: full,
+  };
+  return normalize(raw);
+}
+
+test('UX-ACTION-BELOW-FOLD fires when the only interactive element is entirely below the fold', () => {
+  // root (n0) + one button at y=900, viewportHeight=812
+  const ir = makeIrWithViewport(812, [
+    { parent: null },
+    { interactive: true, box: { x: 0, y: 900, w: 120, h: 44 } },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(v.some((x) => x.id === 'UX-ACTION-BELOW-FOLD'), 'expected UX-ACTION-BELOW-FOLD to fire');
+});
+
+test('UX-ACTION-BELOW-FOLD does not fire when an interactive element is within the fold', () => {
+  // button at y=100 is within the 812px viewport
+  const ir = makeIrWithViewport(812, [
+    { parent: null },
+    { interactive: true, box: { x: 0, y: 100, w: 120, h: 44 } },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-ACTION-BELOW-FOLD'), 'should not fire when button is above fold');
+});
+
+test('UX-ACTION-BELOW-FOLD does not fire when there are no interactive elements', () => {
+  // pure content page — no buttons, no links
+  const ir = makeIrWithViewport(812, [
+    { parent: null },
+    { type: 'TEXT', text: 'Hello world' },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-ACTION-BELOW-FOLD'), 'should not fire when no interactive elements exist');
+});
+
+test('UX-ACTION-BELOW-FOLD does not fire when ir.meta.viewportHeight is absent', () => {
+  // IR without viewportHeight — the when condition must be false (backward compat)
+  const full = [
+    { id: 'n0', name: 'div', type: 'FRAME' as const, path: 'body/div0', parent: null, box: { x: 0, y: 900, w: 100, h: 50 }, children: [] },
+    { id: 'n1', name: 'button', type: 'FRAME' as const, path: 'body/button', parent: null, box: { x: 0, y: 900, w: 120, h: 44 }, children: [], interactive: true },
+  ];
+  const raw: RawIr = { nodes: full }; // no meta.viewportHeight
+  const ir = normalize(raw);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-ACTION-BELOW-FOLD'), 'should not fire when viewportHeight is not in meta (old IR)');
+});
+
+test('UX-ACTION-BELOW-FOLD does not fire when one CTA is below fold but nav is within fold', () => {
+  // nav link at y=20 (within fold), CTA button at y=1200 (below fold)
+  const ir = makeIrWithViewport(812, [
+    { parent: null },
+    { interactive: true, box: { x: 0, y: 20, w: 80, h: 40 } },   // nav link
+    { interactive: true, box: { x: 0, y: 1200, w: 120, h: 44 } }, // CTA below fold
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-ACTION-BELOW-FOLD'), 'nav within fold should suppress the rule');
+});
+
+// ── UX-NO-KEYBOARD-PATH ──────────────────────────────────────��────────────────
+
+test('UX-NO-KEYBOARD-PATH fires when every interactive element has focusable:false', () => {
+  const ir = makeIr([
+    { parent: null },
+    { interactive: true, focusable: false },
+    { interactive: true, focusable: false },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(v.some((x) => x.id === 'UX-NO-KEYBOARD-PATH'), 'expected UX-NO-KEYBOARD-PATH to fire');
+});
+
+test('UX-NO-KEYBOARD-PATH does not fire when at least one interactive element is focusable', () => {
+  const ir = makeIr([
+    { parent: null },
+    { interactive: true, focusable: false },
+    { interactive: true, focusable: true },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-NO-KEYBOARD-PATH'), 'one focusable element is enough');
+});
+
+test('UX-NO-KEYBOARD-PATH does not fire when there are no interactive elements', () => {
+  const ir = makeIr([
+    { parent: null },
+    { type: 'TEXT', text: 'Static content' },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-NO-KEYBOARD-PATH'), 'no interactive elements — no finding');
+});
+
+test('UX-NO-KEYBOARD-PATH does not fire when interactive elements have no focusable data (old IR)', () => {
+  // interactive nodes without a focusable field — old IRs, pre-extractor update
+  const ir = makeIr([
+    { parent: null },
+    { interactive: true }, // focusable absent
+    { interactive: true }, // focusable absent
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-NO-KEYBOARD-PATH'), 'should not fire when focusable data is absent (old IR)');
+});
+
+test('UX-NO-KEYBOARD-PATH does not fire when interactive element is focusable with no explicit tabindex', () => {
+  // focusable:true represents a natively focusable button
+  const ir = makeIr([
+    { parent: null },
+    { interactive: true, focusable: true },
+  ]);
+  const v = check(ir, uxRules);
+  assert.ok(!v.some((x) => x.id === 'UX-NO-KEYBOARD-PATH'), 'natively focusable button should not fire');
 });
 
 test('UX-TWO-PRIMARIES value reports the number of competing sibling groups', () => {


### PR DESCRIPTION
Converts the measurable parts of ux.md from prompt to code: extractor captures scroll/focus/form signal; UX-ACTION-BELOW-FOLD + UX-NO-KEYBOARD-PATH; the frame's three UX questions become validated fields with FRAME-UX-INCOMPLETE. 718→739 tests.