### PR TITLE
feat: fill four detectable design gates (font circus, justified, tiny text, heading skip)

### DIFF
--- a/core/rules/builtin/heading-order.yaml
+++ b/core/rules/builtin/heading-order.yaml
@@ -1,0 +1,20 @@
+# A11Y-HEADING-SKIP — heading levels must not skip a level going down (h1 -> h3 with no h2).
+# Screen-reader users navigate by heading level; a skipped level breaks the document outline
+# and hides the missing rank. WCAG 2.1 §1.3.1 (Info and Relationships) and §2.4.6 (Headings
+# and Labels). Fires at the page level, reading node.heading (1-6) in document order. Going
+# back up (h3 -> h2) is fine — only a downward jump greater than one level is a defect.
+#
+# Positive test:  headings [1, 3]        -> fires ("1->3")
+# Negative tests:
+#   — [1, 2, 3]        -> silent
+#   — [1, 2, 2, 3]     -> silent
+#   — [2, 1]           -> silent (upward jump)
+#   — no headings      -> silent
+id: A11Y-HEADING-SKIP
+layer: 1
+category: a11y
+severity: warn
+when: "node.parent === null"
+value: "(() => { const hs = ir.nodes.filter(n => typeof n.heading === 'number').map(n => n.heading); const skips = []; for (let i = 1; i < hs.length; i++) { if (hs[i] > hs[i-1] + 1) skips.push(hs[i-1] + '->' + hs[i]); } return skips; })()"
+assert: "value.length === 0"
+message: "Heading level skipped: {value}. A heading jumps down more than one level (e.g. h1 -> h3 with no h2), breaking the document outline screen-reader users navigate by. Use the next level down, or restructure. WCAG 2.1 §1.3.1 and §2.4.6. See theory/ux.md §Accessibility as a UX floor."

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -378,3 +378,40 @@
   value: "(() => { const sizes = [...new Set(ir.nodes.filter(n => n.fontSize && n.fontSize > 0).map(n => n.fontSize))].sort((a, b) => a - b); if (sizes.length < 3) return null; const allFlat = sizes.every(s => s >= 13 && s <= 19); const ratios = sizes.slice(1).map((s, i) => s / sizes[i]); const minR = ratios.reduce((a, b) => Math.min(a, b), 99); const flatCount = ratios.filter(r => r < 1.15).length; return (allFlat || flatCount >= 2) ? { sizes, minRatio: Math.round(minR * 100) / 100 } : null; })()"
   assert: "value === null"
   message: "Flat type hierarchy: {value}. Font sizes all cluster between 13–19px or adjacent steps differ by less than 1.15×. Size stops carrying hierarchy. Establish at least three steps at 1.25× minimum (e.g. 14/18/24px). Use weight — not colour shade — to differentiate content at the same size."
+
+# Type circus: three faces can be a display + text + monospace-numeral system; four or more
+# distinct font families on one page is almost always accidental font soup — a system default,
+# a pasted-in Google Font, a component library's face, and a brand face fighting each other.
+# Refactoring UI: one or two typefaces, a third only for a real role. Fires at four.
+- id: SLOP-FONT-CIRCUS
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.parent === null"
+  value: "[...new Set(ir.nodes.filter(n => n.text && n.fontFamily).map(n => n.fontFamily))]"
+  assert: "value.length < 4"
+  message: "Type circus: {value} — four or more typefaces on one page. A page reads as one system with one or two faces (a third only for a real role, such as monospace tabular numbers). Four families fighting is font soup: pick a text face, at most one display face, and drop the rest. See theory/typography.md §Role map."
+
+# Justified body on the web: without fine hyphenation control, full justification opens uneven
+# word gaps ('rivers') that slow reading. Left-aligned (ragged-right) is the web default for
+# prose. Fires on a real text block (>40 chars), not a one-word cell or heading.
+- id: SLOP-JUSTIFIED-TEXT
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.type === 'TEXT' && Boolean(node.text) && node.text.length > 40"
+  value: "node.textAlign"
+  assert: "value !== 'justify'"
+  message: "Justified body text. On the web, without fine hyphenation control, full justification opens uneven word gaps ('rivers') that slow reading. Use left-aligned (ragged-right) for prose. See theory/typography.md."
+
+# Unreadable body: prose (>30 chars, not a label or numeral) rendered below 11px breaches the
+# readability floor on any screen. Fine print is not an exception — legal and caption text
+# still has to be readable. Short labels and numbers are excluded by the length gate.
+- id: SLOP-TINY-TEXT
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.type === 'TEXT' && Boolean(node.text) && node.text.length > 30 && typeof node.fontSize === 'number'"
+  value: "node.fontSize"
+  assert: "value >= 11"
+  message: "Body text at {value}px is below the readability floor. Prose under ~11px is hard to read on any screen; fine print is not an exception. Set body copy near the mid-teens and secondary text no smaller than 12px. See theory/typography.md §Size, measure, and line height."

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -138,6 +138,49 @@ test('SLOP-DIFFUSE-ACCENT does not fire on one accent plus status colours and ne
   assert.ok(!v.some((x) => x.id === 'SLOP-DIFFUSE-ACCENT'), 'one accent + status + neutrals must not fire');
 });
 
+const richText = (id: string, over: Partial<RawNode>): RawNode => ({
+  id, name: 'T', type: 'TEXT', path: `Root/${id}`, parent: 'root',
+  box: { x: 0, y: 0, w: 320, h: 20 }, children: [], text: 'Some readable body text here.', ...over,
+});
+const runSlop = (nodes: RawNode[]) => check(normalize({ nodes }), builtin, { categories: ['slop'] });
+const runA11y = (nodes: RawNode[]) => check(normalize({ nodes }), builtin, { categories: ['a11y'] });
+
+test('SLOP-FONT-CIRCUS fires at four or more distinct font families, not three', () => {
+  const four = runSlop([accentRoot(['a', 'b', 'c', 'd']),
+    richText('a', { fontFamily: 'inter' }), richText('b', { fontFamily: 'georgia' }),
+    richText('c', { fontFamily: 'jetbrains mono' }), richText('d', { fontFamily: 'arial' })]);
+  assert.ok(four.some((x) => x.id === 'SLOP-FONT-CIRCUS'), 'four families should fire');
+  const three = runSlop([accentRoot(['a', 'b', 'c']),
+    richText('a', { fontFamily: 'inter' }), richText('b', { fontFamily: 'georgia' }),
+    richText('c', { fontFamily: 'jetbrains mono' })]);
+  assert.ok(!three.some((x) => x.id === 'SLOP-FONT-CIRCUS'), 'text + display + mono (three) must not fire');
+});
+
+test('SLOP-JUSTIFIED-TEXT fires on a justified prose block, not on left-aligned', () => {
+  const long = 'This is a real paragraph of body copy long enough to justify.';
+  const yes = runSlop([accentRoot(['a']), richText('a', { text: long, textAlign: 'justify' })]);
+  assert.ok(yes.some((x) => x.id === 'SLOP-JUSTIFIED-TEXT'));
+  const no = runSlop([accentRoot(['a']), richText('a', { text: long, textAlign: 'left' })]);
+  assert.ok(!no.some((x) => x.id === 'SLOP-JUSTIFIED-TEXT'));
+});
+
+test('SLOP-TINY-TEXT fires on sub-11px prose, not on mid-teens body', () => {
+  const long = 'This is a body sentence with more than thirty characters of prose.';
+  const yes = runSlop([accentRoot(['a']), richText('a', { text: long, fontSize: 9 })]);
+  assert.ok(yes.some((x) => x.id === 'SLOP-TINY-TEXT'));
+  const no = runSlop([accentRoot(['a']), richText('a', { text: long, fontSize: 14 })]);
+  assert.ok(!no.some((x) => x.id === 'SLOP-TINY-TEXT'));
+});
+
+test('A11Y-HEADING-SKIP fires on a skipped heading level, not on a contiguous outline', () => {
+  const skip = runA11y([accentRoot(['a', 'b']),
+    richText('a', { heading: 1, text: 'Title' }), richText('b', { heading: 3, text: 'Sub' })]);
+  assert.ok(skip.some((x) => x.id === 'A11Y-HEADING-SKIP'));
+  const ok = runA11y([accentRoot(['a', 'b', 'c']),
+    richText('a', { heading: 1 }), richText('b', { heading: 2 }), richText('c', { heading: 3 })]);
+  assert.ok(!ok.some((x) => x.id === 'A11Y-HEADING-SKIP'));
+});
+
 // Helpers for text-node rule tests
 function makeTextIr(text: string) {
   const node: RawNode = {


### PR DESCRIPTION
feat: fill four detectable design gates missing from the deterministic layer

Same class of gap as the colour one: essential design/accessibility defects that the IR can
measure but no rule caught, so the RED/GREEN loop passed them. All four are reliably detectable
from existing IR fields (fontFamily, fontSize, textAlign, heading), low false-positive, and cite
established theory.

- SLOP-FONT-CIRCUS (slop): four or more distinct font families on one page. One or two faces
  read as a system; a third earns its place only for a real role (monospace tabular numbers).
  Four is font soup. Fires at four to leave display+text+mono alone. (typography.md §Role map.)
- SLOP-JUSTIFIED-TEXT (slop): a prose block (>40 chars) set to text-align: justify. On the web,
  without fine hyphenation, full justification opens word-gap rivers that slow reading.
- SLOP-TINY-TEXT (slop): prose (>30 chars, not a label/number) rendered below 11px — a
  readability floor breach. Fine print is not an exception.
- A11Y-HEADING-SKIP (a11y, new heading-order.yaml): a heading level that jumps down more than
  one step (h1 -> h3 with no h2), breaking the outline screen-reader users navigate by.
  WCAG 2.1 §1.3.1 and §2.4.6. Upward jumps (h3 -> h2) are fine.

Locking positive/negative tests for each. None fire on the existing fixtures.
