### PR TITLE
fix: scout no longer rejects premium references as slop

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -60,9 +60,14 @@ reference. Capture a motion study (the default energy pass) only where motion ma
 typography, layout, colour, and voice references set `noEnergy` (or `omd ref add --no-energy`) to
 skip the second browser launch — it does not affect a non-motion reference's usefulness.
 
-Preserve contamination defenses: reject sources with two or more slop signals unless
-user-provided (retain those as named anti-references); drop kinship at similarity >= .85;
-prefer first-party/product evidence and direct user/community sources over SEO summaries.
+Preserve contamination defenses: reject a non-user source only when it is derivative or
+convergent — an SEO/content-farm summary, a near-duplicate, or a page whose repeated
+patterns are unauthored defaults — not a premium, first-party, intentional design that
+uses a common pattern (a gradient, a card grid, a common sans) with a point of view. Slop
+is convergence without an author, not any use of a familiar pattern; a well-made source is
+a reference to measure, not slop to drop. Retain a user-provided contaminated source as a
+named anti-reference; drop kinship at similarity >= .85; prefer first-party/product
+evidence and direct user/community sources over SEO summaries.
 Return measured invariants, sanitized rules, coverage gaps, stable source keys/labels, trust,
 and uncertainty. Use tight selectors for component anatomy. A source screenshot remains
 scout-local: never pass it, its URL, pixels, or a source-derived render downstream. When image

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -81,8 +81,12 @@ the resulting hash-bound sanitized selected assembly and checked clean-room line
 
 Prefer first-party product sources and direct user/community evidence over SEO summaries.
 Label source trust, uncertainty, and whether evidence is independent or derivative. Reject
-a non-user source with two or more slop signals. Keep a user-provided contaminated source
-only as a named anti-reference. Drop kin at similarity `>= .85`; a cluster of related pages
+a non-user source only when it is derivative or convergent — an SEO/content-farm summary, a
+near-duplicate, or a page whose repeated patterns are unauthored defaults. A premium,
+first-party, intentional design is not slop for using a common pattern (a gradient, a card
+grid, a common sans) with a point of view; measure it. Slop is convergence without an
+author, not any use of a familiar pattern. Keep a user-provided contaminated source only as
+a named anti-reference. Drop kin at similarity `>= .85`; a cluster of related pages
 is one evidence family, not independent corroboration. A blocked page is not retried; use an
 honest image/discourse fallback or discard it.
 

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -68,9 +68,14 @@ instructions: |
   typography, layout, colour, and voice references set `noEnergy` (or `omd ref add --no-energy`) to
   skip the second browser launch — it does not affect a non-motion reference's usefulness.
 
-  Preserve contamination defenses: reject sources with two or more slop signals unless
-  user-provided (retain those as named anti-references); drop kinship at similarity >= .85;
-  prefer first-party/product evidence and direct user/community sources over SEO summaries.
+  Preserve contamination defenses: reject a non-user source only when it is derivative or
+  convergent — an SEO/content-farm summary, a near-duplicate, or a page whose repeated
+  patterns are unauthored defaults — not a premium, first-party, intentional design that
+  uses a common pattern (a gradient, a card grid, a common sans) with a point of view. Slop
+  is convergence without an author, not any use of a familiar pattern; a well-made source is
+  a reference to measure, not slop to drop. Retain a user-provided contaminated source as a
+  named anti-reference; drop kinship at similarity >= .85; prefer first-party/product
+  evidence and direct user/community sources over SEO summaries.
   Return measured invariants, sanitized rules, coverage gaps, stable source keys/labels, trust,
   and uncertainty. Use tight selectors for component anatomy. A source screenshot remains
   scout-local: never pass it, its URL, pixels, or a source-derived render downstream. When image

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -81,8 +81,12 @@ the resulting hash-bound sanitized selected assembly and checked clean-room line
 
 Prefer first-party product sources and direct user/community evidence over SEO summaries.
 Label source trust, uncertainty, and whether evidence is independent or derivative. Reject
-a non-user source with two or more slop signals. Keep a user-provided contaminated source
-only as a named anti-reference. Drop kin at similarity `>= .85`; a cluster of related pages
+a non-user source only when it is derivative or convergent — an SEO/content-farm summary, a
+near-duplicate, or a page whose repeated patterns are unauthored defaults. A premium,
+first-party, intentional design is not slop for using a common pattern (a gradient, a card
+grid, a common sans) with a point of view; measure it. Slop is convergence without an
+author, not any use of a familiar pattern. Keep a user-provided contaminated source only as
+a named anti-reference. Drop kin at similarity `>= .85`; a cluster of related pages
 is one evidence family, not independent corroboration. A blocked page is not retried; use an
 honest image/discourse fallback or discard it.
 

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -356,3 +356,19 @@ test('humanize uses discourse repair modes and preserves evidence without rhythm
   assert.doesNotMatch(voice, /any one of these signals[\s\S]*model wrote|Product\s+copy[^.]*해요체[^.]*without exception|No human founder|mark the\s+text as generated|Two Korean AI tells are real/i);
   assert.doesNotMatch(voice, /will not need connectives|never explains the product's own mechanism/i);
 });
+
+test('scout rejects derivative or convergent references, not premium sites using common patterns', () => {
+  const scout = read('src/agents/scout.agent.yaml');
+  const skill = read('src/skills/omd-scout/SKILL.md');
+  for (const raw of [scout, skill]) {
+    const source = raw.replace(/\s+/g, ' ');
+    // The blunt "tally two or more slop signals and drop" heuristic over-rejected premium,
+    // first-party references (e.g. a violet-brand SaaS like Linear) and is gone.
+    assert.doesNotMatch(source, /two or more slop signals/i);
+    // Rejection now targets derivative/convergent sources...
+    assert.match(source, /reject[\s\S]*only when it is derivative or convergent/i);
+    // ...while premium, intentional design using common patterns is explicitly protected.
+    assert.match(source, /premium, first-party, intentional/i);
+    assert.match(source, /convergence without an author/i);
+  }
+});


### PR DESCRIPTION
## Problem

Running the scout on a genuinely well-made site (Linear was the report) got it rejected as slop and dropped from the reference set. The cause is the scout's contamination rule:

> Reject a non-user source with two or more slop signals.

A premium, first-party SaaS trivially exhibits two or more *surface* patterns OMD's taxonomy lists as slop tells — an indigo/violet gradient, a card grid, a common sans (Inter/Geist), a size hierarchy. Counting those and dropping the source contradicts OMD's own definition of slop, which is convergence *without an author* (see the `core/rules/builtin/slop.yaml` header and `theory/expressive.md` § "Slop-free is not the same as distinctive"), not any use of a familiar pattern.

## Fix

Reframe the scout rejection in the two source-of-truth prompts:

- `src/agents/scout.agent.yaml`
- `src/skills/omd-scout/SKILL.md`

Drop a non-user source only when it is **derivative or convergent** — an SEO/content-farm summary, a near-duplicate, or a page whose repeated patterns are unauthored defaults — and explicitly **keep a premium, first-party, intentional design that uses a common pattern with a point of view**. The `designSignal` low-signal gate (`core/ref/signal.ts`) still catches sources with nothing to teach (e.g. `danluu.com`), and the clean-room/contamination boundary is unchanged.

## Validation

- `npm run build`: ok (regenerated `agents/scout.md`, `skills/scout/SKILL.md`)
- `npx tsc --noEmit`: clean
- `node --test 'test/*.test.ts'`: 1369 pass / 0 fail / 1 skip (1370 total)
- New `test/prompt-contract.test.ts` case: positive (premium/intentional protected, "convergence without an author") + negative (old "two or more slop signals" heuristic gone).
