### PR TITLE
feat: hand builds a user-directed component from its local part-image

### DIFF
--- a/agents/hand.md
+++ b/agents/hand.md
@@ -9,8 +9,11 @@ composition, graphics, motion, and craft files under `omd pack dir`. Read `.omd/
 `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
 applies, start only after the coordinator's successful checked clean-room lineage: receive the
 hash-bound sanitized selected assembly plus its chosen generated draft, or its checked unavailable
-lineage plus CSS/SVG evidence path. Never receive the internal raw evidence record, source
-URL/hostname, screenshot, pixels, capture path, provenance, or source-page prose. Run
+lineage plus CSS/SVG evidence path. For a user-directed selected component slot, also open that
+slot's local part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`)
+and build that one component against it with image-to-code fidelity. Do not take another slot's
+capture, a source URL/hostname, or source-page prose to imitate a whole page; `omd ref distance`
+still blocks shipping a page that clones a single source. Run
 `omd composition --check` before the first production write and again before ship; stop on a
 missing, malformed, or stale contract. On the Figma structural-bypass route, instead read
 `.omd/figma/snapshot.json`, `.omd/figma/design-system.md`, `.omd/attribution.md`, and the selected
@@ -199,3 +202,9 @@ section fresh at larger scale rather than cropping the old draft. Any abstract/a
 image you generate is a real asset — abstract or atmospheric zone only, never a factual carrier,
 with committed provenance recorded via `omd decision`. `omd ref distance` still gates the shipped
 build regardless of how the draft was seeded.
+For a user-directed selected component slot, apply the same image-to-code discipline to that slot's
+local part-image capture under `.omd/refs/`: reproduce that one component's anatomy, geometry,
+spacing rhythm, and type relationships faithfully into a reusable primitive, and record the outcome
+with `recordReferenceUsage`. This is a per-component transplant, not whole-page imitation — vary the
+source across components and keep the shipped page under the `omd ref distance` ceiling, and never
+ship the source capture itself as an asset.

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -75,9 +75,10 @@ art direction needs a component seed (see `theory/imagegen.md`), pass only sanit
 principles and a skin-abstracted blueprint. Make the draft lineage explicit: the coordinator, not
 composer, records it from those permitted inputs and the clean-room boundary, never from a source
 capture or its visual likeness.
-Never show reference screenshots to a builder. The builder never sees the capture, and `omd ref
-distance` still gates the shipped build. The clean-room boundary forbids copying pixels/copy or
-describing a page for imitation.
+For a user-directed selected component, the hand builds that one component from its local part-image
+capture under `.omd/refs/`; that per-component transplant is intended, and `omd ref distance` still
+gates the shipped build. Do not hand a builder a whole page or a source-page description to imitate.
+The clean-room boundary still forbids whole-page copying and copying source copy.
 
 Turn the validated inventory into sanitized bricks in `.omd/scout.md`, then create two or more
 viable candidate assemblies in the internal `.omd/reference-board.json`. Run `omd ref check`, then

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -31,9 +31,12 @@ Markdown table directly into the Codex or Claude conversation. That table is the
 candidate presentation surface and names, per component slot, the source site/page, exact
 captured UI or image region, the local part-image capture path, proposed target, take, avoid,
 and adaptation. The local capture column lets the human open and attach the exact per-component
-part-image — the referenced button, card, or region — while selecting and building; it is a
-selection-stage aid on the raw scout surface only. Downstream composer, eye, and hand still
-receive only the sanitized selected assembly, never the source part-image, path, or pixels.
+part-image — the referenced button, card, or region — while selecting and building. For a
+user-directed selected component, the hand opens that slot's local part-image under `.omd/refs/`
+and builds that one component against it with image-to-code fidelity: a per-component transplant,
+not whole-page imitation. Composer and eye stay clean-room and receive only the sanitized selected
+assembly; `omd ref distance` still blocks a shipped page that clones a single source, so components
+are transplanted from varied sources rather than one page reproduced whole.
 The coordinator records the selected candidate with the existing `omd ref select` command
 behind the conversation.
 

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -80,8 +80,11 @@ Work at component granularity: for a specific button, card, or region, capture t
 component with a tight `--selector` and `--shot`, and record its own take, avoid, and
 adaptation per slot. The candidate table's local-capture column carries each part-image's
 local path, so attach the precise per-component capture in chat while the user selects and
-builds. That attachment is a selection-stage aid only; downstream composer, eye, and hand
-still receive the sanitized assembly, never the source part-image, path, or pixels.
+builds. For a user-directed selected component, the hand then opens that slot's local part-image
+capture under `.omd/refs/` and builds that one component against it with image-to-code fidelity —
+a per-component transplant, not whole-page imitation. Composer and eye stay clean-room; `omd ref
+distance` still blocks a shipped page that clones a single source, so vary the source across
+components.
 
 ## Evidence quality and contamination
 
@@ -104,7 +107,9 @@ Every retained capture records:
 - source trust and uncertainty;
 - the token, component, motion, voice, or composition question it may inform.
 
-Never describe a page for imitation, show reference screenshots to the builder, copy visual
-skin, or turn award status into evidence. Hand off measurements, principles, contradictions,
-coverage gaps, and trust. Raw captures remain under `.omd/refs/`; downstream agents receive
-only the sanitized evidence summary required for their decision.
+Never describe a whole page for imitation, hand off a source-page description for imitation, copy a
+whole page's visual skin, or turn award status into evidence. The hand may open a user-directed
+selected component's local part-image under `.omd/refs/` and build that one component to match; that
+per-component transplant is intended and `omd ref distance` still guards a page that clones a single
+source. Hand off measurements, principles, contradictions, coverage gaps, and trust; composer and eye
+receive only the sanitized evidence summary required for their decision.

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -18,8 +18,11 @@ instructions: |
   `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
   applies, start only after the coordinator's successful checked clean-room lineage: receive the
   hash-bound sanitized selected assembly plus its chosen generated draft, or its checked unavailable
-  lineage plus CSS/SVG evidence path. Never receive the internal raw evidence record, source
-  URL/hostname, screenshot, pixels, capture path, provenance, or source-page prose. Run
+  lineage plus CSS/SVG evidence path. For a user-directed selected component slot, also open that
+  slot's local part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`)
+  and build that one component against it with image-to-code fidelity. Do not take another slot's
+  capture, a source URL/hostname, or source-page prose to imitate a whole page; `omd ref distance`
+  still blocks shipping a page that clones a single source. Run
   `omd composition --check` before the first production write and again before ship; stop on a
   missing, malformed, or stale contract. On the Figma structural-bypass route, instead read
   `.omd/figma/snapshot.json`, `.omd/figma/design-system.md`, `.omd/attribution.md`, and the selected
@@ -208,3 +211,9 @@ instructions: |
   image you generate is a real asset — abstract or atmospheric zone only, never a factual carrier,
   with committed provenance recorded via `omd decision`. `omd ref distance` still gates the shipped
   build regardless of how the draft was seeded.
+  For a user-directed selected component slot, apply the same image-to-code discipline to that slot's
+  local part-image capture under `.omd/refs/`: reproduce that one component's anatomy, geometry,
+  spacing rhythm, and type relationships faithfully into a reusable primitive, and record the outcome
+  with `recordReferenceUsage`. This is a per-component transplant, not whole-page imitation — vary the
+  source across components and keep the shipped page under the `omd ref distance` ceiling, and never
+  ship the source capture itself as an asset.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -83,9 +83,10 @@ instructions: |
   principles and a skin-abstracted blueprint. Make the draft lineage explicit: the coordinator, not
   composer, records it from those permitted inputs and the clean-room boundary, never from a source
   capture or its visual likeness.
-  Never show reference screenshots to a builder. The builder never sees the capture, and `omd ref
-  distance` still gates the shipped build. The clean-room boundary forbids copying pixels/copy or
-  describing a page for imitation.
+  For a user-directed selected component, the hand builds that one component from its local part-image
+  capture under `.omd/refs/`; that per-component transplant is intended, and `omd ref distance` still
+  gates the shipped build. Do not hand a builder a whole page or a source-page description to imitate.
+  The clean-room boundary still forbids whole-page copying and copying source copy.
 
   Turn the validated inventory into sanitized bricks in `.omd/scout.md`, then create two or more
   viable candidate assemblies in the internal `.omd/reference-board.json`. Run `omd ref check`, then

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -80,8 +80,11 @@ Work at component granularity: for a specific button, card, or region, capture t
 component with a tight `--selector` and `--shot`, and record its own take, avoid, and
 adaptation per slot. The candidate table's local-capture column carries each part-image's
 local path, so attach the precise per-component capture in chat while the user selects and
-builds. That attachment is a selection-stage aid only; downstream composer, eye, and hand
-still receive the sanitized assembly, never the source part-image, path, or pixels.
+builds. For a user-directed selected component, the hand then opens that slot's local part-image
+capture under `.omd/refs/` and builds that one component against it with image-to-code fidelity —
+a per-component transplant, not whole-page imitation. Composer and eye stay clean-room; `omd ref
+distance` still blocks a shipped page that clones a single source, so vary the source across
+components.
 
 ## Evidence quality and contamination
 
@@ -104,7 +107,9 @@ Every retained capture records:
 - source trust and uncertainty;
 - the token, component, motion, voice, or composition question it may inform.
 
-Never describe a page for imitation, show reference screenshots to the builder, copy visual
-skin, or turn award status into evidence. Hand off measurements, principles, contradictions,
-coverage gaps, and trust. Raw captures remain under `.omd/refs/`; downstream agents receive
-only the sanitized evidence summary required for their decision.
+Never describe a whole page for imitation, hand off a source-page description for imitation, copy a
+whole page's visual skin, or turn award status into evidence. The hand may open a user-directed
+selected component's local part-image under `.omd/refs/` and build that one component to match; that
+per-component transplant is intended and `omd ref distance` still guards a page that clones a single
+source. Hand off measurements, principles, contradictions, coverage gaps, and trust; composer and eye
+receive only the sanitized evidence summary required for their decision.

--- a/test/imagegen-wiring.test.ts
+++ b/test/imagegen-wiring.test.ts
@@ -57,10 +57,16 @@ test('hand implements against the draft with image-to-code fidelity and never sh
   assert.match(h, /ref distance/);
 });
 
-test('scout still forbids screenshot imitation while providing blueprint seed material', () => {
+test('scout allows a per-component transplant but still forbids whole-page imitation', () => {
   const s = read('agents/scout.md');
-  // The clean-room invariant must survive.
-  assert.match(s, /Never show reference screenshots to a builder/);
+  // The page-level clean-room invariant must survive: no whole-page imitation, distance still gates.
+  assert.match(s, /Do not hand a builder a whole page or a source-page description to imitate/i);
+  assert.match(s, /forbids whole-page copying/i);
+  assert.match(s, /omd ref distance/);
+  // A user-directed component transplant from the local part-image is intended.
+  assert.match(s, /per-component transplant is intended/i);
+  assert.match(s, /\.omd\/refs\//);
+  // The imagegen draft-seed path (blueprint, synthesized seeds) still exists.
   assert.match(s, /blueprint/i);
   assert.match(s, /theory\/imagegen\.md/);
 });

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -372,3 +372,19 @@ test('scout rejects derivative or convergent references, not premium sites using
     assert.match(source, /convergence without an author/i);
   }
 });
+
+test('hand transplants a user-directed component from its local part-image, page clone still gated', () => {
+  const hand = read('src/agents/hand.agent.yaml');
+  const skill = read('src/skills/omd-scout/SKILL.md');
+  const protocol = read('core/protocol/reference-assembly.md');
+  for (const raw of [hand, skill, protocol]) {
+    const source = raw.replace(/\s+/g, ' ');
+    // The hand opens the selected slot's local part-image and builds against it image-to-code.
+    assert.match(source, /local part-image/i);
+    assert.match(source, /\.omd\/refs\//);
+    assert.match(source, /image-to-code fidelity/i);
+    assert.match(source, /per-component transplant/i);
+    // The page-level anti-clone gate survives (mix sources; do not clone one page whole).
+    assert.match(source, /omd ref distance/i);
+  }
+});


### PR DESCRIPTION
## What

The implementer (hand) now develops directly from the reference part-image, as decided by the owner.

- When the user directs a reference for a specific component, the hand opens that slot's local part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`) and builds **that one component** against it with image-to-code fidelity.
- Prompts updated: `src/agents/hand.agent.yaml`, `src/agents/scout.agent.yaml`, `src/skills/omd-scout/SKILL.md`, `core/protocol/reference-assembly.md`.

## Scope / boundary

This is a **per-component transplant, not whole-page imitation**:

- **Composer and eye stay clean-room** — sanitized assembly only, no source pixels. The imagegen synthesized draft-seed path is unchanged.
- **`omd ref distance` still gates** — a page that clones a single source (page similarity above the ceiling) still does not ship, so components are transplanted from varied sources rather than one page reproduced whole.

## Reversal note (load-bearing)

This reverses the previous **"the builder never sees the capture"** clean-room invariant for user-directed component slots. The README still markets the strict clean-room / "reconstruct, don't copy" thesis; if per-component transplant becomes the default story, the README should be updated to match. Flagging, not doing it here.

## Validation

- `npm run build`: ok (regenerated `agents/hand.md`, `agents/scout.md`, `skills/scout/SKILL.md`)
- `npx tsc --noEmit`: clean
- `node --test 'test/*.test.ts'`: 1370 pass / 0 fail / 1 skip (1371 total)
- `test/imagegen-wiring.test.ts`: scout case rewritten to assert whole-page-imitation prohibition + intended per-component transplant.
- `test/prompt-contract.test.ts`: new case asserts hand/scout/protocol all carry the local part-image transplant with the distance gate intact.
