### PR TITLE
feat: React uses GSAP ScrollTrigger + Framer Motion as a first-class lane

### DIFF
--- a/agents/composer.md
+++ b/agents/composer.md
@@ -164,8 +164,10 @@ signal board of collected reference interaction patterns. The signal board is a
 separate collection surface from `core/ref/distance.ts` scoring — never ground a
 reference interaction pattern against the distance gate, and never imitate a
 reference screenshot; only its transferable principle transfers, per the clean-room
-transfer boundary above. The default interaction lane is CSS scroll-driven (pointer-
-or scroll-tracked custom properties, `radial-gradient`, `animation-timeline`);
+transfer boundary above. The interaction lanes are, in order: CSS scroll-driven (pointer-/scroll-
+tracked custom properties, `radial-gradient`, `animation-timeline`); then, on a React stack, real
+animation libraries — GSAP with ScrollTrigger for scroll choreography and Framer Motion (`motion`)
+for enter/gesture/layout transitions — as a first-class lane preferred over hand-rolled rAF;
 escalating to WebGL is an escalation, not a default, and remains gated on hand
 precedence, a declared performance budget, and a non-canvas semantic fallback, exactly
 as for the WebGL/3D media-role precedence above — autonomous ideation never bypasses

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -129,6 +129,11 @@ Use a purposeful visual carrier, not a bare gray box or unstyled default: pick f
 register (quiet/confident/showpiece) and the dominant anchor's domain mechanism.
 Exercise restraint: implement at most one signature moment per surface, matched to the
 register (quiet surfaces may carry none), never a catalogue of techniques.
+On a React stack, reach for real animation libraries instead of hand-rolling: GSAP + ScrollTrigger
+for scroll choreography and Framer Motion (`motion`) for enter, gesture, and layout transitions.
+They are allowed greenfield dependencies. The one-signature-moment restraint, the declared
+performance budget, `prefers-reduced-motion`, and the `.omd/motion-spec.md` scene list still bound
+every use — a library buys cleaner motion, never more of it.
 Before you implement a signature interaction, confirm all five gates hold — register-fit, a
 declared performance budget, slop-clean, hand precedence, and a non-canvas semantic fallback — and
 build it only when every one is satisfied. A missing gate names what to fix first and never

--- a/src/agents/composer.agent.yaml
+++ b/src/agents/composer.agent.yaml
@@ -173,8 +173,10 @@ instructions: |
   separate collection surface from `core/ref/distance.ts` scoring — never ground a
   reference interaction pattern against the distance gate, and never imitate a
   reference screenshot; only its transferable principle transfers, per the clean-room
-  transfer boundary above. The default interaction lane is CSS scroll-driven (pointer-
-  or scroll-tracked custom properties, `radial-gradient`, `animation-timeline`);
+  transfer boundary above. The interaction lanes are, in order: CSS scroll-driven (pointer-/scroll-
+  tracked custom properties, `radial-gradient`, `animation-timeline`); then, on a React stack, real
+  animation libraries — GSAP with ScrollTrigger for scroll choreography and Framer Motion (`motion`)
+  for enter/gesture/layout transitions — as a first-class lane preferred over hand-rolled rAF;
   escalating to WebGL is an escalation, not a default, and remains gated on hand
   precedence, a declared performance budget, and a non-canvas semantic fallback, exactly
   as for the WebGL/3D media-role precedence above — autonomous ideation never bypasses

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -138,6 +138,11 @@ instructions: |
   register (quiet/confident/showpiece) and the dominant anchor's domain mechanism.
   Exercise restraint: implement at most one signature moment per surface, matched to the
   register (quiet surfaces may carry none), never a catalogue of techniques.
+  On a React stack, reach for real animation libraries instead of hand-rolling: GSAP + ScrollTrigger
+  for scroll choreography and Framer Motion (`motion`) for enter, gesture, and layout transitions.
+  They are allowed greenfield dependencies. The one-signature-moment restraint, the declared
+  performance budget, `prefers-reduced-motion`, and the `.omd/motion-spec.md` scene list still bound
+  every use — a library buys cleaner motion, never more of it.
   Before you implement a signature interaction, confirm all five gates hold — register-fit, a
   declared performance budget, slop-clean, hand precedence, and a non-canvas semantic fallback — and
   build it only when every one is satisfied. A missing gate names what to fix first and never

--- a/test/phase3-interaction-prompts.test.ts
+++ b/test/phase3-interaction-prompts.test.ts
@@ -20,8 +20,10 @@ test('composer names the three autonomous signature-interaction mechanisms and k
   assert.match(composer, /separate collection surface from `core\/ref\/distance\.ts`/);
   assert.match(composer, /never imitate a\s+reference screenshot/i);
 
-  // Default lane is CSS scroll-driven; WebGL is escalation-only.
-  assert.match(composer, /default interaction lane is CSS scroll-driven/i);
+  // Lanes in order: CSS scroll-driven, then React animation libraries (GSAP/ScrollTrigger, Framer Motion), WebGL escalation-only.
+  assert.match(composer, /interaction lanes are, in order: CSS scroll-driven/i);
+  assert.match(composer, /GSAP with ScrollTrigger[\s\S]*Framer Motion \(`motion`\)/i);
+  assert.match(composer, /first-class lane preferred over hand-rolled rAF/i);
   assert.match(composer, /escalating to WebGL is an escalation, not a default/i);
 
   // Autonomy never bypasses the existing gates.


### PR DESCRIPTION
feat: React uses GSAP ScrollTrigger + Framer Motion as a first-class lane

Add real animation libraries to the interaction lanes for React stacks:
GSAP with ScrollTrigger for scroll choreography and Framer Motion (`motion`)
for enter/gesture/layout transitions, preferred over hand-rolled rAF and
sitting between the CSS scroll-driven default and the WebGL escalation.

Guardrails unchanged: the one-signature-moment restraint, the declared
performance budget, `prefers-reduced-motion`, the `.omd/motion-spec.md` scene
list, and the slop gates still bound every use — a library buys cleaner
motion, never more of it. They are allowed greenfield dependencies.

composer.agent.yaml + hand.agent.yaml; phase3-interaction-prompts test updated
to assert the lane ordering and the named libraries.

Gates: build ok, tsc clean, 1370 pass / 0 fail / 1 skip.
