### PR TITLE
chore: release v0.18.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "omd",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "interface": {
     "displayName": "Oh My Design"
   },
@@ -16,7 +16,7 @@
         "authentication": "ON_FIRST_USE"
       },
       "category": "design",
-      "version": "0.17.0"
+      "version": "0.18.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
   "owner": {
     "name": "3x-haust"
   },
-  "version": "0.17.0",
+  "version": "0.18.0",
   "plugins": [
     {
       "name": "oh-my-design",
       "description": "The design cognition loop: doubt the brief, measure real references (type and motion included), build once, look at the render, reframe. Plus a deterministic slop linter and a de-AI copy pass.",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "author": {
         "name": "3x-haust"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem. Ships a slop linter that makes 'looks AI-generated' a checkable claim.",
   "author": {
     "name": "3x-haust",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem.",
   "author": {
     "name": "3x-haust",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@3xhaust/oh-my-design",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@3xhaust/oh-my-design",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3xhaust/oh-my-design",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Design cognition loop for Codex and Claude Code — frame, diverge, see, reframe",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Version bump 0.17.0 -> 0.18.0 (minor: new features + fixes across PRs #58-#86). tsc clean; full suite green except the two offline-tarball tests that need a warm npm cache (ENOTCACHED, environment-only).