### PR TITLE
chore: sync package-lock version on release bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@3xhaust/oh-my-design",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@3xhaust/oh-my-design",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.61.1",

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -80,6 +80,21 @@ function run(args: string[]): void {
   }
   process.stdout.write(`\nwrote ${MANIFESTS.length} manifests\n`);
 
+  // Keep package-lock.json's version field in sync with package.json.
+  // MANIFESTS deliberately excludes the lockfile (bumpJson's global regex
+  // would rewrite every dependency version), so resync it via npm here.
+  process.stdout.write('\nsyncing package-lock.json...\n');
+  const lockSync = spawnSync('npm', ['install', '--package-lock-only', '--no-audit', '--no-fund'], {
+    cwd: root,
+    stdio: 'inherit',
+    encoding: 'utf8',
+    shell: true,
+  });
+  if (lockSync.status !== 0) {
+    process.stderr.write('package-lock sync failed — manifests were written.\n');
+    process.exit(lockSync.status ?? 1);
+  }
+
   // Build
   process.stdout.write('\nrunning build...\n');
   const build = spawnSync(process.execPath, ['adapters/build.ts'], {


### PR DESCRIPTION
## Summary

The v0.17.0 release bump left `package-lock.json` at the previous version while the five manifests moved to 0.17.0, because `bump.ts` intentionally excludes the lockfile from `MANIFESTS` (its global `"version"` regex would rewrite every dependency version).

- Resync `package-lock.json` to `0.17.0` (root + `packages[""]` version fields).
- `bump.ts` now runs `npm install --package-lock-only` after writing manifests, so future bumps keep the lockfile version in sync automatically.

No product/runtime behaviour changes; the published package does not include `package-lock.json`.

## Validation

- `npx tsc --noEmit`: clean
- `npm run build`: ok
- `node --test 'test/*.test.ts'`: 1368 pass / 0 fail / 1 platform skip (1369 total)

Version fields unchanged (stays 0.17.0), so the release workflow's bump detection is a no-op — this does not re-trigger a release.
