### PR TITLE
feat: gate crammed body leading (rule) + icon-only accessible names (eye)

### DIFF
--- a/agents/eye.md
+++ b/agents/eye.md
@@ -85,6 +85,10 @@ action and critical state (`theory/color.md`). A diffuse or multi-hue accent spr
 decoration across peer elements (a different accent per card, borders and text included, not
 just fills) is a hierarchy defect, not a palette preference, even when every deterministic slop
 rule passes.
+Every interactive control needs a discernible accessible name. An icon-only button, link, tab,
+or menu trigger with no visible text must carry an aria-label, a title, or visually-hidden text
+(WCAG 4.1.2). The static IR cannot read the accessible name, so this is your call from the
+render: flag any control whose only content is an icon glyph with no text alternative.
 
 In sketch-selector mode, receive only sanitized frame/copy deck, the approved typography
 contract, the sanitized composition contract, and anonymous renders. The contracts expose

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -415,3 +415,15 @@
   value: "node.fontSize"
   assert: "value >= 11"
   message: "Body text at {value}px is below the readability floor. Prose under ~11px is hard to read on any screen; fine print is not an exception. Set body copy near the mid-teens and secondary text no smaller than 12px. See theory/typography.md §Size, measure, and line height."
+
+# Crammed body leading: a real paragraph (>80 chars, not a heading) at line-height below ~1.3
+# crowds its lines and slows reading. The browser 'normal' default resolves to ~1.2, so this
+# also catches prose that never set a leading. Headings may be tighter and are excluded.
+- id: SLOP-TIGHT-LEADING
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.type === 'TEXT' && !node.heading && Boolean(node.text) && node.text.length > 80 && typeof node.lineHeight === 'number'"
+  value: "node.lineHeight"
+  assert: "value >= 1.3"
+  message: "Body leading {value} is too tight for a paragraph. Long prose at line-height below ~1.3 (the browser 'normal' default is ~1.2) crowds the lines and slows reading; set body leading around 1.4–1.6. Headings may be tighter. See theory/typography.md §Size, measure, and line height."

--- a/core/theory/ux.md
+++ b/core/theory/ux.md
@@ -545,6 +545,12 @@ checks that `omd check` runs on every build. Principles not listed here remain a
 - Nielsen heuristics 2, 4, 7, 8, 10 (real-world match, consistency, efficiency, minimalism,
   help): all require semantic content understanding that the IR does not provide.
 
+- §Accessibility as a UX floor: whether every interactive control has a discernible accessible
+  name. The static IR captures `text`, `role`, and `ariaInvalid` but not the computed accessible
+  name (aria-label, aria-labelledby, title, or visually-hidden descendant text), so an icon-only
+  control cannot be judged deterministically without false positives. The eye agent flags a
+  control whose only content is an icon glyph with no text alternative. WCAG 2.1 §4.1.2.
+
 ---
 
 ## Official evidence map and layer ownership

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -92,6 +92,10 @@ instructions: |
   decoration across peer elements (a different accent per card, borders and text included, not
   just fills) is a hierarchy defect, not a palette preference, even when every deterministic slop
   rule passes.
+  Every interactive control needs a discernible accessible name. An icon-only button, link, tab,
+  or menu trigger with no visible text must carry an aria-label, a title, or visually-hidden text
+  (WCAG 4.1.2). The static IR cannot read the accessible name, so this is your call from the
+  render: flag any control whose only content is an icon glyph with no text alternative.
 
   In sketch-selector mode, receive only sanitized frame/copy deck, the approved typography
   contract, the sanitized composition contract, and anonymous renders. The contracts expose

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -457,3 +457,10 @@ test('the loop and eye gate colour strategy (60-30-10 / reserved accent)', () =>
   assert.match(eye, /verify a legible 60-30-10 distribution/i);
   assert.match(eye, /diffuse or multi-hue accent/i);
 });
+
+test('the eye gates the accessible name of icon-only controls the IR cannot see', () => {
+  const eye = read('src/agents/eye.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(eye, /Every interactive control needs a discernible accessible name/i);
+  const ux = read('core/theory/ux.md').replace(/\s+/g, ' ');
+  assert.match(ux, /icon-only control cannot be judged deterministically without false positives/i);
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -181,6 +181,14 @@ test('A11Y-HEADING-SKIP fires on a skipped heading level, not on a contiguous ou
   assert.ok(!ok.some((x) => x.id === 'A11Y-HEADING-SKIP'));
 });
 
+test('SLOP-TIGHT-LEADING fires on a crammed paragraph, not on well-led body', () => {
+  const para = 'This is a genuinely long paragraph of body copy, long enough to exceed eighty characters and need real leading.';
+  const tight = runSlop([accentRoot(['a']), richText('a', { text: para, lineHeight: 1.15 })]);
+  assert.ok(tight.some((x) => x.id === 'SLOP-TIGHT-LEADING'));
+  const roomy = runSlop([accentRoot(['a']), richText('a', { text: para, lineHeight: 1.5 })]);
+  assert.ok(!roomy.some((x) => x.id === 'SLOP-TIGHT-LEADING'));
+});
+
 // Helpers for text-node rule tests
 function makeTextIr(text: string) {
   const node: RawNode = {


### PR DESCRIPTION
feat: gate crammed body leading (rule) and icon-only accessible names (eye)

Two of the three requested gates land in the layer each belongs to; the third is not a clean
deterministic rule and is not shipped as noise.

- SLOP-TIGHT-LEADING (slop): a real paragraph (>80 chars, not a heading) at line-height below
  ~1.3 crowds its lines and slows reading. The browser 'normal' default resolves to ~1.2, so
  this also catches prose that never set a leading. Headings are excluded. Detectable from
  node.lineHeight.

- Accessible name of icon-only controls -> eye gate (not a rule): the static IR captures text,
  role, and ariaInvalid but NOT the computed accessible name (aria-label, aria-labelledby,
  title, visually-hidden descendant text), so a deterministic rule would false-positive on
  every properly-labelled icon button. The eye — which sees the render — now flags a control
  whose only content is an icon glyph with no text alternative (WCAG 4.1.2), and ux.md's
  advisory list records why it stays a judgment call.

Not shipped — radius/shadow tokenisation (TOKEN-004/005): the extractor matches a token by exact
string, but radius is captured as a unitless number ("8") while a `--radius: 8px` var stores
"8PX", so radius.token/shadow.token are effectively always null — the rule would fire on every
rounded or shadowed element (universal false positive). Radius and shadow consistency is already
gated by SLOP-RADIUS-MONOCULTURE and SLOP-SHADOW-MONOCULTURE; making tokenisation detectable
needs a token-matching fix in the extractor, which is a separate change.

Locking tests: SLOP-TIGHT-LEADING positive/negative, and the eye + ux.md accessible-name clauses.
