### PR TITLE
feat: ref distance is advisory; hand builds references to fidelity (clean-room teardown 1/N)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -244,7 +244,7 @@ OMD는 결정적 검사와 렌더 리뷰를 결합합니다.
 | 소스 후보 | `omd slop scan [root] [--json]` 은 지원되는 프로덕션 소스를 쓰지 않고 읽습니다. 후보는 맥락적 분류가 필요하며 `omd check` 경고·점수·작성자 주장이 아닙니다. |
 | 디자인 린트 | `omd check` 는 `system`, `a11y`, `slop`, `motion`, `ux` 조건을 평가합니다. 대비·터치 영역 규칙은 오류이고, slop과 기타 품질 하한 규칙은 그렇게 작성된 경우 경고입니다. 어떤 발견이든 1로 종료하므로 CI에서 쓸 수 있습니다. |
 | 사이트 일관성 | `omd check --site <dir>` 또는 다중 페이지 위치 인자 검사가 페이지 간 래더·토큰 드리프트를 보고합니다. |
-| 레퍼런스 거리 | `omd ref distance <page>` 가 측정 불변량을 저장된 레퍼런스와 비교해 지나치게 가까운 결과를 잡는 데 돕습니다. |
+| 레퍼런스 거리 | `omd ref distance <page>` 가 측정 불변량을 저장된 레퍼런스와 비교해 빌드가 얼마나 가까운지 보고하는 자문(advisory) 충실도 신호입니다 — 배포를 막지 않습니다. |
 | Figma 충실도 | `omd figma pull`, `system`, `diff` 가 Figma 스냅샷을 측정된 구현 보고와 연결합니다. `export FIGMA_TOKEN=…` 이 필요하며, `omd doctor` 는 토큰 부재를 선택 사항으로 처리합니다. |
 | 시각 타깃 | `omd target set <이미지-경로-또는-URL> --as <name>` 과 `omd target diff` 가 등록된 PNG 타깃에 대해 경계 있는 이미지 비교를 실행합니다. URL은 직접 HTTP(S) 이미지 URL이어야 합니다. |
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ OMD combines deterministic checks with rendered review.
 | Source candidates | `omd slop scan [root] [--json]` reads supported production source without writing it. Candidates require contextual triage; they are not `omd check` warnings, scores, or authorship claims. |
 | Design lint | `omd check` evaluates `system`, `a11y`, `slop`, `motion`, and `ux` conditions. Contrast and hit-area rules are errors; slop and other quality-floor rules are warnings where authored that way. Any finding exits 1, so it is usable in CI. |
 | Site consistency | `omd check --site <dir>` or multi-page positional checks report cross-page ladder and token drift. |
-| Reference distance | `omd ref distance <page>` compares measured invariants against saved references and helps catch overly close results. |
+| Reference distance | `omd ref distance <page>` compares measured invariants against saved references and reports how close the build is, as an advisory fidelity signal — it never blocks shipping. |
 | Figma fidelity | `omd figma pull`, `system`, and `diff` connect a Figma snapshot to a measured implementation report. Requires `export FIGMA_TOKEN=…`; `omd doctor` treats a missing token as optional. |
 | Visual target | `omd target set <image-path-or-url> --as <name>` and `omd target diff` run a bounded image comparison against a registered PNG target. A URL must be a direct HTTP(S) image URL. |
 

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -9,11 +9,11 @@ composition, graphics, motion, and craft files under `omd pack dir`. Read `.omd/
 `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
 applies, start only after the coordinator's successful checked clean-room lineage: receive the
 hash-bound sanitized selected assembly plus its chosen generated draft, or its checked unavailable
-lineage plus CSS/SVG evidence path. For a user-directed selected component slot, also open that
-slot's local part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`)
-and build that one component against it with image-to-code fidelity. Do not take another slot's
-capture, a source URL/hostname, or source-page prose to imitate a whole page; `omd ref distance`
-still blocks shipping a page that clones a single source. Run
+lineage plus CSS/SVG evidence path. For a user-directed selected reference, also open its local
+part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`) and build
+against it with image-to-code fidelity; component-level and whole-surface fidelity are both allowed.
+`omd ref distance` is advisory and never blocks shipping; record attribution for every used reference
+and write the product's own copy rather than lifting source copy. Run
 `omd composition --check` before the first production write and again before ship; stop on a
 missing, malformed, or stale contract. On the Figma structural-bypass route, instead read
 `.omd/figma/snapshot.json`, `.omd/figma/design-system.md`, `.omd/attribution.md`, and the selected
@@ -137,7 +137,7 @@ Never fabricate assets, data, or product facts to justify a
 carrier; ground every carrier in the approved contract and real evidence.
 
 Enforce the protocol's production gates: `omd design --check` when design.md exists;
-always `omd ref distance` with no shipment above 0.6; a bounded `omd target diff` repair
+always `omd ref distance` as an advisory fidelity signal that never blocks shipping; a bounded `omd target diff` repair
 loop when the target manifest exists; `omd check --site` for multi-page output; and final
 sharp desktop/mobile plus applicable filmstrip, check, humanize, and probe evidence. Once
 production source exists, follow `protocol/slop-review.md`: run the read-only source scan,
@@ -200,11 +200,12 @@ jobs into real reusable primitives — never a screenshot-matched one-off, and n
 image itself. If a section or detail is not readable enough to build from, regenerate that one
 section fresh at larger scale rather than cropping the old draft. Any abstract/atmospheric shipped
 image you generate is a real asset — abstract or atmospheric zone only, never a factual carrier,
-with committed provenance recorded via `omd decision`. `omd ref distance` still gates the shipped
-build regardless of how the draft was seeded.
-For a user-directed selected component slot, apply the same image-to-code discipline to that slot's
-local part-image capture under `.omd/refs/`: reproduce that one component's anatomy, geometry,
-spacing rhythm, and type relationships faithfully into a reusable primitive, and record the outcome
-with `recordReferenceUsage`. This is a per-component transplant, not whole-page imitation — vary the
-source across components and keep the shipped page under the `omd ref distance` ceiling, and never
-ship the source capture itself as an asset.
+with committed provenance recorded via `omd decision`. `omd ref distance` reports the shipped build's
+closeness to each reference as an advisory signal regardless of how the draft was seeded; it never blocks shipping.
+For a user-directed selected reference, apply the same image-to-code discipline to that slot's
+local part-image capture under `.omd/refs/`: reproduce its anatomy, geometry, spacing rhythm, and
+type relationships faithfully into reusable primitives, and record the outcome with
+`recordReferenceUsage` plus attribution. Component-level and whole-surface fidelity are both allowed;
+`omd ref distance` is advisory — it reports closeness to each reference and never blocks shipping. Do
+not ship the source capture itself as an asset, and write the product's own copy rather than lifting
+source copy verbatim.

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -75,10 +75,11 @@ art direction needs a component seed (see `theory/imagegen.md`), pass only sanit
 principles and a skin-abstracted blueprint. Make the draft lineage explicit: the coordinator, not
 composer, records it from those permitted inputs and the clean-room boundary, never from a source
 capture or its visual likeness.
-For a user-directed selected component, the hand builds that one component from its local part-image
-capture under `.omd/refs/`; that per-component transplant is intended, and `omd ref distance` still
-gates the shipped build. Do not hand a builder a whole page or a source-page description to imitate.
-The clean-room boundary still forbids whole-page copying and copying source copy.
+For a user-directed selected reference, the hand builds from its local part-image capture under
+`.omd/refs/` with image-to-code fidelity; component-level and whole-surface fidelity are both intended,
+and `omd ref distance` is advisory — it reports closeness and never blocks shipping. Record attribution
+for every used reference, write the product's own copy rather than lifting source copy, and never ship
+the source capture itself as an asset.
 
 Turn the validated inventory into sanitized bricks in `.omd/scout.md`, then create two or more
 viable candidate assemblies in the internal `.omd/reference-board.json`. Run `omd ref check`, then

--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -422,7 +422,7 @@ These gates are part of every applicable production run, not optional polish:
 - Walk `craft/finish-pass.md`. Complete applicable items and record a concrete reason for
   every skipped item.
 - When `.omd/design.md` exists, run `omd design --check` and resolve its findings.
-- Always run `omd ref distance <page>`; a similarity above `0.6` does not ship.
+- Always run `omd ref distance <page>` as an advisory fidelity signal: it reports closeness to each saved reference and never blocks shipping. High similarity to a chosen reference can be intended; record attribution.
 - When `.omd/target/manifest.json` exists, run a bounded `omd target diff` repair loop.
   Stop at the configured threshold or record the remaining measured mismatch and evidence;
   never iterate without a bound.

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -32,11 +32,11 @@ candidate presentation surface and names, per component slot, the source site/pa
 captured UI or image region, the local part-image capture path, proposed target, take, avoid,
 and adaptation. The local capture column lets the human open and attach the exact per-component
 part-image — the referenced button, card, or region — while selecting and building. For a
-user-directed selected component, the hand opens that slot's local part-image under `.omd/refs/`
-and builds that one component against it with image-to-code fidelity: a per-component transplant,
-not whole-page imitation. Composer and eye stay clean-room and receive only the sanitized selected
-assembly; `omd ref distance` still blocks a shipped page that clones a single source, so components
-are transplanted from varied sources rather than one page reproduced whole.
+user-directed selected reference, the hand opens its local part-image under `.omd/refs/` and builds
+against it with image-to-code fidelity. Component-level and whole-surface fidelity are both allowed;
+`omd ref distance` is advisory — it reports how close the shipped build is to each reference and never
+blocks shipping — and every used reference is recorded with attribution. Eye reviews against the
+composition contract and task/visual evidence, not source pixels.
 The coordinator records the selected candidate with the existing `omd ref select` command
 behind the conversation.
 
@@ -86,8 +86,10 @@ flow, or runtime.
 The internal raw evidence record is scout-only. Composer starts only after a successful checked
 lineage: on the capable route it receives the current hash-bound sanitized selected assembly and
 the coordinator-chosen clean-room draft; on the unavailable route it receives the selected
-assembly and CSS/SVG fallback. Eye and hand are downstream of that checked state. None receives
-the raw record, source URL/hostname, screenshot, pixel, capture path, provenance, source-page
-prose, or visual likeness. They preserve real copy, task traceability, responsive proofs,
-attribution, measured transfer, reduced motion, and the distance gate. A clean-room composite is
-design-reference material only and never a shipped source asset.
+assembly and CSS/SVG fallback. Eye and composer are downstream of that checked state and receive no
+raw record, source URL/hostname, screenshot, pixel, capture path, provenance, source-page prose, or
+visual likeness — they work from the sanitized synthesis. The hand may additionally open a user-directed
+selected reference's local part-image under `.omd/refs/` and build against it for fidelity. Every role
+preserves real copy, task traceability, responsive proofs, attribution, measured transfer, and reduced
+motion. `omd ref distance` is advisory and never blocks shipping; a source capture is a design reference
+only and is never shipped as an asset.

--- a/core/theory/imagegen.md
+++ b/core/theory/imagegen.md
@@ -33,9 +33,10 @@ input classes. A missing capability records the explicit unavailable state inste
 it carries no composite, provider, or image fields. This is provenance for a generated design
 reference, never a provider implementation or API-key workflow.
 
-`omd ref distance` still measures the SHIPPED build against every saved reference and nothing at or
-above 0.6 kinship ships. The kinship gate remains the anti-laundering backstop for the final build,
-but it does not relax the clean-room input boundary. Never target a specific reference's pixels.
+`omd ref distance` measures the SHIPPED build against every saved reference as an advisory fidelity
+signal — it reports closeness and never blocks shipping. The imagegen draft still consumes only the
+declared clean-room input classes above, and the draft-generation stage never targets a specific
+reference's pixels, even though the hand may build the final surface to reference fidelity.
 
 ## When image-first applies
 

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -80,11 +80,10 @@ Work at component granularity: for a specific button, card, or region, capture t
 component with a tight `--selector` and `--shot`, and record its own take, avoid, and
 adaptation per slot. The candidate table's local-capture column carries each part-image's
 local path, so attach the precise per-component capture in chat while the user selects and
-builds. For a user-directed selected component, the hand then opens that slot's local part-image
-capture under `.omd/refs/` and builds that one component against it with image-to-code fidelity —
-a per-component transplant, not whole-page imitation. Composer and eye stay clean-room; `omd ref
-distance` still blocks a shipped page that clones a single source, so vary the source across
-components.
+builds. For a user-directed selected reference, the hand then opens that slot's local part-image
+capture under `.omd/refs/` and builds against it with image-to-code fidelity. Component-level and
+whole-surface fidelity are both allowed; `omd ref distance` is advisory — it reports closeness and
+never blocks shipping. Record attribution for every used reference and write the product's own copy.
 
 ## Evidence quality and contamination
 
@@ -107,9 +106,9 @@ Every retained capture records:
 - source trust and uncertainty;
 - the token, component, motion, voice, or composition question it may inform.
 
-Never describe a whole page for imitation, hand off a source-page description for imitation, copy a
-whole page's visual skin, or turn award status into evidence. The hand may open a user-directed
-selected component's local part-image under `.omd/refs/` and build that one component to match; that
-per-component transplant is intended and `omd ref distance` still guards a page that clones a single
-source. Hand off measurements, principles, contradictions, coverage gaps, and trust; composer and eye
-receive only the sanitized evidence summary required for their decision.
+Hand off measurements, principles, contradictions, coverage gaps, and trust. The hand may open a
+user-directed selected reference's local part-image under `.omd/refs/` and build against it with
+image-to-code fidelity; component-level and whole-surface fidelity are both intended, and `omd ref
+distance` is advisory (it reports closeness, never blocks shipping). Record attribution and write the
+product's own copy rather than lifting source copy. Composer and eye still receive only the sanitized
+evidence summary required for their decision.

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -510,7 +510,7 @@ For a confident/showpiece register — and always when the brief signals awards-
 first shippable build is not the ship: it is round 0 of a bounded RED/GREEN loop. First write the
 acceptance criteria (the GREEN target) from the frame and `theory/expressive.md` § "Slop-free is not
 the same as distinctive": for example, names the template it resembles and departs from it; no two
-competing primary masses; one clear first-read; slop scan clean; `omd ref distance` <= 0.6; carrier
+competing primary masses; one clear first-read; slop scan clean; `omd ref distance` recorded (advisory, never a gate); carrier
 present and register-fit; and the blind-choose after beats before. Any unmet criterion is RED.
 
 Then iterate, leaving evidence every round — a round with no evidence does not count:

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -18,11 +18,11 @@ instructions: |
   `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
   applies, start only after the coordinator's successful checked clean-room lineage: receive the
   hash-bound sanitized selected assembly plus its chosen generated draft, or its checked unavailable
-  lineage plus CSS/SVG evidence path. For a user-directed selected component slot, also open that
-  slot's local part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`)
-  and build that one component against it with image-to-code fidelity. Do not take another slot's
-  capture, a source URL/hostname, or source-page prose to imitate a whole page; `omd ref distance`
-  still blocks shipping a page that clones a single source. Run
+  lineage plus CSS/SVG evidence path. For a user-directed selected reference, also open its local
+  part-image capture under `.omd/refs/` (resolved through `.omd/reference-selection.json`) and build
+  against it with image-to-code fidelity; component-level and whole-surface fidelity are both allowed.
+  `omd ref distance` is advisory and never blocks shipping; record attribution for every used reference
+  and write the product's own copy rather than lifting source copy. Run
   `omd composition --check` before the first production write and again before ship; stop on a
   missing, malformed, or stale contract. On the Figma structural-bypass route, instead read
   `.omd/figma/snapshot.json`, `.omd/figma/design-system.md`, `.omd/attribution.md`, and the selected
@@ -146,7 +146,7 @@ instructions: |
   carrier; ground every carrier in the approved contract and real evidence.
 
   Enforce the protocol's production gates: `omd design --check` when design.md exists;
-  always `omd ref distance` with no shipment above 0.6; a bounded `omd target diff` repair
+  always `omd ref distance` as an advisory fidelity signal that never blocks shipping; a bounded `omd target diff` repair
   loop when the target manifest exists; `omd check --site` for multi-page output; and final
   sharp desktop/mobile plus applicable filmstrip, check, humanize, and probe evidence. Once
   production source exists, follow `protocol/slop-review.md`: run the read-only source scan,
@@ -209,11 +209,12 @@ instructions: |
   image itself. If a section or detail is not readable enough to build from, regenerate that one
   section fresh at larger scale rather than cropping the old draft. Any abstract/atmospheric shipped
   image you generate is a real asset — abstract or atmospheric zone only, never a factual carrier,
-  with committed provenance recorded via `omd decision`. `omd ref distance` still gates the shipped
-  build regardless of how the draft was seeded.
-  For a user-directed selected component slot, apply the same image-to-code discipline to that slot's
-  local part-image capture under `.omd/refs/`: reproduce that one component's anatomy, geometry,
-  spacing rhythm, and type relationships faithfully into a reusable primitive, and record the outcome
-  with `recordReferenceUsage`. This is a per-component transplant, not whole-page imitation — vary the
-  source across components and keep the shipped page under the `omd ref distance` ceiling, and never
-  ship the source capture itself as an asset.
+  with committed provenance recorded via `omd decision`. `omd ref distance` reports the shipped build's
+  closeness to each reference as an advisory signal regardless of how the draft was seeded; it never blocks shipping.
+  For a user-directed selected reference, apply the same image-to-code discipline to that slot's
+  local part-image capture under `.omd/refs/`: reproduce its anatomy, geometry, spacing rhythm, and
+  type relationships faithfully into reusable primitives, and record the outcome with
+  `recordReferenceUsage` plus attribution. Component-level and whole-surface fidelity are both allowed;
+  `omd ref distance` is advisory — it reports closeness to each reference and never blocks shipping. Do
+  not ship the source capture itself as an asset, and write the product's own copy rather than lifting
+  source copy verbatim.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -83,10 +83,11 @@ instructions: |
   principles and a skin-abstracted blueprint. Make the draft lineage explicit: the coordinator, not
   composer, records it from those permitted inputs and the clean-room boundary, never from a source
   capture or its visual likeness.
-  For a user-directed selected component, the hand builds that one component from its local part-image
-  capture under `.omd/refs/`; that per-component transplant is intended, and `omd ref distance` still
-  gates the shipped build. Do not hand a builder a whole page or a source-page description to imitate.
-  The clean-room boundary still forbids whole-page copying and copying source copy.
+  For a user-directed selected reference, the hand builds from its local part-image capture under
+  `.omd/refs/` with image-to-code fidelity; component-level and whole-surface fidelity are both intended,
+  and `omd ref distance` is advisory — it reports closeness and never blocks shipping. Record attribution
+  for every used reference, write the product's own copy rather than lifting source copy, and never ship
+  the source capture itself as an asset.
 
   Turn the validated inventory into sanitized bricks in `.omd/scout.md`, then create two or more
   viable candidate assemblies in the internal `.omd/reference-board.json`. Run `omd ref check`, then

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -80,11 +80,10 @@ Work at component granularity: for a specific button, card, or region, capture t
 component with a tight `--selector` and `--shot`, and record its own take, avoid, and
 adaptation per slot. The candidate table's local-capture column carries each part-image's
 local path, so attach the precise per-component capture in chat while the user selects and
-builds. For a user-directed selected component, the hand then opens that slot's local part-image
-capture under `.omd/refs/` and builds that one component against it with image-to-code fidelity —
-a per-component transplant, not whole-page imitation. Composer and eye stay clean-room; `omd ref
-distance` still blocks a shipped page that clones a single source, so vary the source across
-components.
+builds. For a user-directed selected reference, the hand then opens that slot's local part-image
+capture under `.omd/refs/` and builds against it with image-to-code fidelity. Component-level and
+whole-surface fidelity are both allowed; `omd ref distance` is advisory — it reports closeness and
+never blocks shipping. Record attribution for every used reference and write the product's own copy.
 
 ## Evidence quality and contamination
 
@@ -107,9 +106,9 @@ Every retained capture records:
 - source trust and uncertainty;
 - the token, component, motion, voice, or composition question it may inform.
 
-Never describe a whole page for imitation, hand off a source-page description for imitation, copy a
-whole page's visual skin, or turn award status into evidence. The hand may open a user-directed
-selected component's local part-image under `.omd/refs/` and build that one component to match; that
-per-component transplant is intended and `omd ref distance` still guards a page that clones a single
-source. Hand off measurements, principles, contradictions, coverage gaps, and trust; composer and eye
-receive only the sanitized evidence summary required for their decision.
+Hand off measurements, principles, contradictions, coverage gaps, and trust. The hand may open a
+user-directed selected reference's local part-image under `.omd/refs/` and build against it with
+image-to-code fidelity; component-level and whole-surface fidelity are both intended, and `omd ref
+distance` is advisory (it reports closeness, never blocks shipping). Record attribution and write the
+product's own copy rather than lifting source copy. Composer and eye still receive only the sanitized
+evidence summary required for their decision.

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -510,7 +510,7 @@ For a confident/showpiece register — and always when the brief signals awards-
 first shippable build is not the ship: it is round 0 of a bounded RED/GREEN loop. First write the
 acceptance criteria (the GREEN target) from the frame and `theory/expressive.md` § "Slop-free is not
 the same as distinctive": for example, names the template it resembles and departs from it; no two
-competing primary masses; one clear first-read; slop scan clean; `omd ref distance` <= 0.6; carrier
+competing primary masses; one clear first-read; slop scan clean; `omd ref distance` recorded (advisory, never a gate); carrier
 present and register-fit; and the blind-choose after beats before. Any unmet criterion is RED.
 
 Then iterate, leaving evidence every round — a round with no evidence does not count:

--- a/test/human-design-loop.test.ts
+++ b/test/human-design-loop.test.ts
@@ -191,7 +191,7 @@ test('prompt contract keeps content-first isolation and checkpoint defaults exec
     /\.omd\/attribution\.md[\s\S]*tokens, motion, composition, and graphics/i,
     /craft\/finish-pass\.md[\s\S]*skipped item/i,
     /\.omd\/design\.md[\s\S]*omd design --check/i,
-    /always run `omd ref distance <page>`[\s\S]*above `0\.6` does not ship/i,
+    /always run `omd ref distance <page>`[\s\S]*advisory[\s\S]*never blocks shipping/i,
     /\.omd\/target\/manifest\.json[\s\S]*bounded `omd target diff` repair loop/i,
     /multi-page output[\s\S]*omd check --site/i,
     /sharp desktop and mobile[\s\S]*filmstrip[\s\S]*humanize review[\s\S]*declared(?:\/applicable)? probe/i,

--- a/test/imagegen-wiring.test.ts
+++ b/test/imagegen-wiring.test.ts
@@ -24,13 +24,13 @@ test('imagegen theory keeps a generated image as a design reference, never a shi
   assert.match(t, /factual carrier[\s\S]*never (be )?AI-generated|NEVER AI-generated/i);
 });
 
-test('imagegen theory names the kinship gate as the anti-laundering backstop for reference seeding', () => {
+test('imagegen ref distance is advisory while the draft stage stays clean-room', () => {
   const t = read('core/theory/imagegen.md');
   assert.match(t, /ref distance/);
-  assert.match(t, /0\.6/);
-  assert.match(t, /backstop/i);
-  // The builder never sees reference screenshots; seeds are synthesized, not single-reference pixels.
-  assert.match(t, /never target a specific reference'?s? pixels|builder\s+never sees these reference screenshots/i);
+  assert.match(t, /advisory/i);
+  assert.match(t, /never blocks shipping/i);
+  // The imagegen draft-generation stage still never targets a specific reference's pixels.
+  assert.match(t, /never targets a specific\s+reference's pixels/i);
 });
 
 test('imagegen theory carries the variation engine and the anti-AI-default tells', () => {
@@ -57,16 +57,14 @@ test('hand implements against the draft with image-to-code fidelity and never sh
   assert.match(h, /ref distance/);
 });
 
-test('scout allows a per-component transplant but still forbids whole-page imitation', () => {
+test('scout routes reference fidelity to the hand with an advisory distance signal', () => {
   const s = read('agents/scout.md');
-  // The page-level clean-room invariant must survive: no whole-page imitation, distance still gates.
-  assert.match(s, /Do not hand a builder a whole page or a source-page description to imitate/i);
-  assert.match(s, /forbids whole-page copying/i);
-  assert.match(s, /omd ref distance/);
-  // A user-directed component transplant from the local part-image is intended.
-  assert.match(s, /per-component transplant is intended/i);
+  assert.match(s, /the hand builds from its local part-image/i);
   assert.match(s, /\.omd\/refs\//);
-  // The imagegen draft-seed path (blueprint, synthesized seeds) still exists.
+  assert.match(s, /image-to-code fidelity/i);
+  assert.match(s, /omd ref distance` is advisory/i);
+  assert.match(s, /never blocks shipping/i);
+  // The imagegen draft-seed path (blueprint) still exists for the composer route.
   assert.match(s, /blueprint/i);
   assert.match(s, /theory\/imagegen\.md/);
 });

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -373,18 +373,20 @@ test('scout rejects derivative or convergent references, not premium sites using
   }
 });
 
-test('hand transplants a user-directed component from its local part-image, page clone still gated', () => {
+test('hand builds a user-directed reference to fidelity; ref distance is advisory', () => {
   const hand = read('src/agents/hand.agent.yaml');
   const skill = read('src/skills/omd-scout/SKILL.md');
   const protocol = read('core/protocol/reference-assembly.md');
   for (const raw of [hand, skill, protocol]) {
     const source = raw.replace(/\s+/g, ' ');
-    // The hand opens the selected slot's local part-image and builds against it image-to-code.
+    // The hand opens the selected reference's local part-image and builds against it image-to-code.
     assert.match(source, /local part-image/i);
     assert.match(source, /\.omd\/refs\//);
     assert.match(source, /image-to-code fidelity/i);
-    assert.match(source, /per-component transplant/i);
-    // The page-level anti-clone gate survives (mix sources; do not clone one page whole).
+    // ref distance no longer blocks shipping — it is advisory.
     assert.match(source, /omd ref distance/i);
+    assert.match(source, /advisory/i);
+    assert.match(source, /never blocks shipping/i);
+    assert.doesNotMatch(source, /omd ref distance` still (?:gates|blocks|guards)/i);
   }
 });


### PR DESCRIPTION
feat: omd ref distance is advisory; hand builds references to fidelity

Start dismantling the clean-room / anti-copy thesis that was solving the
wrong problem. `omd ref distance` no longer blocks shipping — it is an
advisory fidelity signal that reports how close the build is to each saved
reference. The hand may open a user-directed selected reference's local
part-image under `.omd/refs/` and build against it with image-to-code
fidelity; component-level and whole-surface fidelity are both allowed.

Kept for a later increment: composer/eye still work from the sanitized
synthesis, and the imagegen draft-generation stage still consumes only its
declared clean-room input classes (the composite-lineage code and its tests
are untouched). Attribution recording and "write the product's own copy,
never ship the source capture as an asset" stay as hygiene.

Prompts/protocol/theory/README updated (hand, scout, omd-scout,
omd-ultradesign, human-design-loop, reference-assembly, imagegen, both
READMEs). Tests updated: distance-gate assertions in prompt-contract,
imagegen-wiring, and human-design-loop now assert the advisory framing.

Gates: build ok, tsc --noEmit clean, 1370 pass / 0 fail / 1 skip.
