### PR TITLE
feat: flow-first framing and rough->imagegen->redesign loop

### DIFF
--- a/agents/framer.md
+++ b/agents/framer.md
@@ -30,6 +30,13 @@ proves its selected detail identity and object-local state. Identify selection b
 identity, never a fixture identifier or list position. This conditional branch does not impose
 list-detail tasks on non-list-detail product, marketing, editorial, or static surfaces.
 
+For a multi-screen product or mixed surface, map the flow before any drawing: list the features
+and, for each, the pages it needs; then list the pages and, for each, the features each must carry.
+Name the primary flow(s) as an ordered step sequence from entry to task completion. Prune steps and
+screens that do not serve the task — fewer screens and fewer steps to the same outcome is better UX;
+record each removed step and why. Keep this map and flow in the frame body (not the task matrix), and
+let it decide which screens exist and which `T#` rows the matrix carries.
+
 Taste is admissible only when the coordinator explicitly provides `omd taste profile`
 output. That default profile contains explicit user records only. Never run `--all` and
 never treat an agent/legacy choice as user preference. Apply precedence exactly:

--- a/core/theory/imagegen.md
+++ b/core/theory/imagegen.md
@@ -56,6 +56,11 @@ When the host provides an image-generation capability and image-first applies, t
    section for a multi-section page — never one tall board with unreadable text. Do not crop an old
    image for a detail view; regenerate that section fresh, keeping the same
    palette/type/radius/treatment.
+   A project-owned rough — a quick pass built on the committed design system — is a permitted
+   generation seed: feed it plus the committed palette/type/material as the project-owned inputs so the
+   draft fleshes out ("구체화") that rough rather than inventing an unrelated look. The build then
+   redesigns the draft back onto the design system's tokens, spacing, and component rules; the draft is
+   a reference, never shipped, and the shipped surface obeys the system, not the raw draft.
 2. **Analyze** — only after the coordinator has checked the selected generated lineage, composer
    analyzes and translates that draft into the composition contract: extract tokens, layout geometry,
    spacing rhythm, type-scale relationships, component anatomy, interaction affordances, and each

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -35,6 +35,13 @@ instructions: |
   identity, never a fixture identifier or list position. This conditional branch does not impose
   list-detail tasks on non-list-detail product, marketing, editorial, or static surfaces.
 
+  For a multi-screen product or mixed surface, map the flow before any drawing: list the features
+  and, for each, the pages it needs; then list the pages and, for each, the features each must carry.
+  Name the primary flow(s) as an ordered step sequence from entry to task completion. Prune steps and
+  screens that do not serve the task — fewer screens and fewer steps to the same outcome is better UX;
+  record each removed step and why. Keep this map and flow in the frame body (not the task matrix), and
+  let it decide which screens exist and which `T#` rows the matrix carries.
+
   Taste is admissible only when the coordinator explicitly provides `omd taste profile`
   output. That default profile contains explicit user records only. Never run `--all` and
   never treat an agent/legacy choice as user preference. Apply precedence exactly:


### PR DESCRIPTION
feat: flow-first framing and rough->imagegen->redesign loop

Framer: for a multi-screen product/mixed surface, map the flow before drawing
— features->pages and pages->features, name the primary flow as an ordered
step sequence, and prune steps/screens that do not serve the task (fewer
screens/steps to the same outcome is better UX, each removal recorded). The
map drives which screens exist and which T# rows the matrix carries.

imagegen: a project-owned rough built on the committed design system is a
permitted generation seed — feed it plus committed palette/type/material so
the draft fleshes out that rough, then redesign the draft back onto the
design systems tokens/spacing/component rules. The draft is a reference,
never shipped; the shipped surface obeys the system, not the raw draft.

Gates: build ok, tsc clean, 1370 pass / 0 fail / 1 skip.
