### PR TITLE
fix: de-anchor scout from famous benchmarks, register-gate the one-risk rule

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -57,6 +57,12 @@ remaining decision. Never choose, target, estimate, or announce a number or rang
 (never "18–25 references", never an "N of M" count) — a fabricated count is the fake specificity this
 tool removes. Report only which decision you are gathering evidence for. If motion is irrelevant,
 state why rather than manufacturing a motion study.
+Do not reflexively web-search the same famous benchmarks on every brief (토스/Toss, Linear, Stripe,
+Vercel, 당근, Kakao). They are documented examples, not a default reference set; reaching for them every
+time is the reference-grammar homogenization this tool exists to remove. Search this product's own domain,
+its real competitors, and its audience's language; a famous product enters only when this brief's actual
+problem points to it, and even then it is one measured source among the domain's own evidence, never the
+starting point. Issue the independent searches for a research pass in parallel, not one at a time.
 Two output-neutral ways to save time, neither of which changes what the fragment inventory teaches: reuse a
 coverage-complete `.omd/refs/` inventory when this directory already has one for the concept (capture
 only the missing categories rather than rebuilding it), and capture references in parallel with

--- a/core/theory/expressive.md
+++ b/core/theory/expressive.md
@@ -74,6 +74,8 @@ Each is a layout that survives the slop scan and still announces a template. Tre
 
 A distinctive composition commits at least one genuine risk a template would not take, grounded in the concept and never in decoration: a deliberate asymmetry that directs the eye to one mass; a scale or weight contrast large enough to read as a decision, not a default; a grid break at the one moment that matters; or the real supplied material (image, portrait, slide, dataset) made structural rather than illustrative. One committed risk beats five safe refinements. If a candidate reads as "the reasonable layout," it has not earned the register — name the template it resembles and depart from it once, on purpose.
 
+On a `product` or quiet surface the risk is functional, not thematic. The template to break is the generic admin/dashboard — evenly-weighted panels, decorative chrome, a hero band on a work surface — and the departure is a real operating advantage a template ignores: higher information density, faster scanning, fewer errors, keyboard/bulk efficiency, or a domain workflow the generic tool omits. A named theme, a decorative metaphor, or a "memorable moment" is the wrong risk here. A product's distinction is that it is faster and clearer to operate; the best work surface is closer to forgettable than memorable. "Memorable" is a marketing goal — never import it into a tool.
+
 ### The AI-SaaS landing tells (the specific template to break)
 
 The most common generic result is the AI-SaaS landing page. Every item below is a tell to avoid, not a default to reach for — a design that matches the checklist reads as machine-made in one second regardless of polish.

--- a/core/theory/voice.md
+++ b/core/theory/voice.md
@@ -161,6 +161,11 @@ Their stated reason is consistency of experience — 합니다체 anywhere break
 the rest of the product has established. The rule also extends to avoiding over-polite forms
 (~시겠어요?, ~께) that amplify formality past what the relationship calls for.
 
+Cite Toss (and 당근, Kakao) as documented examples of register discipline, never as a voice to copy. The
+register rules are already stated above — do not web-search a product's copy strings to imitate "토스식
+해요체" reflexively, which reproduces one company's register across every Korean product. This product's
+voice is chosen from its own audience, situation, and authority, not from a famous app's strings.
+
 What the `SLOP-KO-REGISTER-MIX` rule detects — 해요체 and 합니다체 alternating within one
 text node — is a review candidate. It may expose unplanned register drift, or it may be
 required by quoted speech or a deliberate change of speaker. Context decides.

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   getting wrong, design habits.
 ---
 
-# oh-my-design:coach
+# OMD-coach
 
 ```bash
 omd coach

--- a/skills/figma/SKILL.md
+++ b/skills/figma/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   Triggers: 피그마, figma link, 피그마 그대로 구현, any figma.com URL in the brief.
 ---
 
-# oh-my-design:figma
+# OMD-figma
 
 When Figma exists, the design is already decided. The frame/concept/reference steps
 of the design loop are not needed — someone made those choices, and they are visible

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   make it sound human, de-AI, rewrite naturally.
 ---
 
-# oh-my-design:humanize
+# OMD-humanize
 
 Natural writing is not text with detector bait removed. It is a person, in a specific
 situation, trying to change what a specific listener knows, feels able to do, or does next.

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   이 페이지 UX 개선해줘, find references, inspiration board, how do other sites do, fix/improve the UX.
 ---
 
-# oh-my-design:scout
+# OMD-scout
 
 A LEGO reference assembly, measured instead of pinned. Read
 `protocol/reference-assembly.md` under `omd pack dir`; it owns the exact eight stages,
@@ -68,6 +68,13 @@ omd ref list
 omd ref check
 omd ref candidates
 ```
+
+Do not reflexively web-search the same famous benchmarks (토스/Toss, Linear, Stripe, Vercel, 당근) on
+every brief — that reflex is the reference-grammar homogenization this tool removes. Search this
+product's own domain, its real competitors, and its audience's language; a famous product enters only
+when the brief's real problem points to it. Run independent searches and captures in parallel — batch
+captures with `omd ref add-batch <manifest.json>`, never a sequential `omd ref add` per reference when
+several are already known.
 
 Whole-page captures establish rhythm or product feel; tight selectors establish component
 anatomy; type and motion studies establish measured behavior; image references support only

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -65,6 +65,12 @@ instructions: |
   (never "18–25 references", never an "N of M" count) — a fabricated count is the fake specificity this
   tool removes. Report only which decision you are gathering evidence for. If motion is irrelevant,
   state why rather than manufacturing a motion study.
+  Do not reflexively web-search the same famous benchmarks on every brief (토스/Toss, Linear, Stripe,
+  Vercel, 당근, Kakao). They are documented examples, not a default reference set; reaching for them every
+  time is the reference-grammar homogenization this tool exists to remove. Search this product's own domain,
+  its real competitors, and its audience's language; a famous product enters only when this brief's actual
+  problem points to it, and even then it is one measured source among the domain's own evidence, never the
+  starting point. Issue the independent searches for a research pass in parallel, not one at a time.
   Two output-neutral ways to save time, neither of which changes what the fragment inventory teaches: reuse a
   coverage-complete `.omd/refs/` inventory when this directory already has one for the concept (capture
   only the missing categories rather than rebuilding it), and capture references in parallel with

--- a/src/skills/omd-coach/SKILL.md
+++ b/src/skills/omd-coach/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   getting wrong, design habits.
 ---
 
-# omd-coach
+# OMD-coach
 
 ```bash
 omd coach

--- a/src/skills/omd-figma/SKILL.md
+++ b/src/skills/omd-figma/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   Triggers: 피그마, figma link, 피그마 그대로 구현, any figma.com URL in the brief.
 ---
 
-# omd-figma
+# OMD-figma
 
 When Figma exists, the design is already decided. The frame/concept/reference steps
 of the design loop are not needed — someone made those choices, and they are visible

--- a/src/skills/omd-humanize/SKILL.md
+++ b/src/skills/omd-humanize/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   make it sound human, de-AI, rewrite naturally.
 ---
 
-# omd-humanize
+# OMD-humanize
 
 Natural writing is not text with detector bait removed. It is a person, in a specific
 situation, trying to change what a specific listener knows, feels able to do, or does next.

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   이 페이지 UX 개선해줘, find references, inspiration board, how do other sites do, fix/improve the UX.
 ---
 
-# omd-scout
+# OMD-scout
 
 A LEGO reference assembly, measured instead of pinned. Read
 `protocol/reference-assembly.md` under `omd pack dir`; it owns the exact eight stages,
@@ -68,6 +68,13 @@ omd ref list
 omd ref check
 omd ref candidates
 ```
+
+Do not reflexively web-search the same famous benchmarks (토스/Toss, Linear, Stripe, Vercel, 당근) on
+every brief — that reflex is the reference-grammar homogenization this tool removes. Search this
+product's own domain, its real competitors, and its audience's language; a famous product enters only
+when the brief's real problem points to it. Run independent searches and captures in parallel — batch
+captures with `omd ref add-batch <manifest.json>`, never a sequential `omd ref add` per reference when
+several are already known.
 
 Whole-page captures establish rhythm or product feel; tight selectors establish component
 anatomy; type and motion studies establish measured behavior; image references support only

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -404,3 +404,29 @@ test('scout captures by decision coverage, never by a targeted or announced refe
     assert.match(source, /fabricated specificity|fake specificity/i);
   }
 });
+
+test('the one-risk requirement is functional, not thematic, on a product surface', () => {
+  const expressive = read('core/theory/expressive.md');
+  const source = expressive.replace(/\s+/g, ' ');
+  assert.match(source, /On a `product` or quiet surface the risk is functional, not thematic/i);
+  assert.match(source, /A named theme, a decorative metaphor, or a "memorable moment" is the wrong risk/i);
+  assert.match(source, /"Memorable" is a marketing goal/i);
+});
+
+test('scout does not reflexively reach for famous benchmarks and searches in parallel', () => {
+  const skill = read('src/skills/omd-scout/SKILL.md');
+  const agent = read('src/agents/scout.agent.yaml');
+  for (const raw of [skill, agent]) {
+    const source = raw.replace(/\s+/g, ' ');
+    assert.match(source, /reflexively web-search the same famous benchmarks/i);
+    assert.match(source, /reference-grammar homogenization/i);
+    assert.match(source, /Linear/);
+    assert.match(source, /in parallel/i);
+  }
+});
+
+test('voice cites Toss as a documented example, never a voice to copy', () => {
+  const voice = read('core/theory/voice.md').replace(/\s+/g, ' ');
+  assert.match(voice, /documented examples of register discipline, never as a voice to copy/i);
+  assert.match(voice, /do not web-search a product's copy strings to imitate/i);
+});


### PR DESCRIPTION
fix: stop the scout reflexively reaching for famous benchmarks, register-gate the one-risk rule

Three prompt-contract fixes against the same root failure: importing an outside
grammar instead of deriving from this product.

Scout de-homogenization + parallel research
- The scout web-searched the same famous apps on every brief (토스 for Korean
  copy voice, Linear for dark/neutral UI, Stripe, Vercel, 당근). That reflex is
  the reference-grammar homogenization this tool exists to remove: every design
  converges on the same few benchmarks. It now searches this product's own
  domain, its real competitors, and its audience language; a famous product
  enters only when the brief's actual problem points to it.
- It also ran searches and captures one at a time (~15-16s each, sequential). The
  contract now requires issuing independent searches in parallel and batching
  captures with `omd ref add-batch`, not a sequential `omd ref add` per reference.
- voice.md no longer treats Toss as the Korean product-voice authority to copy;
  Toss/당근/Kakao are documented examples of register discipline, the register
  rules are already stated, and there is no web-searching a product's copy strings
  to imitate "토스식 해요체".

Register-gate the one-risk requirement
- On a product/quiet surface the required risk is functional (density, scanning,
  fewer errors, keyboard/bulk efficiency, domain workflow), not a named theme or
  "memorable moment". "Memorable" is a marketing goal, never imported into a tool.
  Fixes the ERP theming drift.

Brand casing
- Skill H1 titles carry the OMD brand uppercase (OMD-scout/coach/figma/humanize),
  matching the already-uppercase prose. CLI commands, `.omd/` paths, and machine
  identifiers (name: omd, oh-my-design@omd) are unchanged — uppercasing those
  breaks install.

Locking positive/negative tests added in test/prompt-contract.test.ts.
