### PR TITLE
fix: /plugin shows full name first — oh-my-design Plugin · omd

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "oh-my-design",
+  "name": "omd",
   "description": "Design like a person, not like the mean of the training set.",
   "owner": {
     "name": "3x-haust"
@@ -9,6 +9,7 @@
   "plugins": [
     {
       "name": "omd",
+      "displayName": "oh-my-design",
       "description": "The design cognition loop: doubt the brief, measure real references (type and motion included), build once, look at the render, reframe. Plus a deterministic slop linter and a de-AI copy pass.",
       "version": "0.14.0",
       "author": {


### PR DESCRIPTION
## What

The \`/plugin\` list showed \`omd Plugin · oh-my-design…\` — short name first, full name truncated — the inverse of how oh-my-claudecode reads (\`oh-my-claudecode Plugin · omc\`).

## How

Matched the omc arrangement without touching the plugin's install name (which is the skill/agent namespace — \`/omd:ultradesign\` etc. must keep working):

- marketplace \`name\`: \`oh-my-design\` → \`omd\` (the short token after the dot)
- \`plugins[0].displayName\`: \`oh-my-design\` added — the CLI renders \`displayName || name\`, verified against the bundled binary and official-marketplace entries
- \`plugins[0].name\` stays \`omd\`, so the namespace, cross-references rewritten by \`adapters/claude.ts\`, and install pruning are all unaffected

## Validation

- \`npm test\` — 0 fail
- No name assertions in bump/version-sync tests; versions untouched

## Note for installed copies

The marketplace was registered under its old name, so after merge: \`/plugin marketplace remove oh-my-design\` → re-add \`3x-haust/oh-my-design\` (registers as \`omd\`) → reinstall \`omd\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)