### PR TITLE
feat: distill FWA distinctly and add the horizontal-scroll-gallery recipe

### DIFF
--- a/core/composition/horizontal-scroll-gallery.md
+++ b/core/composition/horizontal-scroll-gallery.md
@@ -1,0 +1,113 @@
+# Horizontal scroll gallery
+
+> Candidate hypothesis only. Revalidate its condition, values, and responsive transition
+> against the current composition contract; do not transfer this page recipe unchanged.
+
+A horizontal scroll gallery lays a set of peer panels in a single row and moves the reading
+axis sideways: the user scrolls (or drags, or arrows) through items along the x-axis instead
+of the y-axis. It is a showpiece/marketing move — a portfolio index, a campaign lookbook, a
+product-shot sequence — where the sideways travel is itself the concept (a filmstrip, a shelf,
+a runway). Use it with the register conditions in `core/theory/expressive.md`; it is never a
+default container for a list.
+
+## When it earns its place / When it does not
+
+Use it when the items are genuine peers with no priority order, the sideways motion carries a
+concept (a reel, a shelf, a horizon), and the surface is a `marketing` or showpiece register
+where experiencing the sequence is part of the point. The affordance must be unmistakable — a
+visible scrollbar, a progress rail, paired prev/next controls, or a partially-clipped next
+panel that signals "there is more this way." Keyboard and native scroll must reach every panel.
+
+Do not use it on a `product` or quiet surface, or for content the user needs to scan, compare,
+or find fast: horizontal rows hide items off-screen behind a gesture many users never discover,
+defeat Ctrl/Cmd+F, and break the vertical scan the eye defaults to. Do not hijack vertical
+scroll into horizontal translation (`translateX` driven by `scrollY`) as the primary mechanism
+on a required-task path — it steals the scroll gesture, strands keyboard and screen-reader
+users, and is disorienting on trackpads and wheels. A gallery whose next panel gives no visual
+signal that it exists has failed even if it animates beautifully once found.
+
+## Parameters
+
+The passing specimen must supply these required custom properties:
+
+```text
+--hscroll-panel-size
+--hscroll-gap
+--hscroll-peek
+--hscroll-padding-inline
+--hscroll-rail-size
+```
+
+There are no recipe defaults. `--hscroll-peek` is the amount of the next panel left visible at
+the trailing edge (the "there is more" signal); `--hscroll-panel-size` is the per-item inline
+size. `.omd/design.md` records the values chosen for the real item count and media aspect.
+`clamp()`, container queries, and discrete steps are all valid when the rendered targets justify
+them.
+
+## Implementation
+
+Use native overflow with scroll-snap, not scroll-hijacked transforms. Real content order is the
+DOM order, so keyboard, `Home`/`End`, `find-in-page`, and screen readers all work. The panels
+are focusable/reachable; the container announces itself as a scrollable region.
+
+```css
+.hscroll {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--hscroll-panel-size);
+  gap: var(--hscroll-gap);
+  padding-inline: var(--hscroll-padding-inline);
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin; /* keep the affordance visible; never hide the scrollbar */
+}
+
+.hscroll__panel {
+  scroll-snap-align: start;
+  /* --hscroll-peek keeps the next panel's leading edge visible as a "more this way" cue */
+  margin-inline-end: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hscroll { scroll-behavior: auto; }
+}
+```
+
+Provide real prev/next controls that call `element.scrollBy({ left: panelWidth })`; the buttons
+are progressive enhancement over a natively scrollable region, never the only way to advance.
+
+## Responsive behavior
+
+The required evidence is the rendered gallery at 375, 768, and 1280, not a fixed formula. At
+375 (mobile) the row is a native swipe with one panel snapped and the next peeking; the affordance
+is the peek plus the scrollbar. At 768 two or more panels are visible with the rail/controls. At
+1280 the panels sit at their intended size with generous `--hscroll-padding-inline`. If, at any
+width, no next-panel cue is visible and no control is present, the gallery has failed the
+affordance test — reflow to a vertical stack rather than ship a hidden row.
+
+## Do not combine with
+
+**marquee.md (motion recipe)** — an auto-scrolling marquee and a user-driven horizontal
+gallery are two horizontal-motion systems in one view; the auto-motion fights the user's own
+scroll and destroys the snap.
+
+**parallax.md / sticky-scene-transition.md** — a scroll-hijacked vertical→horizontal pin plus a
+native horizontal gallery double-encode the x-axis; the user cannot tell which gesture drives
+which motion.
+
+**bento-grid.md** — a bento mosaic imposes a priority hierarchy on cells; a horizontal gallery
+asserts the items are equal peers in a sequence. Choose the one that matches the content's real
+structure.
+
+## Linter notes
+
+- A horizontal gallery with a hidden scrollbar, no peek, and no controls is an accessibility
+  and discoverability defect: content exists that the user has no signal to reach. `omd check`
+  cannot see the missing affordance directly; a visual/probe review must confirm the next-panel
+  cue or a control is present and keyboard-reachable at 375/768/1280.
+- Scroll-hijack (`translateX` bound to `scrollY`) on a required-task path is a UX defect, not a
+  style choice; it removes the native scroll gesture and keyboard reach. Permitted only on a
+  pure showpiece scene that also passes the Usability obligations in `theory/expressive.md`.
+- A single horizontal row used as the container for scannable or comparable data (prices, specs,
+  search results) is the wrong grammar; the axis mismatch costs the user the vertical scan.

--- a/core/theory/expressive.md
+++ b/core/theory/expressive.md
@@ -52,6 +52,10 @@ What the entrance must do in those seconds: commit the palette, declare the type
 
 A showpiece site that loses its nerve in the footer — reverting to small-print-grey, default columns, four generic links — reveals that the expressive register was applied to the hero and nowhere else. Applied design covers the whole surface. The footer is a scene. It may be quieter than the hero, but it is not absent.
 
+### FWA — the experimental / technical bias
+
+FWA (thefwa.com) rewards a different axis than Awwwards. Its Site/App of the Day skews to technical and interactive ambition — WebGL and shader work, physics and generative systems, bespoke interaction models, and "does this push what the medium can do" — where Awwwards balances that against its 30% usability weight and GDWEB against Korean campaign craft. Treat FWA as evidence of the ceiling for interactive/technical concepts, not as permission to abandon usability: an immersive scene still owes the user reach, orientation, a way out, and a reduced-motion path. Import the ambition of the mechanism, not the excuse to make the surface unusable.
+
 ---
 
 ## Slop-free is not the same as distinctive
@@ -165,6 +169,14 @@ Each entry names the condition under which the technique earns its place and the
 
 **Condition against**: Static backgrounds where the contrast can be calculated and set directly — `difference` on a static background produces a predictable result that could be a fixed colour choice, but with more browser overhead. Not appropriate for body copy (the visual complexity of difference blending at small sizes degrades legibility).
 
+### Horizontal scroll gallery
+
+**Condition for use**: A `marketing`/showpiece surface where a set of equal peers reads as a sequence and the sideways travel is the concept — a portfolio index, a lookbook, a product reel. The affordance is explicit: a visible scrollbar, a progress rail, prev/next controls, or a peeking next panel. See `composition/horizontal-scroll-gallery.md`.
+
+**Condition against**: `product`/quiet surfaces and any content the user scans, compares, or searches. Horizontal rows hide items behind a gesture many users never discover and defeat find-in-page. Never hijack vertical scroll into horizontal translation on a required-task path — it strands keyboard and screen-reader users.
+
+**Implementation constraint**: Native `overflow-x` with `scroll-snap-type: x`; DOM order equals reading order so keyboard, Home/End, and find-in-page work; the scrollbar stays visible and controls are enhancement over a natively scrollable region, never the only way to advance. Reduced-motion disables smooth scroll.
+
 ---
 
 ## The restraint clause
@@ -212,5 +224,6 @@ is documented in `core/graphics/placeholder-policy.md`.
 - W3C, Requirements for Hangul Text Layout and Typography (w3.org/TR/klreq/) — syllable block structure; spacing constraints and the fixed-width character cell at display scale
 - Awwwards, "Customize your mouse cursor" (awwwards.com/customize-your-mouse-cursor) — cursor as brand vocabulary on award-winning sites; pointer-fine scoping requirement
 - GDWEB Design Awards, About (gdweb.co.kr/sub/about.asp) — Korean award context, judge composition, selection categories dominated by agency and campaign microsites
+- FWA (thefwa.com/awards) — Site/App of the Day bias toward technical and interactive ambition (WebGL, generative systems, bespoke interaction); the interactive/technical ceiling reference, distinct from Awwwards' usability-weighted and GDWEB's campaign-craft criteria
 - Motion theory cross-reference: see `core/theory/motion.md` — duration windows, reduced-motion requirement, transform/opacity constraint, and the attention budget argument all apply in the showpiece register without exception
 - Motion cookbook: working implementations of every technique catalogued above (split-text, scroll-reveal, sticky scene, section inversion, marquee, magnetic hover, and more) are in `core/motion/recipes/`; easing token vocabulary is in `core/motion/easing.md`

--- a/test/composition-cookbook.test.ts
+++ b/test/composition-cookbook.test.ts
@@ -20,7 +20,7 @@ const REQUIRED_HEADINGS = [
   '## Do not combine with',
 ];
 
-// ── Exactly 11 recipe files: 8 editorial/marketing + 3 product-surface ────────
+// ── Exactly 12 recipe files: 9 editorial/marketing + 3 product-surface ────────
 const EXPECTED_RECIPES = [
   'typographic-hero.md',
   'asymmetric-diagonal-grid.md',
@@ -30,6 +30,7 @@ const EXPECTED_RECIPES = [
   'bento-grid.md',
   'split-screen-hero.md',
   'sticky-sidebar-scroll.md',
+  'horizontal-scroll-gallery.md',
   'app-shell-workbench.md',
   'master-detail-flow.md',
   'form-wizard-stepper.md',
@@ -39,19 +40,19 @@ test('core/composition/ directory exists', () => {
   assert.ok(existsSync(recipesDir), `composition directory not found at ${recipesDir}`);
 });
 
-test('all 11 expected composition recipe files exist', () => {
+test('all 12 expected composition recipe files exist', () => {
   for (const name of EXPECTED_RECIPES) {
     const path = join(recipesDir, name);
     assert.ok(existsSync(path), `missing composition recipe: ${name}`);
   }
 });
 
-test('composition directory contains exactly 11 .md files', () => {
+test('composition directory contains exactly 12 .md files', () => {
   const files = readdirSync(recipesDir).filter((f) => f.endsWith('.md'));
   assert.equal(
     files.length,
-    11,
-    `expected 11 composition recipe files, found ${files.length}: ${files.join(', ')}`
+    12,
+    `expected 12 composition recipe files, found ${files.length}: ${files.join(', ')}`
   );
 });
 
@@ -164,4 +165,14 @@ test('every composition recipe has substantive Implementation section', () => {
       `${name}: Implementation section contains no code block`
     );
   }
+});
+
+// ── horizontal-scroll-gallery.md must gate its own accessibility failure modes ──
+
+test('horizontal-scroll-gallery.md gates against product/quiet and forbids scroll-hijack on task paths', () => {
+  const path = join(recipesDir, 'horizontal-scroll-gallery.md');
+  assert.ok(existsSync(path), 'horizontal-scroll-gallery.md not found');
+  const content = readFileSync(path, 'utf8').replace(/\s+/g, ' ');
+  assert.ok(content.includes('Do not use it on a `product` or quiet surface'), 'must gate out product/quiet');
+  assert.ok(content.includes('hijack vertical scroll into horizontal'), 'must forbid scroll-hijack on a task path');
 });

--- a/test/interaction-recipes.test.ts
+++ b/test/interaction-recipes.test.ts
@@ -91,7 +91,7 @@ test('core/interaction/recipes/ does not disturb the composition recipe count', 
   const files = readdirSync(compositionDir).filter((f) => f.endsWith('.md'));
   assert.equal(
     files.length,
-    11,
-    `expected composition recipes to remain 11 (8 editorial + 3 product-surface), found ${files.length}`
+    12,
+    `expected composition recipes to remain 12 (9 editorial + 3 product-surface), found ${files.length}`
   );
 });

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -440,3 +440,11 @@ test('there is no direct-build escape; register gates distinctive, never whether
   const expressive = read('core/theory/expressive.md').replace(/\s+/g, ' ');
   assert.match(expressive, /gates how "distinctive" is judged, never whether the loop runs/i);
 });
+
+test('expressive distills FWA distinctly and gates the horizontal gallery to showpiece', () => {
+  const source = read('core/theory/expressive.md').replace(/\s+/g, ' ');
+  assert.match(source, /FWA \(thefwa\.com\) rewards a different axis than Awwwards/i);
+  assert.match(source, /not as permission to abandon usability/i);
+  assert.match(source, /### Horizontal scroll gallery/);
+  assert.match(source, /composition\/horizontal-scroll-gallery\.md/);
+});


### PR DESCRIPTION
feat: distill FWA distinctly and add the horizontal-scroll-gallery recipe

The award-gallery technique space the request asked for (FWA / Awwwards / GDWEB) is already
distilled in core/theory/expressive.md — a register-conditioned `## Technique catalogue`, a
`## The restraint clause` (two or three techniques, never an effects catalogue), a
`## Korean showpiece typography` section for GDWEB, and cited Awwwards evaluation sources. The
composition (11), graphics (5), and motion (12) cookbooks implement those moves. Authoring a
second "atlas" would duplicate that. This fills only the two real gaps.

- FWA was named as a showpiece context but never distilled. Add a `### FWA — the experimental /
  technical bias` subsection: FWA rewards technical/interactive ambition (WebGL, generative,
  bespoke interaction) on a different axis than Awwwards' usability-weighted or GDWEB's campaign
  criteria — imported as a ceiling for the mechanism, never as permission to abandon usability.
  Cited in Sources.
- The horizontal scroll gallery was a genuinely missing composition move. Add
  core/composition/horizontal-scroll-gallery.md (full schema): native overflow + scroll-snap,
  DOM order = reading order, visible affordance. Gated hard — showpiece/marketing only, never
  product/quiet, and scroll-hijack on a required-task path is called a UX defect. Catalogued in
  expressive.md.

Cookbook counts updated to 12 (composition-cookbook + interaction-recipes). Locking tests: the
recipe's product/quiet + scroll-hijack gates, and the FWA + catalogue clauses in expressive.md.
