### PR TITLE
feat: radius tokenisation rule + data-viz theory

### DIFF
--- a/agents/eye.md
+++ b/agents/eye.md
@@ -89,6 +89,9 @@ Every interactive control needs a discernible accessible name. An icon-only butt
 or menu trigger with no visible text must carry an aria-label, a title, or visually-hidden text
 (WCAG 4.1.2). The static IR cannot read the accessible name, so this is your call from the
 render: flag any control whose only content is an icon glyph with no text alternative.
+For any data visualization, verify it does not lie: a bar chart baseline starts at zero, axes are
+labelled with their real range, the primary quantity is encoded on position or length (no 3-D, no
+rainbow ramp for ordered data), and the chart is not built on invented numbers (`theory/data-viz.md`).
 
 In sketch-selector mode, receive only sanitized frame/copy deck, the approved typography
 contract, the sanitized composition contract, and anonymous renders. The contracts expose

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -129,6 +129,11 @@ Use a purposeful visual carrier, not a bare gray box or unstyled default: pick f
 register (quiet/confident/showpiece) and the dominant anchor's domain mechanism.
 Exercise restraint: implement at most one signature moment per surface, matched to the
 register (quiet surfaces may carry none), never a catalogue of techniques.
+When the surface presents data — charts, metrics, dashboards, trends — read `theory/data-viz.md`:
+choose the chart from the question it answers, keep axes honest (bar baselines at zero, one scale
+per axis), encode the primary quantity on position or length (no 3-D, no rainbow ramp for ordered
+data), reduce non-data ink, and label the insight directly. Never build a chart on invented
+numbers; if the data is not real, label it a demo.
 On a React stack, reach for real animation libraries instead of hand-rolling: GSAP + ScrollTrigger
 for scroll choreography and Framer Motion (`motion`) for enter, gesture, and layout transitions.
 They are allowed greenfield dependencies. The one-signature-moment restraint, the declared

--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -149,7 +149,7 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
       const color = toHex(cs.color);
       if (color) node.color = color;
     }
-    if (radius > 0) node.radius = { value: radius, token: nameOf(String(radius)) };
+    if (radius > 0) node.radius = { value: radius, token: nameOf(String(radius) + 'PX') };
     if (isInteractive(el)) node.interactive = true;
     if (cs.display === 'inline') node.inline = true;
 

--- a/core/rules/builtin/token.yaml
+++ b/core/rules/builtin/token.yaml
@@ -1,8 +1,25 @@
-id: TOKEN-003
-layer: 1
-category: system
-severity: warn
-when: "Boolean(node.fill) && !node.fill.inherited && node.fill.authored !== false"
-value: "node.fill.token"
-assert: "value !== null"
-message: "Fill is not tokenised (got {value})"
+# Tokenisation checks: a value that is not tied to a named token is a one-off — the same
+# convergence problem as any monoculture, one node at a time. Fill and radius are matched by
+# value against the :root token table (dom.ts nameOf). Shadow is NOT checked here: its computed
+# form (colour-first, expanded 0px/spread) never string-matches an authored `--elevation` var,
+# so a shadow-token rule would be a universal false positive; shadow consistency is covered by
+# SLOP-SHADOW-MONOCULTURE instead. All warn.
+- id: TOKEN-003
+  layer: 1
+  category: system
+  severity: warn
+  when: "Boolean(node.fill) && !node.fill.inherited && node.fill.authored !== false"
+  value: "node.fill.token"
+  assert: "value !== null"
+  message: "Fill is not tokenised (got {value})"
+
+# Radius is always author-set when present (dom.ts records it only when radius > 0), so there is
+# no inherited/authored guard — a present radius with no matching token is a hardcoded corner.
+- id: TOKEN-004
+  layer: 1
+  category: system
+  severity: warn
+  when: "Boolean(node.radius)"
+  value: "node.radius.token"
+  assert: "value !== null"
+  message: "Corner radius is not tokenised (got {value}). A one-off radius is a decision made outside the system; map it to a radius token so the corner scale stays coherent."

--- a/core/theory/data-viz.md
+++ b/core/theory/data-viz.md
@@ -1,0 +1,112 @@
+# Data visualization
+
+A chart is an argument about data, and the encoding is the argument. `color.md` owns the
+*palette* of a chart (categorical vs sequential vs diverging, colourblind safety); this file
+owns everything else — which chart the question demands, whether the axes tell the truth, how
+accurately the marks encode the numbers, and when not to draw a chart at all. On a `product`
+surface a chart is quiet: it exists to make a decision faster, not to decorate a dashboard.
+
+## Choose the chart from the question, not the data type
+
+Name the question the chart answers, then pick the encoding that answers it fastest:
+
+- **Comparison / ranking** ("which is biggest?") → bar chart, sorted by value, horizontal when
+  labels are long. Not a pie: humans compare bar lengths far more accurately than pie angles.
+- **Change over time** ("what is the trend?") → line chart; one line per series, direct-labelled.
+  Area only when the cumulative total is the point and series stack meaningfully.
+- **Part-to-whole** ("what share?") → a single stacked bar or a labelled bar set. A pie is
+  tolerable only for two, at most three, slices; beyond that the eye cannot rank the wedges.
+- **Distribution** ("how is it spread?") → histogram or box plot; never a bar chart of raw rows.
+- **Correlation** ("does X track Y?") → scatter plot; add a trend line only when it is real.
+- **Two dimensions of magnitude across categories** → heatmap or small multiples, not a 3-D bar.
+
+If the question is "what is the exact number?", the answer is a table or a single figure, not a
+chart. If the question is "is this one value good or bad right now?", the answer is one large
+number with a reference (target, previous period), not a gauge or a donut.
+
+## Axis honesty
+
+The axis is where charts lie, usually by accident:
+
+- **Bar charts start at zero.** A bar encodes magnitude by length; a truncated baseline
+  multiplies small differences into fake drama. This is not a style choice — a non-zero bar
+  baseline misreports the data.
+- **Line charts may use a non-zero baseline** because a line encodes *rate of change*, not
+  magnitude — but the axis must be labelled with its real range, never cropped silently to
+  manufacture a slope.
+- **One scale per axis.** Dual y-axes let an author align two unrelated series to imply a
+  correlation that the numbers do not support; avoid them, or state the manipulation.
+- **Consistent scales across small multiples.** Panels compared side by side must share an axis
+  range, or the comparison the layout invites is false.
+- **Time flows left to right, evenly.** Do not skip or unevenly space intervals; gaps in the
+  data are shown as gaps, not closed silently.
+
+## Encode on the channels the eye reads accurately
+
+Cleveland & McGill (1984) ranked how accurately people decode visual channels. Prefer the top:
+**position on a common scale > length > angle/slope > area > colour/saturation.** Consequences:
+
+- Encode the primary quantity as **position or length**, not area or colour. Bubble area and
+  colour intensity are for secondary, approximate dimensions only.
+- **No 3-D.** Perspective distorts length and area and occludes marks; it adds no information.
+- **No rainbow ramp for ordered data.** A spectral scale has no perceptual order, so the reader
+  cannot tell high from low; use a single-hue sequential ramp (see `color.md` § data-viz).
+- **Do not re-encode one variable twice** (length *and* colour for the same number) as
+  decoration; a second channel should carry a second fact or nothing.
+
+## Reduce non-data ink
+
+Tufte's data-ink ratio: every pixel that is not the data is a candidate for removal. Drop the
+chart junk before adding polish — heavy gridlines, boxed borders, background fills, drop
+shadows on bars, redundant legends. Gridlines are faint and few; the axis line is often
+unnecessary. What remains should be almost entirely the data and its labels.
+
+## Label the insight, not just the chart
+
+- **Direct-label series** at their end point instead of forcing a legend round-trip; a legend is
+  a lookup the reader pays for on every glance.
+- **State units and the reference** (per month, YoY, vs target) in the title or axis, not a
+  caption the eye never reaches.
+- **Annotate the "so what."** The one point that matters — the spike, the crossover, the
+  threshold breach — carries a short text note. An unannotated chart makes the reader re-derive
+  the insight the author already knows.
+- **The title is the finding**, not the metric name: "Revenue overtook cost in Q3", not
+  "Revenue and cost". A dashboard tile may keep a metric-name title when scanning is the job.
+
+## Density: small multiples and sparklines
+
+For many series, do not overplot one axis into spaghetti — use small multiples (a grid of the
+same chart, one per series, shared scale) so each is readable and the set is comparable. In a
+dense table, a **sparkline** (a word-sized trend line in the row) carries the shape of a series
+without a separate chart. Both fit the high-density product register where the work object,
+not the chart, is the dominant anchor.
+
+## Register fit
+
+On a `product`/quiet surface the chart is an instrument: minimal, labelled, decision-first, and
+subordinate to the numbers and the task. On a `marketing`/showpiece surface a hero data
+visualization may be expressive, but it still obeys axis honesty and channel accuracy — an
+animated or stylized chart that misreports the data is a fabrication, not a flourish, and falls
+under the same rule as an invented statistic (`graphics/placeholder-policy.md`). Never ship a
+chart built on invented numbers; if the data is not real yet, label the chart a demo.
+
+## Accessibility
+
+A chart is not accessible as an image alone. Ensure the encoding does not rely on colour alone
+(add labels, patterns, or direct text); keep text and mark contrast within `color.md`/WCAG
+limits; and provide the underlying values in an associated table or accessible name so a
+screen-reader user reaches the same facts. WCAG 2.1 §1.4.1 (Use of Colour), §1.1.1 (Non-text
+Content).
+
+## Sources
+
+- Cleveland, W. & McGill, R. (1984). "Graphical Perception: Theory, Experimentation, and
+  Application to the Development of Graphical Methods." JASA — the elementary-perceptual-task
+  accuracy ranking (position > length > angle > area > colour).
+- Tufte, E. (1983). *The Visual Display of Quantitative Information* — data-ink ratio, chart
+  junk, the lie factor, small multiples.
+- Few, S. (2012). *Show Me the Numbers* and *Information Dashboard Design* — chart selection by
+  question, dashboard density, direct labelling.
+- Munzner, T. (2014). *Visualization Analysis and Design* — encoding channels and effectiveness.
+- Cynthia Brewer, ColorBrewer (colorbrewer2.org) — categorical/sequential/diverging, colourblind-safe.
+- W3C WCAG 2.1 §1.4.1, §1.1.1 — colour is not the only channel; non-text content has a text alternative.

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -96,6 +96,9 @@ instructions: |
   or menu trigger with no visible text must carry an aria-label, a title, or visually-hidden text
   (WCAG 4.1.2). The static IR cannot read the accessible name, so this is your call from the
   render: flag any control whose only content is an icon glyph with no text alternative.
+  For any data visualization, verify it does not lie: a bar chart baseline starts at zero, axes are
+  labelled with their real range, the primary quantity is encoded on position or length (no 3-D, no
+  rainbow ramp for ordered data), and the chart is not built on invented numbers (`theory/data-viz.md`).
 
   In sketch-selector mode, receive only sanitized frame/copy deck, the approved typography
   contract, the sanitized composition contract, and anonymous renders. The contracts expose

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -138,6 +138,11 @@ instructions: |
   register (quiet/confident/showpiece) and the dominant anchor's domain mechanism.
   Exercise restraint: implement at most one signature moment per surface, matched to the
   register (quiet surfaces may carry none), never a catalogue of techniques.
+  When the surface presents data — charts, metrics, dashboards, trends — read `theory/data-viz.md`:
+  choose the chart from the question it answers, keep axes honest (bar baselines at zero, one scale
+  per axis), encode the primary quantity on position or length (no 3-D, no rainbow ramp for ordered
+  data), reduce non-data ink, and label the insight directly. Never build a chart on invented
+  numbers; if the data is not real, label it a demo.
   On a React stack, reach for real animation libraries instead of hand-rolling: GSAP + ScrollTrigger
   for scroll choreography and Framer Motion (`motion`) for enter, gesture, and layout transitions.
   They are allowed greenfield dependencies. The one-signature-moment restraint, the declared

--- a/test/eye.test.ts
+++ b/test/eye.test.ts
@@ -15,7 +15,7 @@ const violations = check(ir, rules);
 const at = (cls: string) => violations.filter((v) => v.path.endsWith(cls));
 
 test('the eye reads CSS custom properties as design tokens', () => {
-  assert.deepEqual(seen.tokens, { surface: '#FFFFFF', ink: '#111111', brand: '#FF5A1F' });
+  assert.deepEqual(seen.tokens, { surface: '#FFFFFF', ink: '#111111', brand: '#FF5A1F', radius: '8PX' });
 });
 
 test('a tokenised, on-grid, accessible card produces no findings', () => {

--- a/test/fixtures/page.html
+++ b/test/fixtures/page.html
@@ -5,6 +5,7 @@
     --surface: #ffffff;
     --ink: #111111;
     --brand: #ff5a1f;
+    --radius: 8px;
   }
   body { margin: 0; background: var(--surface); font: 16px system-ui; }
   .list { display: flex; flex-direction: column; gap: 8px; padding: 16px; }

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -464,3 +464,14 @@ test('the eye gates the accessible name of icon-only controls the IR cannot see'
   const ux = read('core/theory/ux.md').replace(/\s+/g, ' ');
   assert.match(ux, /icon-only control cannot be judged deterministically without false positives/i);
 });
+
+test('data-viz theory gates chart honesty and is wired into hand and eye', () => {
+  const dv = read('core/theory/data-viz.md').replace(/\s+/g, ' ');
+  assert.match(dv, /Bar charts start at zero/i);
+  assert.match(dv, /Cleveland & McGill/);
+  assert.match(dv, /Choose the chart from the question/i);
+  const hand = read('src/agents/hand.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(hand, /theory\/data-viz\.md/);
+  const eye = read('src/agents/eye.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(eye, /data visualization, verify it does not lie/i);
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -34,7 +34,7 @@ test('loadRules rejects a rule with a duplicate id', () => {
 test('check finds exactly the seeded violations', () => {
   const v = check(ir, builtin);
   const ids = v.map((x) => x.id).sort();
-  assert.deepEqual(ids, ['CONTRAST-001', 'HIT-002', 'SPACING-001', 'TOKEN-003', 'TOKEN-003']);
+  assert.deepEqual(ids, ['CONTRAST-001', 'HIT-002', 'SPACING-001', 'TOKEN-003', 'TOKEN-003', 'TOKEN-004', 'TOKEN-004', 'TOKEN-004', 'TOKEN-004']);
 });
 
 test('violations carry nodeId, path, value and an interpolated message', () => {
@@ -56,7 +56,7 @@ test('check output is deterministic — sorted by path then id', () => {
 
 test('layer filter selects rules by layer', () => {
   assert.equal(check(ir, builtin, { layers: [2] }).length, 0);
-  assert.equal(check(ir, builtin, { layers: [1] }).length, 5);
+  assert.equal(check(ir, builtin, { layers: [1] }).length, 9);
 });
 
 test('category filter selects rules by category', () => {
@@ -187,6 +187,18 @@ test('SLOP-TIGHT-LEADING fires on a crammed paragraph, not on well-led body', ()
   assert.ok(tight.some((x) => x.id === 'SLOP-TIGHT-LEADING'));
   const roomy = runSlop([accentRoot(['a']), richText('a', { text: para, lineHeight: 1.5 })]);
   assert.ok(!roomy.some((x) => x.id === 'SLOP-TIGHT-LEADING'));
+});
+
+test('TOKEN-004 fires on a hardcoded radius, not on a tokenised one', () => {
+  const frame = (id: string, over: Partial<RawNode>): RawNode => ({
+    id, name: 'Card', type: 'FRAME', path: `Root/${id}`, parent: 'root',
+    box: { x: 0, y: 0, w: 50, h: 50 }, children: [], ...over,
+  });
+  const sys = (nodes: RawNode[]) => check(normalize({ nodes }), builtin, { categories: ['system'] });
+  const hard = sys([accentRoot(['a']), frame('a', { radius: { value: 10, token: null } })]);
+  assert.ok(hard.some((x) => x.id === 'TOKEN-004'), 'untokenised radius fires');
+  const soft = sys([accentRoot(['a']), frame('a', { radius: { value: 10, token: 'radius-md' } })]);
+  assert.ok(!soft.some((x) => x.id === 'TOKEN-004'), 'tokenised radius silent');
 });
 
 // Helpers for text-node rule tests


### PR DESCRIPTION
feat: radius tokenisation rule (fixed extractor match) + data-viz theory

Two remaining gates.

Radius tokenisation (TOKEN-004)
- The extractor matched a radius token by the unitless number ("8") against a token table that
  stores the raw value ("8PX"), so radius.token was always null — a rule would have fired on
  every rounded element. Fixed dom.ts to look up `String(radius) + 'PX'`, so a `--radius: 8px`
  var now resolves. TOKEN-004 then flags a present radius with no matching token. Shadow is
  deliberately not added: its computed form (colour-first, expanded 0px/spread) never
  string-matches an authored `--elevation` var, so a shadow-token rule would be a universal
  false positive; shadow consistency stays with SLOP-SHADOW-MONOCULTURE. Fixtures updated
  (page.html gains a --radius token; ir.raw seeded-violation expectations include TOKEN-004).

Data visualization theory (core/theory/data-viz.md)
- The big gap for dashboards: color.md owned chart *palettes* but nothing owned chart choice,
  axis honesty, or encoding accuracy. New file covers choosing the chart from the question,
  axis honesty (zero-baseline bars, one scale per axis), Cleveland & McGill channel accuracy
  (position/length over area/colour, no 3-D, no rainbow for ordered data), Tufte data-ink,
  direct labelling and annotation, small multiples/sparklines for density, register fit
  (quiet dashboards), never charting invented numbers, and chart accessibility. Wired into the
  hand (build) and the eye (verify it does not lie).

Locking tests: TOKEN-004 positive/negative, and the data-viz chart-honesty + wiring clauses.
