### PR TITLE
chore: release v0.14.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "interface": {
     "displayName": "Oh My Design"
   },
@@ -16,7 +16,7 @@
         "authentication": "ON_FIRST_USE"
       },
       "category": "design",
-      "version": "0.13.0"
+      "version": "0.14.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
   "owner": {
     "name": "3x-haust"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "plugins": [
     {
       "name": "omd",
       "description": "The design cognition loop: doubt the brief, measure real references (type and motion included), build once, look at the render, reframe. Plus a deterministic slop linter and a de-AI copy pass.",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "author": {
         "name": "3x-haust"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omd",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem. Ships a slop linter that makes 'looks AI-generated' a checkable claim.",
   "author": {
     "name": "3x-haust",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omd",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem.",
   "author": {
     "name": "3x-haust",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = [
+    "-y",
+    "chrome-devtools-mcp@latest",
+    "--headless",
+    "--isolated",
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Design cognition loop for Codex and Claude Code — frame, diverge, see, reframe",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Codex marketplace manifest (#42), READMEs rewritten (#43), agents inherit the user's model (#44), UX harness — extractor widening + below-fold/keyboard rules + frame UX fields (#45), voice.md robotic-formal register tell (#46), and the release-notes git-log fix (#41).