### PR TITLE
feat: slop scan flags a fake form submit (reality-depth gate)

### DIFF
--- a/core/slop/index.ts
+++ b/core/slop/index.ts
@@ -12,6 +12,7 @@ export type SlopSourceCandidateId =
   | 'rounded-accent-callout'
   | 'decorative-ordinal-run'
   | 'default-font-pair'
+  | 'fake-submit'
   | 'global-terminal-styling';
 
 export interface SlopSourceCandidate {
@@ -74,6 +75,10 @@ const REASONS: Record<SlopSourceCandidateId, Pick<SlopSourceCandidate, 'reason' 
   'global-terminal-styling': {
     reason: 'Monospace terminal styling is applied to a global or primary interface surface.',
     reviewQuestion: 'Is terminal language intrinsic to the product, or should monospace stay with code content?',
+  },
+  'fake-submit': {
+    reason: 'A form submit prevents default and fakes a success state on a timer, but the file makes no network call — the request never leaves the page.',
+    reviewQuestion: 'Does this submit actually deliver the request (API, form action, mailto, waitlist), or is it a success animation with no delivery? Wire it, or label it a UI-state demo.',
   },
 };
 
@@ -348,6 +353,21 @@ function detectTerminalChrome(source: string, path: string): SlopSourceCandidate
   return null;
 }
 
+function detectFakeSubmit(source: string, path: string): SlopSourceCandidate | null {
+  // A JS-handled form submit that fakes success on a timer and never touches the network.
+  const network = /\b(?:fetch|axios|XMLHttpRequest|useMutation|useSWRMutation|useActionState)\b|fetcher\.(?:submit|load|Form)|navigator\.sendBeacon|mailto:|method\s*=\s*['"]?post|(?:^|[\s{;(=])(?:form)?action\s*[:=]/mi;
+  if (network.test(source)) return null;
+  if (!/preventDefault\s*\(/.test(source)) return null;
+  const success = /(['"`])(?:success|submitted|sent|done|complete)\1|set(?:Submitted|Success|Sent)\s*\(/i;
+  for (const match of source.matchAll(/setTimeout\s*\(/g)) {
+    const region = source.slice(match.index!, match.index! + 320);
+    if (success.test(region)) {
+      return candidate('fake-submit', path, source, match.index!, ['submit:preventDefault', 'transition:setTimeout->success', 'network:none']);
+    }
+  }
+  return null;
+}
+
 function detectCandidates(source: string, path: string, extension: string): SlopSourceCandidate[] {
   const masked = maskComments(source, extension);
   const candidates = [
@@ -359,6 +379,7 @@ function detectCandidates(source: string, path: string, extension: string): Slop
     detectOrdinalRun(masked, path),
     detectFontPair(masked, path),
     detectTerminalChrome(masked, path),
+    detectFakeSubmit(masked, path),
   ];
   return candidates.filter((item): item is SlopSourceCandidate => item !== null);
 }

--- a/test/slop-source.test.ts
+++ b/test/slop-source.test.ts
@@ -71,6 +71,11 @@ const detectorCases: Array<{
     positive: 'main { font-family: "JetBrains Mono", monospace; }',
     negative: 'body { font-family: system-ui; } code, pre { font-family: "JetBrains Mono", monospace; }',
   },
+  {
+    id: 'fake-submit', extension: 'tsx',
+    positive: 'function F(){ const [s,setS]=useState("idle"); const onSubmit=(e)=>{ e.preventDefault(); setS("loading"); setTimeout(()=>setS("success"),1100); }; return <form onSubmit={onSubmit} />; }',
+    negative: 'function F(){ const onSubmit=async(e)=>{ e.preventDefault(); await fetch("/api",{method:"POST"}); setTimeout(()=>setS("success"),300); }; return <form onSubmit={onSubmit} />; }',
+  },
 ];
 
 for (const fixture of detectorCases) {


### PR DESCRIPTION
feat: slop scan flags a fake form submit (reality-depth gate)

Add a fake-submit source candidate to omd slop scan: a form submit that
prevents default and fakes a success state on a timer while the file makes no
network call (fetch/axios/XHR/useMutation/form action/mailto/POST). This is
the clearest reality-depth tell from the design critique — the visual promise
(a working request) outruns the implementation (a success animation with no
delivery).

Narrow, warn-only, hand-owned, with positive and negative cases (the negative
has a real fetch, so it does not fire). Timing theatre and self-referential
in-page trust stay at the prompt layer (the RED/GREEN loop criteria) per the
narrow-rule discipline, since a source scanner cannot flag them without high
false positives.

Gates: build ok, tsc clean, 1372 pass / 0 fail / 1 skip.
