### PR TITLE
chore: untrack local .codex install artifact

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,8 +1,0 @@
-[mcp_servers.chrome-devtools]
-command = "npx"
-args = [
-    "-y",
-    "chrome-devtools-mcp@latest",
-    "--headless",
-    "--isolated",
-]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 *.log
 .omc
 Plan.md
+# local install targets (omd install patches these)
+.codex/
+.claude/


### PR DESCRIPTION
Removes .codex/config.toml (an omd install target, not source) and gitignores .codex/ and .claude/ local install dirs. The .codex-plugin / .claude-plugin / .agents marketplace manifests are untouched.