### PR TITLE
fix: scout captures by decision coverage, never by an invented reference count

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -51,8 +51,12 @@ A gallery image is never copied and never travels downstream — only measured s
 principles do. For a Pinterest-like or gallery image, capture the user-selected region through
 browser-rs, retain source-page provenance and rights notes, and import only the resulting local
 PNG with `omd ref import-image <input.json>`; never scrape, hotlink, or ship remote source bytes.
-Search until each category has enough evidence to support a decision; do not report query/capture
-quotas. If motion is irrelevant, state why rather than manufacturing a motion study.
+Capture strictly per decision: for each decision the design must make, capture until you have enough
+independent evidence to settle it, then move on. Stop when another capture would not change any
+remaining decision. Never choose, target, estimate, or announce a number or range of references
+(never "18–25 references", never an "N of M" count) — a fabricated count is the fake specificity this
+tool removes. Report only which decision you are gathering evidence for. If motion is irrelevant,
+state why rather than manufacturing a motion study.
 Two output-neutral ways to save time, neither of which changes what the fragment inventory teaches: reuse a
 coverage-complete `.omd/refs/` inventory when this directory already has one for the concept (capture
 only the missing categories rather than rebuilding it), and capture references in parallel with

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -48,6 +48,12 @@ There is no minimum query count, capture quota, famous-site quota, or mandatory 
 gallery. A small inventory with complete, independent evidence is better than a large gallery of
 near-duplicates. If a category is irrelevant, record why. If evidence remains weak or
 contradictory, report the gap and uncertainty instead of filling a slot with decoration.
+Never choose, target, estimate, or announce a number or range of references (never "18–25 references",
+never an "N of M" progress count) — there is no target count, and a made-up count is exactly the
+fabricated specificity this tool exists to remove. Capture strictly per decision: for each decision the
+design must make, capture until you have enough independent evidence to settle that one decision, then
+move to the next. Stop when another capture would not change any remaining decision. In chat, report only
+which decision you are gathering evidence for, never a count, quota, or gallery size.
 
 Use the narrowest useful capture:
 

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -59,8 +59,12 @@ instructions: |
   principles do. For a Pinterest-like or gallery image, capture the user-selected region through
   browser-rs, retain source-page provenance and rights notes, and import only the resulting local
   PNG with `omd ref import-image <input.json>`; never scrape, hotlink, or ship remote source bytes.
-  Search until each category has enough evidence to support a decision; do not report query/capture
-  quotas. If motion is irrelevant, state why rather than manufacturing a motion study.
+  Capture strictly per decision: for each decision the design must make, capture until you have enough
+  independent evidence to settle it, then move on. Stop when another capture would not change any
+  remaining decision. Never choose, target, estimate, or announce a number or range of references
+  (never "18–25 references", never an "N of M" count) — a fabricated count is the fake specificity this
+  tool removes. Report only which decision you are gathering evidence for. If motion is irrelevant,
+  state why rather than manufacturing a motion study.
   Two output-neutral ways to save time, neither of which changes what the fragment inventory teaches: reuse a
   coverage-complete `.omd/refs/` inventory when this directory already has one for the concept (capture
   only the missing categories rather than rebuilding it), and capture references in parallel with

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -48,6 +48,12 @@ There is no minimum query count, capture quota, famous-site quota, or mandatory 
 gallery. A small inventory with complete, independent evidence is better than a large gallery of
 near-duplicates. If a category is irrelevant, record why. If evidence remains weak or
 contradictory, report the gap and uncertainty instead of filling a slot with decoration.
+Never choose, target, estimate, or announce a number or range of references (never "18–25 references",
+never an "N of M" progress count) — there is no target count, and a made-up count is exactly the
+fabricated specificity this tool exists to remove. Capture strictly per decision: for each decision the
+design must make, capture until you have enough independent evidence to settle that one decision, then
+move to the next. Stop when another capture would not change any remaining decision. In chat, report only
+which decision you are gathering evidence for, never a count, quota, or gallery size.
 
 Use the narrowest useful capture:
 

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -390,3 +390,17 @@ test('hand builds a user-directed reference to fidelity; ref distance is advisor
     assert.doesNotMatch(source, /omd ref distance` still (?:gates|blocks|guards)/i);
   }
 });
+
+test('scout captures by decision coverage, never by a targeted or announced reference count', () => {
+  const skill = read('src/skills/omd-scout/SKILL.md');
+  const agent = read('src/agents/scout.agent.yaml');
+  for (const raw of [skill, agent]) {
+    const source = raw.replace(/\s+/g, ' ');
+    // Capture is per-decision and stops on convergence, not at a number.
+    assert.match(source, /Capture strictly per decision/i);
+    assert.match(source, /stop when another capture would not change any remaining decision/i);
+    // A targeted, estimated, or announced reference count is forbidden as fabricated specificity.
+    assert.match(source, /never choose, target, estimate, or announce a number or range of references/i);
+    assert.match(source, /fabricated specificity|fake specificity/i);
+  }
+});


### PR DESCRIPTION
fix: scout captures by decision coverage, never by an invented reference count

The scout narrated a fabricated quota ("18-25 references") even though the
coverage contract already forbids capture quotas — the model invented a
confident-sounding number, exactly the fake specificity this tool removes.

Harden the scout skill and agent: capture strictly per decision (for each
decision the design must make, capture until there is enough independent
evidence to settle it, then move on), stop when another capture would not
change any remaining decision, and never choose, target, estimate, or
announce a number or range of references (no "18-25", no "N of M"). Report
only which decision is being evidenced.

prompt-contract test locks the per-decision + convergence-stop + no-count rule
in both the skill and the agent.

Gates: build ok, tsc clean, 1364 pass / 0 fail / 1 skip.
