### PR TITLE
feat: framer records a product-reality ledger and differentiates sections

### DIFF
--- a/agents/framer.md
+++ b/agents/framer.md
@@ -37,6 +37,15 @@ screens that do not serve the task — fewer screens and fewer steps to the same
 record each removed step and why. Keep this map and flow in the frame body (not the task matrix), and
 let it decide which screens exist and which `T#` rows the matrix carries.
 
+Record a reality ledger in the frame body so the design cannot outrun the product: what is real
+versus demo/simulated (a demo is labeled a demo, never dressed as a real record); what the product
+cannot do; and the messy questions it must eventually answer — authentication, pricing, failure and
+ambiguous-result handling, limits, data/permissions, and who operates it and how to reach them.
+Then require each major section to answer a different question (what it solves, exactly what you get,
+how it is verified, what happens on failure, scope, security, cost) rather than restating one message
+across hero, steps, trust, and CTA. A surface whose sections only re-vary a single promise is a
+reframe target, not a finished frame.
+
 Taste is admissible only when the coordinator explicitly provides `omd taste profile`
 output. That default profile contains explicit user records only. Never run `--all` and
 never treat an agent/legacy choice as user preference. Apply precedence exactly:

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -42,6 +42,15 @@ instructions: |
   record each removed step and why. Keep this map and flow in the frame body (not the task matrix), and
   let it decide which screens exist and which `T#` rows the matrix carries.
 
+  Record a reality ledger in the frame body so the design cannot outrun the product: what is real
+  versus demo/simulated (a demo is labeled a demo, never dressed as a real record); what the product
+  cannot do; and the messy questions it must eventually answer — authentication, pricing, failure and
+  ambiguous-result handling, limits, data/permissions, and who operates it and how to reach them.
+  Then require each major section to answer a different question (what it solves, exactly what you get,
+  how it is verified, what happens on failure, scope, security, cost) rather than restating one message
+  across hero, steps, trust, and CTA. A surface whose sections only re-vary a single promise is a
+  reframe target, not a finished frame.
+
   Taste is admissible only when the coordinator explicitly provides `omd taste profile`
   output. That default profile contains explicit user records only. Never run `--all` and
   never treat an agent/legacy choice as user preference. Apply precedence exactly:


### PR DESCRIPTION
feat: framer records a product-reality ledger and differentiates sections

So the design cannot outrun the product, the framer records a reality ledger
in the frame body: what is real vs demo/simulated (a demo is labeled a demo,
never dressed as a real record), what the product cannot do, and the messy
questions it must eventually answer (auth, pricing, failure/ambiguous-result
handling, limits, data/permissions, operator + contact).

Each major section must answer a different question (what it solves, exactly
what you get, how it is verified, what happens on failure, scope, security,
cost) instead of restating one message across hero, steps, trust, and CTA — a
surface whose sections only re-vary a single promise is a reframe target.

Gates: build ok, tsc clean, 1372 pass / 0 fail / 1 skip.
