### PR TITLE
fix: install links the omd CLI to the build so omd pack dir serves current core

### DIFF
--- a/bin/omd-install.ts
+++ b/bin/omd-install.ts
@@ -2,6 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
 import { detectHosts } from '../core/install/detect.ts';
 import { install, uninstall, doctor } from '../core/install/install.ts';
 import { installBrowserRs, resolveBrowserRs, uninstallBrowserRs } from '../core/install/browser-rs.ts';
@@ -9,6 +10,7 @@ import { doctorBrowserProvider } from '../core/install/browser-provider.ts';
 import { runBrowserRsSmoke } from '../core/install/browser-rs-smoke.ts';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const cliBinDir = join(homedir(), '.local', 'bin');
 
 function usage(): never {
   console.error(
@@ -161,7 +163,7 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'install') {
-    for (const line of await install(hosts)) console.log(line);
+    for (const line of await install(hosts, { cliBinDir })) console.log(line);
     console.log(`\nInstalled for: ${hosts.map((h) => h.host).join(', ')}.`);
     console.log('Open a session there and type /ultradesign.');
     return;
@@ -173,7 +175,7 @@ async function main(): Promise<void> {
   }
 
   // doctor
-  const results = await doctor(hosts);
+  const results = await doctor(hosts, { cliBinDir });
   let failed = false;
   for (const r of results) {
     console.log(`${r.host}:`);

--- a/core/install/install.ts
+++ b/core/install/install.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, cpSync, rmSync, readdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, cpSync, rmSync, readdirSync, symlinkSync, lstatSync, readlinkSync, unlinkSync, chmodSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -203,6 +203,7 @@ function uninstallCodex(d: Detected, changes: string[]): void {
 export type InstallOptions = {
   readonly browser?: BrowserRsInstallDependencies;
   readonly prebuiltRoot?: string;
+  readonly cliBinDir?: string;
 };
 
 export async function install(hosts: Detected[], options: InstallOptions = {}): Promise<string[]> {
@@ -211,11 +212,95 @@ export async function install(hosts: Detected[], options: InstallOptions = {}): 
   const version = pkgVersion();
   const changes: string[] = [];
   for (const d of hosts) {
-    if (d.host === 'claude') installClaude(d, changes);
-    else installCodex(d, version, distributionRoot, changes);
+    if (d.host === 'claude') {
+      installClaude(d, changes);
+      claudePluginFreshnessNote(d, changes);
+    } else {
+      installCodex(d, version, distributionRoot, changes);
+    }
   }
+  if (options.cliBinDir !== undefined) linkCli(options.cliBinDir, changes);
   changes.push(browserInstallChange(await installBrowserRs(options.browser)));
   return changes;
+}
+
+/**
+ * Point the user's `omd` / `oh-my-design` CLI at THIS build's bin shims. `omd pack dir`
+ * resolves the knowledge pack relative to the running binary, and every skill reads its
+ * theory/protocol files through `omd pack dir`. If the CLI symlink is left pointing at an
+ * older install, the plugin can update while the whole core pack the agents actually read
+ * stays frozen — every core/ change is invisible at runtime. Linking here keeps the CLI, its
+ * pack dir, and the freshly installed plugin on one build. Only runs when a bin dir is given
+ * (the command-line entry supplies ~/.local/bin); a hermetic caller opts out by omitting it.
+ */
+export function linkCli(binDir: string, changes: string[]): void {
+  mkdirSync(binDir, { recursive: true });
+  const links: ReadonlyArray<readonly [string, string]> = [
+    ['omd', join(pkgRoot, 'bin', 'omd.mjs')],
+    ['oh-my-design', join(pkgRoot, 'bin', 'omd-install.mjs')],
+  ];
+  for (const [name, target] of links) {
+    try {
+      chmodSync(target, 0o755);
+    } catch {
+      // A read-only target still resolves through the symlink; the exec bit is best-effort.
+    }
+    const linkPath = join(binDir, name);
+    let existing: 'absent' | 'symlink' | 'file' = 'absent';
+    let previous: string | undefined;
+    try {
+      const stat = lstatSync(linkPath);
+      if (stat.isSymbolicLink()) {
+        existing = 'symlink';
+        previous = readlinkSync(linkPath);
+      } else {
+        existing = 'file';
+      }
+    } catch {
+      // Nothing linked yet.
+    }
+    if (existing === 'symlink' && previous === target) {
+      changes.push(`cli: ${name} -> ${target} (already current)`);
+      continue;
+    }
+    if (existing === 'symlink') {
+      unlinkSync(linkPath);
+    } else if (existing === 'file') {
+      backupFile(linkPath, binDir);
+      rmSync(linkPath, { force: true });
+    }
+    symlinkSync(target, linkPath);
+    changes.push(
+      existing === 'symlink'
+        ? `cli: relinked ${name} -> ${target} (was ${previous})`
+        : `cli: linked ${name} -> ${target}`,
+    );
+  }
+}
+
+/**
+ * Read-only advisory. Claude Code loads OMD from its own versioned plugin cache, not from what
+ * this installer writes; when that cache is older than the build, the skill/agent wrappers are
+ * stale even though the marketplace is registered and the CLI is freshly linked. Surface it so
+ * the user runs /plugin to update — core/theory is already current through the linked omd CLI.
+ */
+function claudePluginFreshnessNote(d: Detected, changes: string[]): void {
+  const installedPath = join(d.home, 'plugins', 'installed_plugins.json');
+  if (!existsSync(installedPath)) return;
+  try {
+    const data = JSON.parse(readFileSync(installedPath, 'utf8')) as {
+      plugins?: Record<string, ReadonlyArray<{ version?: string }>>;
+    };
+    const installed = data.plugins?.['oh-my-design@omd']?.[0]?.version;
+    const build = pkgVersion();
+    if (installed !== undefined && installed !== build) {
+      changes.push(
+        `claude: loaded plugin is ${installed}, this build is ${build} — run /plugin in Claude and update oh-my-design so the skill/agent wrappers match (core/theory is already live via the omd CLI link)`,
+      );
+    }
+  } catch {
+    // installed_plugins.json unreadable — skip the advisory rather than fail the install.
+  }
 }
 
 export type UninstallOptions = { readonly browser?: BrowserRsDependencies };
@@ -353,7 +438,7 @@ function doctorCodex(d: Detected): DoctorCheck[] {
   return checks;
 }
 
-export type DoctorOptions = { readonly browser?: BrowserProviderDoctorOptions };
+export type DoctorOptions = { readonly browser?: BrowserProviderDoctorOptions; readonly cliBinDir?: string };
 
 function browserProviderCheck(result: BrowserProviderHealth): DoctorCheck {
   if ('fallback' in result) {
@@ -376,12 +461,27 @@ function browserProviderCheck(result: BrowserProviderHealth): DoctorCheck {
   }
 }
 
+function cliLinkCheck(binDir: string): DoctorCheck {
+  const linkPath = join(binDir, 'omd');
+  const expected = join(pkgRoot, 'bin', 'omd.mjs');
+  try {
+    const stat = lstatSync(linkPath);
+    if (!stat.isSymbolicLink()) return check('omd CLI links to this build', false, `${linkPath} is not a symlink`);
+    const actual = readlinkSync(linkPath);
+    return check('omd CLI links to this build', actual === expected, actual === expected ? undefined : `omd -> ${actual}, expected ${expected}`);
+  } catch {
+    return check('omd CLI links to this build', false, `${linkPath} not found`);
+  }
+}
+
 export async function doctor(hosts: Detected[], options: DoctorOptions = {}): Promise<DoctorResult[]> {
   const versionCheck = omdVersionRuns();
   const browserCheck = browserProviderCheck(await doctorBrowserProvider(options.browser));
+  const cliCheck = options.cliBinDir === undefined ? undefined : cliLinkCheck(options.cliBinDir);
   return hosts.map((d) => {
     const checks = d.host === 'claude' ? doctorClaude(d) : doctorCodex(d);
     checks.push(versionCheck);
+    if (cliCheck !== undefined) checks.push(cliCheck);
     checks.push(browserCheck);
     return { host: d.host, ok: checks.every((c) => c.ok), checks };
   });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmodSync, cpSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -433,5 +433,99 @@ test('Given a healthy host and explicit browser provider When install runs Then 
     assert.equal(settings.enabledPlugins?.['oh-my-design@omd'], true);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── CLI symlink + plugin freshness ──
+
+const OMD_SHIM = join(PACKAGE_ROOT, 'bin', 'omd.mjs');
+const INSTALL_SHIM = join(PACKAGE_ROOT, 'bin', 'omd-install.mjs');
+const BUILD_VERSION = (JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8')) as { version: string }).version;
+
+test('install links the omd CLI to this build so omd pack dir serves the current core', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'omd-cli-home-'));
+  const binDir = mkdtempSync(join(tmpdir(), 'omd-cli-bin-'));
+  const detected = { host: 'codex' as const, home };
+  try {
+    const changes = await install([detected], { browser: UNSUPPORTED_BROWSER.browser, cliBinDir: binDir });
+    assert.ok(lstatSync(join(binDir, 'omd')).isSymbolicLink(), 'omd is a symlink');
+    assert.ok(lstatSync(join(binDir, 'oh-my-design')).isSymbolicLink(), 'oh-my-design is a symlink');
+    assert.equal(readlinkSync(join(binDir, 'omd')), OMD_SHIM);
+    assert.equal(readlinkSync(join(binDir, 'oh-my-design')), INSTALL_SHIM);
+    assert.ok(changes.some((c) => c.startsWith('cli: linked omd -> ') && c.endsWith('omd.mjs')));
+
+    const result = (await doctor([detected], { ...UNSUPPORTED_BROWSER_DOCTOR, cliBinDir: binDir }))[0]!;
+    assert.equal(result.checks.find((c) => c.name === 'omd CLI links to this build')?.ok, true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});
+
+test('install relinks a stale omd symlink and reports the previous target', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'omd-cli-home-'));
+  const binDir = mkdtempSync(join(tmpdir(), 'omd-cli-bin-'));
+  const stale = join(binDir, 'stale-omd.mjs');
+  writeFileSync(stale, '// stale');
+  symlinkSync(stale, join(binDir, 'omd'));
+  const detected = { host: 'codex' as const, home };
+  try {
+    const changes = await install([detected], { browser: UNSUPPORTED_BROWSER.browser, cliBinDir: binDir });
+    assert.equal(readlinkSync(join(binDir, 'omd')), OMD_SHIM);
+    assert.ok(changes.some((c) => c.includes('relinked omd ->') && c.includes(`(was ${stale})`)));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});
+
+test('install without a cli bin dir never touches the user PATH', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'omd-cli-home-'));
+  const binDir = mkdtempSync(join(tmpdir(), 'omd-cli-bin-'));
+  const detected = { host: 'codex' as const, home };
+  try {
+    const changes = await install([detected], UNSUPPORTED_BROWSER);
+    assert.ok(!existsSync(join(binDir, 'omd')), 'no symlink created without cliBinDir');
+    assert.ok(!changes.some((c) => c.startsWith('cli:')), 'no cli change reported');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});
+
+test('a Claude plugin cache older than the build is surfaced as a /plugin update advisory', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'omd-claude-stale-plugin-'));
+  const detected = { host: 'claude' as const, home };
+  try {
+    mkdirSync(join(home, 'plugins'), { recursive: true });
+    const write = (version: string) => writeFileSync(
+      join(home, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({ plugins: { 'oh-my-design@omd': [{ version }] } }),
+    );
+    write('0.0.1');
+    const stale = await install([detected], UNSUPPORTED_BROWSER);
+    assert.ok(stale.some((c) => c.includes('loaded plugin is 0.0.1') && c.includes('/plugin')));
+
+    write(BUILD_VERSION);
+    const fresh = await install([detected], UNSUPPORTED_BROWSER);
+    assert.ok(!fresh.some((c) => c.startsWith('claude: loaded plugin')), 'no advisory when versions match');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('a second install with the same cli bin dir leaves the omd symlink in place', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'omd-cli-home-'));
+  const binDir = mkdtempSync(join(tmpdir(), 'omd-cli-bin-'));
+  const detected = { host: 'codex' as const, home };
+  try {
+    await install([detected], { browser: UNSUPPORTED_BROWSER.browser, cliBinDir: binDir });
+    const changes = await install([detected], { browser: UNSUPPORTED_BROWSER.browser, cliBinDir: binDir });
+    assert.ok(lstatSync(join(binDir, 'omd')).isSymbolicLink(), 'omd symlink survives a repeat install');
+    assert.equal(readlinkSync(join(binDir, 'omd')), OMD_SHIM);
+    assert.ok(changes.some((c) => c === `cli: omd -> ${OMD_SHIM} (already current)`));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
fix: install links the omd CLI to the build so omd pack dir serves the current core

The local-build install workflow silently no-op'd every core/ change. `install` patched
host configs (settings.json / config.toml) and copied the Codex plugin dist, but never
touched the `omd` CLI. Skills read all theory/protocol through `omd pack dir`, which resolves
relative to the running binary — and that binary stayed pinned to an old versioned npm store
(0.16.1). So the CLI, and the entire knowledge pack the agents actually read, were frozen
while the plugin advanced. Register gates, scout de-anchoring, and the no-direct-build gate
all landed in git but were invisible at runtime.

- `install` now links `~/.local/bin/{omd,oh-my-design}` to this build's bin shims (the CLI
  entry supplies the bin dir via `InstallOptions.cliBinDir`; hermetic callers omit it). It
  only removes an existing link when the target actually changes — an "already current" link
  is left in place, never deleted-then-skipped.
- Claude loads OMD from its own versioned plugin cache, which this installer cannot rewrite.
  When that cache is older than the build, install now prints a read-only advisory to run
  /plugin in Claude; core/theory is already live via the freshly linked CLI.
- `doctor --cliBinDir` gains an "omd CLI links to this build" check so the exact staleness
  that caused this regression is caught next time.

Locking tests: CLI link + relink + idempotent-repeat (symlink survives) + no-op without a bin
dir + the Claude freshness advisory.
