### PR TITLE
feat: UX-fix requests trigger reference research

### DIFF
--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -15,6 +15,10 @@ sequence in `protocol/reference-assembly.md`. That protocol owns its owners, art
 boundaries, chat presentation, browser fallback, and stop conditions; this protocol does
 not create a parallel reference flow.
 
+A request to fix or improve the UX of an existing surface is a reference-worthy run: research how
+strong products solve that same UX problem — the specific flow, state, or component — before proposing
+changes, rather than applying generic UX rules from memory alone.
+
 ## Stack routing
 
 Apply one precedence everywhere: explicit user request > existing repository stack/toolchain

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -4,9 +4,12 @@ description: >-
   Build a measured LEGO reference inventory without designing anything: whole pages for feel,
   tight selectors for component anatomy, typography studies, motion studies, image refs
   for the unrenderable. Use when the user asks for references, inspiration, benchmarks,
-  or "how do good sites do X" — standalone, before or without a build.
-  Triggers: 레퍼런스 찾아줘, 레퍼런스 수집, 참고 사이트, 벤치마킹, find references,
-  inspiration board, how do other sites do.
+  or "how do good sites do X" — standalone, before or without a build — and also when the
+  request is to fix or improve the UX of an existing surface: research how strong products
+  solve that same UX problem before proposing changes, instead of applying generic rules from
+  memory.
+  Triggers: 레퍼런스 찾아줘, 레퍼런스 수집, 참고 사이트, 벤치마킹, UX 고쳐줘, UX 개선,
+  이 페이지 UX 개선해줘, find references, inspiration board, how do other sites do, fix/improve the UX.
 ---
 
 # oh-my-design:scout

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -4,9 +4,12 @@ description: >-
   Build a measured LEGO reference inventory without designing anything: whole pages for feel,
   tight selectors for component anatomy, typography studies, motion studies, image refs
   for the unrenderable. Use when the user asks for references, inspiration, benchmarks,
-  or "how do good sites do X" — standalone, before or without a build.
-  Triggers: 레퍼런스 찾아줘, 레퍼런스 수집, 참고 사이트, 벤치마킹, find references,
-  inspiration board, how do other sites do.
+  or "how do good sites do X" — standalone, before or without a build — and also when the
+  request is to fix or improve the UX of an existing surface: research how strong products
+  solve that same UX problem before proposing changes, instead of applying generic rules from
+  memory.
+  Triggers: 레퍼런스 찾아줘, 레퍼런스 수집, 참고 사이트, 벤치마킹, UX 고쳐줘, UX 개선,
+  이 페이지 UX 개선해줘, find references, inspiration board, how do other sites do, fix/improve the UX.
 ---
 
 # omd-scout


### PR DESCRIPTION
feat: UX-fix requests trigger reference research

A request to fix or improve the UX of an existing surface is now a
reference-worthy run. The scout skill triggers on UX 고쳐/개선 and fix/improve
the UX, and human-design-loop states that such a request should research how
strong products solve that same UX problem (the specific flow, state, or
component) before proposing changes, instead of applying generic UX rules
from memory alone.

Gates: build ok, tsc clean, 1370 pass / 0 fail / 1 skip.
