### PR TITLE
fix: restore example/ landing source accidentally removed in #90

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.omd/
+.omc/
+*.local
+.DS_Store

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OMD — A design process for coding agents, not a visual style</title>
+    <meta
+      name="description"
+      content="OMD questions the brief, gathers evidence, writes real copy, compares structures, builds once, inspects the render, and reframes. Every decision is recorded, not asserted."
+    />
+    <meta property="og:title" content="OMD — A design process for coding agents, not a visual style" />
+    <meta
+      property="og:description"
+      content="Nine stages, each checked before the next begins. Install with npm install -g oh-my-design."
+    />
+    <meta property="og:type" content="website" />
+    <!-- finish-pass.md item 5: inline SVG data-URI favicon, monogram on the brand accent surface -->
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23111813'/%3E%3Ctext x='16' y='22' font-family='ui-monospace,monospace' font-size='16' font-weight='600' fill='%2352e0a8' text-anchor='middle'%3EO%3C/text%3E%3C/svg%3E"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/example/ko/index.html
+++ b/example/ko/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OMD — 코딩 에이전트를 위한 디자인 프로세스, 비주얼 스타일이 아닙니다</title>
+    <meta
+      name="description"
+      content="OMD는 브리프를 캐묻고, 근거를 모으고, 실제 카피를 쓰고, 구조를 비교하고, 한 번 구현하고, 렌더를 살핀 뒤 다시 정의합니다. 모든 결정은 주장이 아니라 기록됩니다."
+    />
+    <meta property="og:title" content="OMD — 코딩 에이전트를 위한 디자인 프로세스, 비주얼 스타일이 아닙니다" />
+    <meta
+      property="og:description"
+      content="아홉 단계, 각 단계는 다음 단계 시작 전에 확인됩니다. npm install -g oh-my-design 로 설치하세요."
+    />
+    <meta property="og:type" content="website" />
+    <!-- finish-pass.md item 5: inline SVG data-URI favicon, monogram on the brand accent surface -->
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23111813'/%3E%3Ctext x='16' y='22' font-family='ui-monospace,monospace' font-size='16' font-weight='600' fill='%2352e0a8' text-anchor='middle'%3EO%3C/text%3E%3C/svg%3E"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ko.tsx"></script>
+  </body>
+</html>

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,0 +1,1757 @@
+{
+  "name": "omd-landing",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omd-landing",
+      "version": "0.0.1",
+      "dependencies": {
+        "@fontsource/geist-mono": "^5.2.5",
+        "@fontsource/geist-sans": "^5.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fontsource/geist-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-mono/-/geist-mono-5.2.8.tgz",
+      "integrity": "sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/geist-sans": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-sans/-/geist-sans-5.2.5.tgz",
+      "integrity": "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "omd-landing",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fontsource/geist-mono": "^5.2.5",
+    "@fontsource/geist-sans": "^5.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,0 +1,25 @@
+import "./app.css";
+import type { Locale } from "./data/content";
+import { Nav } from "./components/Nav";
+import { Hero } from "./components/Hero";
+import { Loop } from "./components/Loop";
+import { EvidenceTable } from "./components/EvidenceTable";
+import { Skills } from "./components/Skills";
+import { Install } from "./components/Install";
+import { Footer } from "./components/Footer";
+
+export default function App({ locale = "en" }: { locale?: Locale }) {
+  return (
+    <>
+      <Nav locale={locale} />
+      <main>
+        <Hero locale={locale} />
+        <Loop locale={locale} />
+        <EvidenceTable locale={locale} />
+        <Skills locale={locale} />
+        <Install locale={locale} />
+      </main>
+      <Footer locale={locale} />
+    </>
+  );
+}

--- a/example/src/app.css
+++ b/example/src/app.css
@@ -1,0 +1,684 @@
+/* ============================================================
+   Layout / section styles. Structure is Candidate A
+   (.omd/.cache/sketch-selection.md winner) rebuilt with production
+   tokens — not the sketch's grayscale values. See .omd/attribution.md.
+   ============================================================ */
+
+/* Default CJK line-breaking allows a split inside any 어절 (word unit);
+   keep-all restricts breaks to spaces, matching how Korean is actually
+   read. Applied page-wide rather than per-selector since every ch-based
+   measure below (13ch, 68ch, ...) was sized for Latin text. */
+html:lang(ko) {
+  word-break: keep-all;
+}
+
+.site-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  height: 56px;
+  padding: 0 var(--space-6);
+  background: color-mix(in srgb, var(--color-bg) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-rule);
+}
+.nav-word {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+}
+.nav-links {
+  display: flex;
+  gap: var(--space-6);
+  margin-right: auto;
+}
+.nav-links a {
+  font-size: var(--text-sm);
+  text-decoration: none;
+  color: var(--color-ink-muted);
+}
+.nav-links a:hover {
+  color: var(--color-ink);
+}
+/* Secondary (outlined), not filled: the hero .cta below is this page's one
+   filled primary action. Repeating a filled black button in the persistent
+   nav — the same weight as the hero and footer CTAs — cancels the hierarchy
+   signal (theory/components.md button-hierarchy ceiling; theory/ux.md). The
+   nav CTA still reaches the same #install target, just demoted a tier. */
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-decoration: none;
+  padding: 0 var(--space-5);
+  border-radius: var(--radius-md);
+  background: transparent;
+  border: 1px solid var(--color-rule-strong);
+  color: var(--color-ink);
+}
+.nav-cta:hover {
+  border-color: var(--color-ink);
+  background: var(--color-surface);
+}
+.nav-lang {
+  font-size: var(--text-sm);
+  text-decoration: none;
+  color: var(--color-ink-muted);
+  white-space: nowrap;
+}
+.nav-lang:hover {
+  color: var(--color-ink);
+}
+
+main {
+  padding-top: 56px;
+}
+
+/* ---------- 1. hero — lowest density, dominant anchor ---------- */
+.hero {
+  padding-top: var(--space-11);
+  padding-bottom: var(--space-10);
+}
+.hero h1 {
+  /* type-proof.md fixes exact px roles at desktop (64px) and mobile (34px)
+     rather than a fluid scale — this is a measured two-step citation, not an
+     omission of clamp(). See .omd/attribution.md. */
+  font-size: var(--text-display);
+  line-height: var(--lh-display);
+  max-width: 13ch;
+  letter-spacing: -0.01em;
+}
+/* Korean text: `ch` is a Latin digit-width unit, so 13ch reads as roughly
+   half as many full-width Korean characters — far narrower than intended —
+   and default CJK line-breaking allows a split inside any 어절. keep-all
+   restricts breaks to spaces; the widened max-width restores a natural
+   two-line wrap instead of a cramped four-line one. */
+html:lang(ko) .hero h1 {
+  max-width: 11em;
+  word-break: keep-all;
+  letter-spacing: normal;
+}
+.hero-body {
+  margin-top: var(--space-7);
+  max-width: var(--measure-body);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  color: var(--color-ink-muted);
+}
+.cta {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  margin-top: var(--space-7);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-decoration: none;
+  color: var(--color-paper);
+  background: var(--color-ink);
+  padding: 0 var(--space-6);
+  border-radius: var(--radius-lg);
+}
+.cta:hover {
+  background: var(--color-accent);
+  transform: translateY(-1px);
+}
+.cta code {
+  font-size: var(--text-xs);
+  color: inherit;
+}
+
+/* ---------- 2. loop — Axis A: pinned anchor + vertical stage list ---------- */
+.loop {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-11);
+  border-top: 1px solid var(--color-rule);
+}
+.loop h2 {
+  font-size: var(--text-xl);
+  line-height: var(--lh-tight);
+  margin-bottom: var(--space-8);
+}
+
+/* The one alignment break on the page: the timeline exceeds the shared
+   text-measure width, up to full viewport width at desktop.
+   composition.md: justified as the one alignment break; theory/layout.md
+   supports a single deliberate break as a focal signal, not a rhythm. */
+.timeline {
+  max-width: none;
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  padding: 0 max(var(--space-6), calc((100vw - var(--section-max)) / 2));
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: var(--space-9);
+  align-items: start;
+}
+
+.anchor-track {
+  position: sticky;
+  top: 96px;
+  align-self: start;
+}
+.anchor {
+  border: 1px solid var(--color-ink);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  background: var(--color-surface);
+}
+.anchor-num {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-medium);
+  color: var(--color-accent);
+}
+.anchor-label {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  margin-top: var(--space-1);
+}
+.anchor-state {
+  display: inline-block;
+  margin-top: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--color-accent);
+  color: var(--color-accent);
+  border-radius: var(--radius-pill);
+  padding: 3px 10px;
+}
+.anchor-connector {
+  margin-top: var(--space-5);
+  height: 2px;
+  background: repeating-linear-gradient(to right, var(--color-rule-strong) 0 6px, transparent 6px 12px);
+}
+.anchor-caption {
+  display: block;
+  margin-top: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--color-ink-faint);
+}
+
+.stage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.stage {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: var(--space-5);
+  padding: var(--space-8) 0;
+  border-bottom: 1px solid var(--color-rule);
+}
+.stage:first-child {
+  padding-top: 0;
+}
+.stage:last-child {
+  border-bottom: none;
+}
+
+.stage-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+}
+.stage-num {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-ink-faint);
+}
+.stage-state {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--color-rule-strong);
+  background: var(--color-paper);
+}
+/* domain grammar: pending / current / checked — never simultaneous "checked" */
+.stage[data-state="checked"] .stage-state {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.stage[data-state="current"] .stage-state {
+  border-color: var(--color-ink);
+  background: var(--color-surface-strong);
+}
+.stage[data-state="checked"] .stage-num,
+.stage[data-state="current"] .stage-num {
+  color: var(--color-ink);
+}
+
+.stage-body h3 {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--lh-tight);
+}
+.stage-body p {
+  margin: var(--space-3) 0 0;
+  font-size: var(--text-base);
+  max-width: var(--measure-narrow);
+  color: var(--color-ink-muted);
+}
+.stage-body .chip {
+  display: inline-block;
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-sm);
+}
+
+/* mobile-only inline anchor restatement — hidden at desktop, since the sticky
+   column already communicates the current stage there. Required production
+   fix from the blind selection: attached inline to the current stage item,
+   never floating above/before the list. */
+.anchor-inline {
+  display: none;
+}
+
+/* ---------- 3. evidence table — highest density, deliberately ---------- */
+.evidence {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-11);
+  border-top: 1px solid var(--color-rule);
+}
+.evidence h2 {
+  font-size: var(--text-xl);
+  line-height: var(--lh-tight);
+  margin-bottom: var(--space-7);
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+th,
+td {
+  text-align: left;
+  vertical-align: top;
+  padding: var(--space-4) var(--space-5) var(--space-4) 0;
+  border-bottom: 1px solid var(--color-rule);
+}
+th {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-ink-faint);
+}
+td:first-child {
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+}
+td code {
+  font-size: var(--text-xs);
+}
+
+/* ---------- 4. skills ---------- */
+.skills {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-11);
+  border-top: 1px solid var(--color-rule);
+}
+.skills h2 {
+  font-size: var(--text-xl);
+  line-height: var(--lh-tight);
+  margin-bottom: var(--space-7);
+}
+.skill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.skill-list li {
+  padding: var(--space-5) 0;
+  border-bottom: 1px solid var(--color-rule);
+  font-size: var(--text-base);
+  max-width: 68ch;
+}
+.skill-list li:last-child {
+  border-bottom: none;
+}
+
+/* ---------- 5. install / quick start ---------- */
+.install {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-11);
+  border-top: 1px solid var(--color-rule);
+}
+.install h2 {
+  font-size: var(--text-xl);
+  line-height: var(--lh-tight);
+}
+.install > p {
+  margin-top: var(--space-5);
+  font-size: var(--text-base);
+  max-width: var(--measure-body);
+  color: var(--color-ink-muted);
+}
+.code-block-wrap {
+  position: relative;
+  margin: var(--space-6) 0;
+}
+.code-block {
+  margin: 0;
+  padding: var(--space-6);
+  background: var(--color-mono-panel);
+  color: var(--color-mono-ink);
+  border-radius: var(--radius-xl);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--lh-mono-block);
+  overflow-x: auto;
+  font-variant-numeric: tabular-nums;
+}
+.code-copy {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  font-family: var(--font-sans);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-medium);
+  /* Solid, opaque background + solid foreground — not a translucent overlay
+     relying on the dark .code-block showing through. The button is a DOM
+     sibling of .code-block (absolutely positioned over it), so any contrast
+     check that resolves background against the actual ancestor chain (not
+     the visual stacking) sees the light page background, not the dark
+     panel — a translucent bg there reads as near-invisible text on paper.
+     Solid colors make the button's contrast correct regardless of DOM
+     position. */
+  color: var(--color-mono-ink);
+  background: var(--color-mono-panel-raised);
+  border: 1px solid rgba(238, 242, 238, 0.24);
+  border-radius: var(--radius-md);
+  padding: 0 var(--space-3);
+  cursor: pointer;
+}
+.code-copy:hover {
+  color: var(--color-mono-panel);
+  background: var(--color-accent-bright);
+  border-color: var(--color-accent-bright);
+}
+.copy-status:empty {
+  margin: 0;
+}
+.copy-status {
+  margin-top: var(--space-3);
+  font-size: var(--text-2xs);
+  color: var(--color-accent);
+  min-height: 1em;
+}
+.copy-error {
+  margin-top: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-ink);
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule-strong);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  max-width: var(--measure-body);
+}
+.fine {
+  font-size: var(--text-2xs);
+  color: var(--color-ink-faint);
+  max-width: var(--measure-body);
+}
+
+/* ---------- 6. footer ---------- */
+.site-footer {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-11);
+  border-top: 1px solid var(--color-rule);
+}
+.site-footer h2 {
+  font-size: var(--text-xl);
+  line-height: var(--lh-tight);
+}
+.site-footer > p {
+  margin-top: var(--space-5);
+  font-size: var(--text-base);
+  color: var(--color-ink-muted);
+}
+.footer-actions {
+  margin-top: var(--space-7);
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+/* The hero .cta is this page's one filled primary action (theory/components.md
+   button-hierarchy ceiling). The footer repeats the identical install command
+   as a closing nudge, not a second task — demoted to outline so it reads as
+   "still here if you need it" rather than competing with the hero's filled
+   button for primacy. Fixes UX-TWO-PRIMARIES. */
+.site-footer .cta {
+  background: transparent;
+  border: 1px solid var(--color-ink);
+  color: var(--color-ink);
+}
+.site-footer .cta:hover {
+  background: var(--color-ink);
+  color: var(--color-paper);
+}
+/* .footer-links is a plain (non-flex) span so the two anchors inside stay true
+   inline text links (computed display: inline), not flex items — .footer-actions
+   being display:flex would otherwise blockify any direct child regardless of its
+   own authored display value. WCAG 2.5.5/2.5.8 exempt inline text links from the
+   44x44 target-size minimum (words in a line, not controls); hit-area.yaml encodes
+   the same exception via `!node.inline`. Keeping these two as inline footnote
+   links — rather than 44px flex-item buttons — also keeps the hero .cta as this
+   page's one filled primary action (theory/ux.md UX-TWO-PRIMARIES): two same-fill,
+   same-parent 44px links previously collided with it. */
+.footer-links a {
+  font-size: var(--text-sm);
+  text-decoration: underline;
+  color: var(--color-ink-muted);
+  margin-right: var(--space-6);
+}
+.footer-links a:last-child {
+  margin-right: 0;
+}
+.footer-links a:hover {
+  color: var(--color-ink);
+}
+
+/* ---------- stagger delay ladders (per motion-spec.md scene) ---------- */
+@media (prefers-reduced-motion: no-preference) {
+  .hero.stagger > *:nth-child(1) {
+    transition-delay: 0ms;
+  }
+  .hero.stagger > *:nth-child(2) {
+    transition-delay: calc(var(--stagger-hero) * 1);
+  }
+  .hero.stagger > *:nth-child(3) {
+    transition-delay: calc(var(--stagger-hero) * 2);
+  }
+
+  .stagger--list > *:nth-child(1) {
+    transition-delay: 0ms;
+  }
+  /* explicit per-index delays: CSS cannot read nth-child index into a
+     variable, so the list length (6 skills, capped at the recipe's 8-10
+     item ceiling) is spelled out directly. */
+  .stagger--list > *:nth-child(2) {
+    transition-delay: calc(var(--stagger-list) * 1);
+  }
+  .stagger--list > *:nth-child(3) {
+    transition-delay: calc(var(--stagger-list) * 2);
+  }
+  .stagger--list > *:nth-child(4) {
+    transition-delay: calc(var(--stagger-list) * 3);
+  }
+  .stagger--list > *:nth-child(5) {
+    transition-delay: calc(var(--stagger-list) * 4);
+  }
+  .stagger--list > *:nth-child(6) {
+    transition-delay: calc(var(--stagger-list) * 5);
+  }
+
+  .stagger--table > *:nth-child(1) {
+    transition-delay: 0ms;
+  }
+  .stagger--table > *:nth-child(2) {
+    transition-delay: calc(var(--stagger-table) * 1);
+  }
+  .stagger--table > *:nth-child(3) {
+    transition-delay: calc(var(--stagger-table) * 2);
+  }
+  .stagger--table > *:nth-child(4) {
+    transition-delay: calc(var(--stagger-table) * 3);
+  }
+  .stagger--table > *:nth-child(5) {
+    transition-delay: calc(var(--stagger-table) * 4);
+  }
+  .stagger--table > *:nth-child(6) {
+    transition-delay: calc(var(--stagger-table) * 5);
+  }
+  .stagger--table > *:nth-child(7) {
+    transition-delay: calc(var(--stagger-table) * 6);
+  }
+  .stagger--table > *:nth-child(8) {
+    transition-delay: calc(var(--stagger-table) * 7);
+  }
+  .stagger--table > *:nth-child(9) {
+    transition-delay: calc(var(--stagger-table) * 8);
+  }
+  .stagger--table > *:nth-child(10) {
+    transition-delay: calc(var(--stagger-table) * 9);
+  }
+}
+
+/* ============================================================
+   Responsive recomposition — composition.md: sidebar/pinned-column
+   patterns disappear below 900px; mobile fallback is designed, not
+   just the desktop layout collapsing.
+   ============================================================ */
+@media (max-width: 900px) {
+  .timeline {
+    width: auto;
+    left: auto;
+    right: auto;
+    margin: 0;
+    padding: 0;
+    grid-template-columns: 1fr;
+    gap: var(--space-7);
+  }
+  /* the required production fix: no global floating anchor on mobile */
+  .anchor-track {
+    display: none;
+  }
+  .anchor-inline {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+  }
+  .anchor-inline-badge {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    font-weight: var(--weight-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    border-radius: var(--radius-pill);
+    padding: 3px 10px;
+  }
+  .anchor-inline-caption {
+    font-size: var(--text-2xs);
+    color: var(--color-ink-faint);
+  }
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding-top: var(--space-11);
+  }
+  .hero h1 {
+    font-size: var(--text-display-mobile);
+    max-width: 15ch;
+  }
+  html:lang(ko) .hero h1 {
+    max-width: 11em;
+  }
+  .nav-links {
+    display: none;
+  }
+  .stage {
+    grid-template-columns: 40px 1fr;
+    padding: var(--space-7) 0;
+  }
+
+  /* evidence table recomposes to stacked per-stage blocks */
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
+  }
+  thead {
+    display: none;
+  }
+  tr {
+    padding: var(--space-5) 0;
+    border-bottom: 1px solid var(--color-rule);
+  }
+  td {
+    padding: var(--space-1) 0;
+    border-bottom: none;
+  }
+  td:first-child {
+    font-weight: var(--weight-semibold);
+  }
+  td:nth-child(2)::before {
+    content: "Artifact — ";
+    color: var(--color-ink-faint);
+    font-size: var(--text-2xs);
+  }
+  td:nth-child(3)::before {
+    content: "Boundary — ";
+    color: var(--color-ink-faint);
+    font-size: var(--text-2xs);
+  }
+  html:lang(ko) td:nth-child(2)::before {
+    content: "산출물 — ";
+  }
+  html:lang(ko) td:nth-child(3)::before {
+    content: "경계 — ";
+  }
+
+  .footer-actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-5);
+  }
+}

--- a/example/src/components/EvidenceTable.tsx
+++ b/example/src/components/EvidenceTable.tsx
@@ -1,0 +1,38 @@
+import { useReveal } from "../hooks/useReveal";
+import type { Locale } from "../data/content";
+import { getContent } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+// Highest density on the page, deliberately (composition.md density arc). Mobile
+// recomposition stacks rows to blocks with ::before pseudo-labels (app.css).
+export function EvidenceTable({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  const { evidenceRows } = getContent(locale);
+  const ref = useReveal<HTMLTableSectionElement>();
+
+  return (
+    <section className="evidence" id="evidence">
+      <h2>{t.evidence.heading}</h2>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">{t.evidence.colStage}</th>
+            <th scope="col">{t.evidence.colArtifact}</th>
+            <th scope="col">{t.evidence.colBoundary}</th>
+          </tr>
+        </thead>
+        <tbody className="stagger stagger--table" ref={ref}>
+          {evidenceRows.map((row) => (
+            <tr key={row.stage}>
+              <td>{row.stage}</td>
+              <td>
+                <code>{row.artifact}</code>
+              </td>
+              <td>{row.boundary}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/example/src/components/Footer.tsx
+++ b/example/src/components/Footer.tsx
@@ -1,0 +1,32 @@
+import type { Locale } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+export function Footer({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  return (
+    <footer className="site-footer">
+      <h2>{t.footer.heading}</h2>
+      <p>{t.footer.body}</p>
+      <div className="footer-actions">
+        <a className="cta" href="#install">
+          <code>npm install -g @3xhaust/oh-my-design</code>
+        </a>
+        {/* Wrapped in a non-flex span so these stay true inline text links (computed
+            display: inline), not flex items blockified by .footer-actions. WCAG
+            2.5.5/2.5.8 exempt inline text links from the 44x44 target minimum —
+            core/rules/builtin/hit-area.yaml encodes the same exception via
+            `!node.inline`. Keeping them inline also keeps the hero .cta as this
+            page's one filled primary action: these two read as footnote links, not
+            competing buttons (theory/ux.md UX-TWO-PRIMARIES). */}
+        <span className="footer-links">
+          <a href="https://github.com/3x-haust/oh-my-design" target="_blank" rel="noreferrer">
+            {t.footer.sourceLink}
+          </a>
+          <a href={t.footer.langHref} lang={locale === "en" ? "ko" : "en"} className="i18n-ko">
+            {t.footer.langLink}
+          </a>
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/example/src/components/Hero.tsx
+++ b/example/src/components/Hero.tsx
@@ -1,0 +1,22 @@
+import { useReveal } from "../hooks/useReveal";
+import type { Locale } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+// Copy verbatim from .omd/copy-deck.md Hero section. Focal hierarchy per
+// composition.md: hero carries ~90% of first-viewport visual mass, no diagram.
+export function Hero({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  // Gated on document.fonts.ready, not an immediate reveal — see useReveal.ts.
+  const ref = useReveal<HTMLElement>(0.2, true);
+
+  return (
+    <section className="hero stagger" ref={ref} id="top">
+      <h1>{t.hero.title}</h1>
+      <p className="hero-body">{t.hero.body}</p>
+      <a className="cta" href="#install">
+        {t.hero.ctaPrefix}
+        <code>npm install -g @3xhaust/oh-my-design</code>
+      </a>
+    </section>
+  );
+}

--- a/example/src/components/Install.tsx
+++ b/example/src/components/Install.tsx
@@ -1,0 +1,66 @@
+import { useRef, useState } from "react";
+import { useReveal } from "../hooks/useReveal";
+import type { Locale } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+const INSTALL_COMMANDS = `npm install -g @3xhaust/oh-my-design
+oh-my-design install
+oh-my-design doctor
+omd doctor`;
+
+type CopyState = "idle" | "success" | "error";
+
+// The one interactive surface on an otherwise static page. Implements the two
+// interaction states that actually apply here: success (Doherty threshold —
+// acknowledgment inside 400ms, here effectively instant) and error (clipboard
+// permission can be denied by the browser). Loading/empty/disabled/offline are
+// recorded as not-applicable via `omd decision` — see .omd/decisions.md.
+export function Install({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  const ref = useReveal<HTMLElement>();
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const timeoutRef = useRef<number | undefined>(undefined);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(INSTALL_COMMANDS);
+      setCopyState("success");
+    } catch {
+      setCopyState("error");
+    } finally {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = window.setTimeout(() => setCopyState("idle"), 3000);
+    }
+  }
+
+  return (
+    <section className="install" id="install" ref={ref}>
+      <h2>{t.install.heading}</h2>
+      <p>{t.install.requires}</p>
+
+      <div className="code-block-wrap">
+        <pre className="code-block">
+          <code>{INSTALL_COMMANDS}</code>
+        </pre>
+        <button type="button" className="code-copy" onClick={handleCopy} aria-label={t.install.copyAriaLabel}>
+          <span className="copy-label-swap" key={copyState}>
+            {copyState === "success" ? t.install.copiedLabel : copyState === "error" ? t.install.copyErrorLabel : t.install.copyLabel}
+          </span>
+        </button>
+      </div>
+
+      <p role="status" aria-live="polite" className="copy-status">
+        {copyState === "success" && t.install.copySuccessStatus}
+      </p>
+      {copyState === "error" && (
+        <p role="alert" className="copy-error">
+          {t.install.copyErrorStatus}
+        </p>
+      )}
+
+      <p className="fine">
+        <code>oh-my-design doctor</code> {t.install.fineHostDoctor} <code>omd doctor</code> {t.install.fineRuntimeDoctor}
+      </p>
+    </section>
+  );
+}

--- a/example/src/components/Loop.tsx
+++ b/example/src/components/Loop.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getContent, type StageState, type Locale } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+// Candidate A (winner, .omd/.cache/sketch-selection.md): vertical scroll timeline,
+// pinned stage anchor. The anchor column stays `position: sticky` (desktop) and
+// shows the currently-active stage's number/label/state/artifact while the stage
+// list scrolls past beside it — the pinned card is a literal embodiment of "the
+// design loop made visible" (composition.md Candidate Axis A; .omd/decisions.md
+// showpiece-motion decision).
+//
+// Required production fix carried from the blind selection (responsive hierarchy
+// scored 2/4 on candidate A): on mobile the anchor must NOT float above/before the
+// stage list. Instead of a single global sticky card, each stage item renders its
+// own inline anchor restatement, shown only via CSS at narrow widths and only for
+// the currently-active stage — so on mobile the "pinned" content is attached
+// directly to the relevant list item in natural document flow, never a floating
+// block ahead of the list. See .omd/motion-spec.md "loop anchor pin / release".
+export function Loop({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  const { stages } = getContent(locale);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const stageRefs = useRef<(HTMLLIElement | null)[]>([]);
+
+  useEffect(() => {
+    // IntersectionObserverEntry.boundingClientRect is a snapshot taken at the
+    // moment a target last crossed the threshold — not a live position. With
+    // several ~185px stages fitting inside the shrunk root margin at once, a
+    // long scroll range can pass with zero threshold crossings, so a
+    // callback-driven pick goes stale mid-scroll even with a persisted map.
+    // "Closest stage to viewport center" is a continuous ranking, not a
+    // boolean visibility event, so it's recomputed on every scroll frame from
+    // live getBoundingClientRect() instead.
+    let rafId: number | null = null;
+    const recompute = () => {
+      rafId = null;
+      const vh = window.innerHeight;
+      let bestIdx = -1;
+      let bestDistance = Infinity;
+      stageRefs.current.forEach((el, idx) => {
+        if (!el) return;
+        const rect = el.getBoundingClientRect();
+        const distance = Math.abs(rect.top + rect.height / 2 - vh / 2);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestIdx = idx;
+        }
+      });
+      if (bestIdx !== -1) setCurrentIndex(bestIdx);
+    };
+    const onScroll = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(recompute);
+    };
+
+    recompute();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  const stateOf = useMemo(
+    () =>
+      (index: number): StageState => {
+        if (index < currentIndex) return "checked";
+        if (index === currentIndex) return "current";
+        return "pending";
+      },
+    [currentIndex],
+  );
+
+  const current = stages[currentIndex];
+
+  return (
+    <section className="loop" id="loop">
+      <h2>{t.loop.heading}</h2>
+
+      <div className="timeline">
+        <div className="anchor-track" aria-hidden="true">
+          <div className="anchor" role="note" aria-label="pinned stage anchor">
+            <div className="anchor-swap" key={current.num}>
+              <div className="anchor-num">{current.num}</div>
+              <div className="anchor-label">{current.title}</div>
+              <div className="anchor-state">{t.loop.current}</div>
+              <div className="anchor-connector" />
+              <code className="anchor-caption">{current.artifact}</code>
+            </div>
+          </div>
+        </div>
+
+        <ol className="stage-list">
+          {stages.map((stage, index) => {
+            const state = stateOf(index);
+            return (
+              <li
+                className="stage"
+                key={stage.num}
+                data-state={state}
+                ref={(el) => {
+                  stageRefs.current[index] = el;
+                }}
+              >
+                <div className="stage-node">
+                  <span className="stage-num">{stage.num}</span>
+                  <span className="stage-state" aria-hidden="true" />
+                </div>
+                <div className="stage-body">
+                  <h3>{stage.title}</h3>
+                  <p>{stage.body}</p>
+                  <code className="chip">{stage.artifact}</code>
+
+                  {/* Mobile-only inline anchor restatement — visible only for the
+                      current stage, hidden at desktop via CSS (the sticky column
+                      handles desktop instead). This is the required fix: the
+                      "pinned" fact lives inline, attached to this exact item. */}
+                  {state === "current" && (
+                    <div className="anchor-inline" aria-label="current stage indicator">
+                      <span className="anchor-inline-badge">{t.loop.current}</span>
+                      <span className="anchor-inline-caption">{t.loop.inlineCaption}</span>
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/example/src/components/Nav.tsx
+++ b/example/src/components/Nav.tsx
@@ -1,0 +1,27 @@
+import type { Locale } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+// Persistent nav + CTA, reachable at every scroll depth — composition.md's
+// Experience spine names this as the persistent element; it is also the direct
+// answer to the frame's uxFrequentAction (reach/activate the primary CTA at any
+// scroll depth). Citations: supabase.com.supabase-homepage.json,
+// warp.dev.warp-nav-anatomy.json.
+export function Nav({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  return (
+    <header className="site-nav">
+      <span className="nav-word">OMD</span>
+      <nav className="nav-links" aria-label="Section navigation">
+        <a href="#loop">{t.nav.loop}</a>
+        <a href="#evidence">{t.nav.evidence}</a>
+        <a href="#skills">{t.nav.skills}</a>
+      </nav>
+      <a className="nav-cta" href="#install">
+        {t.nav.install}
+      </a>
+      <a className="nav-lang" href={t.nav.langHref} lang={locale === "en" ? "ko" : "en"}>
+        {t.nav.langLabel}
+      </a>
+    </header>
+  );
+}

--- a/example/src/components/Skills.tsx
+++ b/example/src/components/Skills.tsx
@@ -1,0 +1,23 @@
+import { useReveal } from "../hooks/useReveal";
+import type { Locale } from "../data/content";
+import { getContent } from "../data/content";
+import { getCopy } from "../data/i18n";
+
+export function Skills({ locale }: { locale: Locale }) {
+  const t = getCopy(locale);
+  const { skills } = getContent(locale);
+  const ref = useReveal<HTMLUListElement>();
+
+  return (
+    <section className="skills" id="skills">
+      <h2>{t.skills.heading}</h2>
+      <ul className="skill-list stagger stagger--list" ref={ref}>
+        {skills.map((skill) => (
+          <li key={skill.name}>
+            <strong>{skill.name}</strong> — {skill.body}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/example/src/data/content.ts
+++ b/example/src/data/content.ts
@@ -1,0 +1,315 @@
+// English copy is used verbatim from .omd/copy-deck.md — no paraphrase, no rewrite.
+// Korean copy translates the same claims using the terminology already
+// established in the repo's own README.ko.md (브리프/근거/카피/구성 계약/
+// 격리된 구조안/프로덕션 구현/렌더 비평/재정의), not a fresh voice.
+
+export type Locale = "en" | "ko";
+
+export type StageState = "checked" | "current" | "pending";
+
+export interface Stage {
+  num: string;
+  title: string;
+  body: string;
+  artifact: string;
+}
+
+// All nine start "pending" in markup; StageState is computed at runtime by
+// scroll position and never more than one stage is "checked" simultaneously
+// past the current one (domain grammar: pending -> current -> checked).
+const stagesEn: Stage[] = [
+  {
+    num: "01",
+    title: "Brief",
+    body: "Records the problem and the evidence behind it; every claim needs a user sentence, research line, datum, or named observation.",
+    artifact: ".omd/frame.md",
+  },
+  {
+    num: "02",
+    title: "Evidence",
+    body: "Gathers measurements and principles from real references, not screenshots to copy.",
+    artifact: ".omd/refs/*.json",
+  },
+  {
+    num: "03",
+    title: "Copy",
+    body: "Writes the fact-traceable words first; every shipped claim points to a verified fact ID.",
+    artifact: ".omd/copy-deck.md",
+  },
+  {
+    num: "04",
+    title: "Typography proof",
+    body: "Proves the real copy at actual size before any layout exists.",
+    artifact: ".omd/type-proof.md",
+  },
+  {
+    num: "05",
+    title: "Composition contract",
+    body: "Fixes the focal point and CTA path before structures are drawn.",
+    artifact: ".omd/composition.md",
+  },
+  {
+    num: "06",
+    title: "Isolated structure",
+    body: "Builds separate candidate layouts from the same contract.",
+    artifact: ".omd/.cache/sketches/",
+  },
+  {
+    num: "07",
+    title: "One production build",
+    body: "Ships exactly one of those candidates as real, working source.",
+    artifact: "repository source",
+  },
+  {
+    num: "08",
+    title: "Rendered critique",
+    body: "A reviewer judges only the rendered result, never the builder's reasoning.",
+    artifact: "cache renders, filmstrip",
+  },
+  {
+    num: "09",
+    title: "Reframe",
+    body: "Appends what the render revealed to the original brief instead of erasing it.",
+    artifact: ".omd/frame.md revision",
+  },
+];
+
+const stagesKo: Stage[] = [
+  {
+    num: "01",
+    title: "브리프",
+    body: "문제와 그 근거를 기록합니다. 모든 주장에는 사용자 문장, 조사 문장, 데이터, 이름을 밝힌 관찰 중 하나가 필요합니다.",
+    artifact: ".omd/frame.md",
+  },
+  {
+    num: "02",
+    title: "근거",
+    body: "베낄 화면이 아니라 실제 레퍼런스에서 측정값과 원리를 모읍니다.",
+    artifact: ".omd/refs/*.json",
+  },
+  {
+    num: "03",
+    title: "카피",
+    body: "레이아웃보다 먼저 사실 근거를 추적할 수 있는 문구를 씁니다. 실제로 나가는 모든 주장은 검증된 팩트 ID를 가리킵니다.",
+    artifact: ".omd/copy-deck.md",
+  },
+  {
+    num: "04",
+    title: "타이포그래피 proof",
+    body: "레이아웃이 생기기 전에 실제 카피를 실제 크기로 증명합니다.",
+    artifact: ".omd/type-proof.md",
+  },
+  {
+    num: "05",
+    title: "구성 계약",
+    body: "구조를 그리기 전에 focal point와 CTA 경로를 고정합니다.",
+    artifact: ".omd/composition.md",
+  },
+  {
+    num: "06",
+    title: "격리된 구조안",
+    body: "같은 계약에서 서로 볼 수 없는 후보 레이아웃을 만듭니다.",
+    artifact: ".omd/.cache/sketches/",
+  },
+  {
+    num: "07",
+    title: "프로덕션 구현 1회",
+    body: "그 후보들 중 하나만 실제로 동작하는 소스로 구현합니다.",
+    artifact: "repository source",
+  },
+  {
+    num: "08",
+    title: "렌더 비평",
+    body: "리뷰어는 구현자의 의도가 아니라 렌더 결과만 보고 판단합니다.",
+    artifact: "cache renders, filmstrip",
+  },
+  {
+    num: "09",
+    title: "재정의",
+    body: "렌더가 드러낸 내용을 원래 브리프에 덧붙입니다. 지우지 않습니다.",
+    artifact: ".omd/frame.md revision",
+  },
+];
+
+export interface EvidenceRow {
+  stage: string;
+  artifact: string;
+  boundary: string;
+}
+
+const evidenceRowsEn: EvidenceRow[] = [
+  {
+    stage: "Frame",
+    artifact: ".omd/frame.md",
+    boundary: "Claims need a user sentence, research line, datum, or named observation.",
+  },
+  {
+    stage: "Research",
+    artifact: ".omd/refs/*.json",
+    boundary: "Builders receive measurements and principles, not screenshots to imitate.",
+  },
+  {
+    stage: "Copy",
+    artifact: ".omd/copy-deck.md",
+    boundary: "Each shipped factual claim points to a verified fact ID.",
+  },
+  {
+    stage: "Blind copy review",
+    artifact: "review handoff",
+    boundary: "The reviewer cannot inspect renders, source, layout, frame, decisions, or authorship.",
+  },
+  {
+    stage: "Typography proof",
+    artifact: ".omd/type-proof.md",
+    boundary: "Actual target-language copy proves roles, glyph coverage, and fallback at real viewports.",
+  },
+  {
+    stage: "Composition contract",
+    artifact: ".omd/composition.md",
+    boundary: "A clean-room composer defines the focal anchor and CTA path from sanitized evidence alone.",
+  },
+  {
+    stage: "Blind choice",
+    artifact: ".omd/taste/preferences.jsonl",
+    boundary: "The selector sees anonymous renders and sanitized task context, not candidate rationale.",
+  },
+  {
+    stage: "Production build",
+    artifact: "repository source",
+    boundary: "One builder implements one selected structure and preserves the copy deck.",
+  },
+  {
+    stage: "Rendered review",
+    artifact: "cache renders, filmstrip",
+    boundary: "The reviewer sees measured outputs, never the builder's rationale.",
+  },
+  {
+    stage: "Reframe",
+    artifact: ".omd/frame.md revision",
+    boundary: "Appends what the render revealed instead of erasing the original framing.",
+  },
+];
+
+const evidenceRowsKo: EvidenceRow[] = [
+  {
+    stage: "프레임",
+    artifact: ".omd/frame.md",
+    boundary: "주장에는 사용자 문장, 조사 문장, 데이터, 이름을 밝힌 관찰 중 하나가 근거로 필요합니다.",
+  },
+  {
+    stage: "리서치",
+    artifact: ".omd/refs/*.json",
+    boundary: "구현 담당자는 베낄 화면 대신 측정값과 원리를 받습니다.",
+  },
+  {
+    stage: "카피",
+    artifact: ".omd/copy-deck.md",
+    boundary: "실제로 나가는 사실 문구는 모두 검증된 팩트 ID를 참조합니다.",
+  },
+  {
+    stage: "블라인드 카피 리뷰",
+    artifact: "review handoff",
+    boundary: "리뷰어는 렌더, 소스, 레이아웃, frame, decisions, 작성자를 볼 수 없습니다.",
+  },
+  {
+    stage: "타이포그래피 proof",
+    artifact: ".omd/type-proof.md",
+    boundary: "실제 언어의 카피가 역할, 글리프 범위, fallback을 실제 viewport에서 증명합니다.",
+  },
+  {
+    stage: "구성 계약",
+    artifact: ".omd/composition.md",
+    boundary: "clean-room composer가 정제된 근거만으로 focal anchor와 CTA 경로를 정합니다.",
+  },
+  {
+    stage: "블라인드 선택",
+    artifact: ".omd/taste/preferences.jsonl",
+    boundary: "선택 담당자는 익명 렌더와 정제된 과업 맥락만 보고, 후보의 이유는 보지 않습니다.",
+  },
+  {
+    stage: "프로덕션 구현",
+    artifact: "repository source",
+    boundary: "구현 담당자 한 명이 선택한 구조 하나를 구현하고 카피 덱을 보존합니다.",
+  },
+  {
+    stage: "렌더 리뷰",
+    artifact: "cache renders, filmstrip",
+    boundary: "리뷰어는 측정된 결과만 보고, 구현자의 이유는 보지 않습니다.",
+  },
+  {
+    stage: "재정의",
+    artifact: ".omd/frame.md revision",
+    boundary: "렌더가 드러낸 내용을 덧붙입니다. 원래 프레임을 지우지 않습니다.",
+  },
+];
+
+export interface Skill {
+  name: string;
+  body: string;
+}
+
+const skillsEn: Skill[] = [
+  {
+    name: "omd-ultradesign",
+    body: "Run the complete human design loop for a page, app, dashboard, blog, landing page, or redesign.",
+  },
+  {
+    name: "omd-figma",
+    body: "Pull a Figma file, synthesize its system, implement frames, compare responsive pairs, and report measured fidelity.",
+  },
+  {
+    name: "omd-scout",
+    body: "Build a measured LEGO fragment inventory and chat-ready Markdown candidate/usage tables without designing or implementing.",
+  },
+  {
+    name: "omd-critique",
+    body: "Review an existing design without changing it; group deterministic findings by root cause and judge rendered craft.",
+  },
+  {
+    name: "omd-humanize",
+    body: "Preserve facts while locally repairing sound discourse or reconstructing a misshapen message from verified facts, voice, and surface action.",
+  },
+  {
+    name: "omd-coach",
+    body: "Read accumulated check history, identify recurring problems and trends, and suggest what to practise next.",
+  },
+];
+
+const skillsKo: Skill[] = [
+  {
+    name: "omd-ultradesign",
+    body: "페이지, 앱, 대시보드, 블로그, 랜딩 페이지, 리디자인에 전체 사람 디자인 루프를 실행합니다.",
+  },
+  {
+    name: "omd-figma",
+    body: "Figma 파일을 가져와 시스템을 추출하고, 프레임과 반응형 쌍을 구현한 뒤 측정한 충실도를 보고합니다.",
+  },
+  {
+    name: "omd-scout",
+    body: "디자인이나 구현 없이 측정된 LEGO 조각 인벤토리와 채팅용 Markdown 후보·사용 표를 만듭니다.",
+  },
+  {
+    name: "omd-critique",
+    body: "기존 디자인을 고치지 않고 리뷰합니다. 검사 결과를 원인별로 묶고 렌더 완성도를 판단합니다.",
+  },
+  {
+    name: "omd-humanize",
+    body: "사실을 보존하면서 구조가 맞는 글은 국소 수리하고, 담화 구조가 망가진 글은 검증된 사실·보이스·실제 행동에서 재구성합니다.",
+  },
+  {
+    name: "omd-coach",
+    body: "누적된 check history에서 반복 문제와 추세를 읽고 다음 연습 항목을 제안합니다.",
+  },
+];
+
+export interface LocaleContent {
+  stages: Stage[];
+  evidenceRows: EvidenceRow[];
+  skills: Skill[];
+}
+
+export function getContent(locale: Locale): LocaleContent {
+  return locale === "ko"
+    ? { stages: stagesKo, evidenceRows: evidenceRowsKo, skills: skillsKo }
+    : { stages: stagesEn, evidenceRows: evidenceRowsEn, skills: skillsEn };
+}

--- a/example/src/data/i18n.ts
+++ b/example/src/data/i18n.ts
@@ -1,0 +1,159 @@
+import type { Locale } from "./content";
+
+export interface Copy {
+  nav: {
+    loop: string;
+    evidence: string;
+    skills: string;
+    install: string;
+    langLabel: string;
+    langHref: string;
+  };
+  hero: {
+    title: string;
+    body: string;
+    ctaPrefix: string;
+  };
+  loop: {
+    heading: string;
+    current: string;
+    checked: string;
+    pending: string;
+    inlineCaption: string;
+  };
+  evidence: {
+    heading: string;
+    colStage: string;
+    colArtifact: string;
+    colBoundary: string;
+  };
+  skills: {
+    heading: string;
+  };
+  install: {
+    heading: string;
+    requires: string;
+    copyLabel: string;
+    copiedLabel: string;
+    copyErrorLabel: string;
+    copyAriaLabel: string;
+    copySuccessStatus: string;
+    copyErrorStatus: string;
+    fineHostDoctor: string;
+    fineRuntimeDoctor: string;
+  };
+  footer: {
+    heading: string;
+    body: string;
+    sourceLink: string;
+    langLink: string;
+    langHref: string;
+  };
+}
+
+const en: Copy = {
+  nav: {
+    loop: "Loop",
+    evidence: "Evidence",
+    skills: "Skills",
+    install: "Install OMD",
+    langLabel: "한국어",
+    langHref: `${import.meta.env.BASE_URL}ko/`,
+  },
+  hero: {
+    title: "A design process for coding agents. Not a visual style.",
+    body: "OMD stops a coding agent from jumping straight from a request to polished UI. It questions the brief, gathers evidence, writes real copy, compares structures, builds once, inspects the render, and reframes. Every decision along that chain is recorded, not asserted.",
+    ctaPrefix: "Install OMD — ",
+  },
+  loop: {
+    heading: "Nine stages. Each one checked before the next begins.",
+    current: "current",
+    checked: "checked",
+    pending: "pending",
+    inlineCaption: "pinned on desktop — attached here on mobile",
+  },
+  evidence: {
+    heading: "What gets checked, and who is blind to what",
+    colStage: "Stage",
+    colArtifact: "Artifact",
+    colBoundary: "Boundary",
+  },
+  skills: {
+    heading: "Six skills. Each one a different entry point.",
+  },
+  install: {
+    heading: "Install, then verify.",
+    requires: "Requires Node.js 22.18 or newer, and Codex, Claude Code, or both, already configured.",
+    copyLabel: "Copy",
+    copiedLabel: "Copied",
+    copyErrorLabel: "Select manually",
+    copyAriaLabel: "Copy install commands to clipboard",
+    copySuccessStatus: "Commands copied to clipboard.",
+    copyErrorStatus:
+      "Clipboard access was blocked by the browser. Select the text in the code block above and copy it manually.",
+    fineHostDoctor: "verifies the host installation.",
+    fineRuntimeDoctor: "checks the runtime, Chromium availability, project write access, and the bundled theory pack.",
+  },
+  footer: {
+    heading: "Run the loop yourself.",
+    body: "MIT licensed. Read the full process in the README, in English or 한국어.",
+    sourceLink: "View source on GitHub",
+    langLink: "한국어로 보기 (View in Korean)",
+    langHref: `${import.meta.env.BASE_URL}ko/`,
+  },
+};
+
+const ko: Copy = {
+  nav: {
+    loop: "루프",
+    evidence: "근거",
+    skills: "스킬",
+    install: "OMD 설치",
+    langLabel: "English",
+    langHref: import.meta.env.BASE_URL,
+  },
+  hero: {
+    title: "비주얼 스타일이 아니라, 코딩 에이전트를 위한 디자인 프로세스입니다.",
+    body: "OMD는 코딩 에이전트가 요청을 받자마자 완성 화면으로 뛰어드는 흐름을 막습니다. 브리프를 캐묻고, 근거를 모으고, 실제 카피를 쓰고, 구조를 비교하고, 한 번 구현하고, 렌더를 살핀 뒤 다시 정의합니다. 그 과정의 모든 결정은 주장이 아니라 기록됩니다.",
+    ctaPrefix: "OMD 설치 — ",
+  },
+  loop: {
+    heading: "아홉 단계. 다음 단계는 이전 단계가 확인된 뒤에만 시작됩니다.",
+    current: "진행 중",
+    checked: "완료",
+    pending: "대기",
+    inlineCaption: "데스크톱에서는 고정 카드, 모바일에서는 이 위치에 붙습니다",
+  },
+  evidence: {
+    heading: "무엇을 검사하고, 누가 무엇을 못 보는가",
+    colStage: "단계",
+    colArtifact: "산출물",
+    colBoundary: "경계",
+  },
+  skills: {
+    heading: "여섯 개의 스킬. 각각 다른 진입점입니다.",
+  },
+  install: {
+    heading: "설치하고 검증하세요.",
+    requires: "Node.js 22.18 이상, 그리고 Codex 또는 Claude Code(또는 둘 다)가 이미 설정되어 있어야 합니다.",
+    copyLabel: "복사",
+    copiedLabel: "복사됨",
+    copyErrorLabel: "직접 선택하세요",
+    copyAriaLabel: "설치 명령어를 클립보드에 복사",
+    copySuccessStatus: "명령어가 클립보드에 복사되었습니다.",
+    copyErrorStatus: "브라우저가 클립보드 접근을 차단했습니다. 위 코드 블록의 텍스트를 직접 선택해서 복사하세요.",
+    fineHostDoctor: "는 호스트 설치를 검증합니다.",
+    fineRuntimeDoctor: "는 런타임, Chromium 존재 여부, 프로젝트 쓰기 권한, 내장 이론 팩을 확인합니다.",
+  },
+  footer: {
+    heading: "직접 루프를 실행해 보세요.",
+    body: "MIT 라이선스입니다. 전체 프로세스는 README에서 영어 또는 한국어로 읽을 수 있습니다.",
+    sourceLink: "GitHub에서 소스 보기",
+    langLink: "View in English (영어로 보기)",
+    langHref: import.meta.env.BASE_URL,
+  },
+};
+
+export function getCopy(locale: Locale): Copy {
+  return locale === "ko" ? ko : en;
+}

--- a/example/src/hooks/useReveal.ts
+++ b/example/src/hooks/useReveal.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Adds `is-visible` to an element once it crosses the viewport threshold, then
+ * disconnects — entrance animations fire once on scroll-into-view, they never
+ * replay (choreography rule). Honors prefers-reduced-motion implicitly: the CSS
+ * in index.css strips the transition/opacity effect entirely under that media
+ * query, so toggling the class is harmless either way.
+ *
+ * `waitForFonts` (used only by the hero, see Hero.tsx) defers the reveal until
+ * `document.fonts.ready` instead of firing the instant the element intersects.
+ * The hero is already in the viewport at mount, so an immediate reveal collapses
+ * into the same frame as first paint — nothing to animate from. Self-hosted
+ * Geist Sans/Mono are still being fetched at that point; gating the entrance on
+ * font readiness is also the correct behavior for real users (no flash of a
+ * fallback face mid-transition), not just a timing fix.
+ */
+export function useReveal<T extends HTMLElement>(threshold = 0.2, waitForFonts = false) {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const reveal = (target: Element) => {
+      const fire = () => {
+        // Double rAF: guarantees the hidden state has actually painted at
+        // least one frame before the class flip, so the transition always
+        // has something to animate from.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => target.classList.add("is-visible"));
+        });
+      };
+      if (waitForFonts && "fonts" in document) {
+        document.fonts.ready.then(fire);
+      } else {
+        fire();
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            reveal(entry.target);
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold, waitForFonts]);
+
+  return ref;
+}

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,0 +1,306 @@
+/* ============================================================
+   Design tokens — every value below cites a board capture or a
+   theory file. See .omd/attribution.md for the full table.
+   ============================================================ */
+:root {
+  /* ---- color ----
+     theory/color.md: developer tools read as dark-mode-by-genre, but the same file
+     names the explicit exception — "Colour the UI dark and the marketing light" for
+     products (Vercel, Linear) positioned at technical users who read a light
+     marketing surface before ever opening the dark tool. OMD's own font citation
+     (Geist Sans/Mono) IS Vercel's own design system, so this page follows Vercel's
+     own marketing register: light, cool-neutral, cool background says "focus" per
+     theory/color.md's background-temperature section. Accent is a single
+     low-saturation green (not indigo/violet or purple/pink — SLOP-GRADIENT hue
+     bands avoided) — chosen because the domain grammar's "checked" stage state is
+     the one semantically loaded moment on the page, and theory/color.md: low
+     saturation reads authoritative/premium, appropriate for an enterprise/process
+     tool whose whole thesis is rigor-before-hype (copy-deck.md voice contract). */
+  --color-bg: #fafbfa;
+  --color-surface: #f1f4f2;
+  --color-surface-strong: #e5eae6;
+  --color-ink: #10160f;
+  --color-ink-muted: rgba(16, 22, 15, 0.62);
+  --color-ink-faint: rgba(16, 22, 15, 0.4);
+  --color-rule: rgba(16, 22, 15, 0.14);
+  --color-rule-strong: rgba(16, 22, 15, 0.32);
+  --color-accent: #1f7a52;
+  --color-accent-bright: #52e0a8;
+  --color-mono-panel: #10160f;
+  /* theory/color.md: dark-surface elevation is a white-tint overlay (Material's
+     4/8/12/16/24% ladder), never a lighter flat hex. #2d322c is #10160f flattened
+     with 12% white pre-computed to a literal solid value (not color-mix()) so
+     every consumer — including static analysis that does not evaluate CSS color
+     functions — resolves the same opaque color. Used for the code-copy button so
+     it reads as a distinct, lower elevation than the page's one filled primary
+     (.hero .cta). */
+  --color-mono-panel-raised: #2d322c;
+  --color-mono-ink: #eef2ee;
+  --color-mono-ink-muted: rgba(238, 242, 238, 0.64);
+  --color-paper: #ffffff;
+
+  /* ---- type ----
+     Family citation: vercel.com.geist-design-system.json (fontFamilies
+     ["geist","geist mono","geistsans"]) corroborated by
+     ui.shadcn.com.shadcn-docs-components.json and
+     ui.shadcn.com.shadcn-codeblock-anatomy.json — three independent captures name
+     the same family pair (.omd/type-proof.md). Korean-capable fallback added after
+     Geist Sans per .omd/decisions.md (Geist Sans's unicode-range false-positives
+     document.fonts.check() for Hangul it has no glyphs for). */
+  --font-sans: "Geist Sans", "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR",
+    ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono", "Apple SD Gothic Neo", "Malgun Gothic", ui-monospace,
+    "SFMono-Regular", Menlo, Consolas, monospace;
+
+  /* type scale — .omd/type-proof.md 10-role map, reused exactly */
+  --text-2xs: 12px;
+  --text-xs: 13px;
+  --text-sm: 15px;
+  --text-base: 17px;
+  --text-lg: 22px;
+  --text-xl: 30px;
+  --text-display: 64px;
+  --text-display-mobile: 34px;
+
+  --lh-body: 1.55;
+  --lh-display: 1.08;
+  --lh-tight: 1.25;
+  --lh-mono-block: 1.7;
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+
+  /* ---- spacing ladder ----
+     vercel.com.geist-design-system.json spacingLadder [4,6,8,12,16,24,32] (the
+     type/font citation source) extended with 40/48 from
+     linear.app.linear-pipeline-motion-study.json spacingLadder (…40,48) and 96 from
+     apple.com.apple-scroll-motion-study.json spacingLadder (…96) for section-level
+     rhythm — .omd/composition.md's density arc needs a larger step than the
+     component-level ladder provides. */
+  --space-1: 4px;
+  --space-2: 6px;
+  --space-3: 8px;
+  --space-4: 12px;
+  --space-5: 16px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 40px;
+  --space-9: 48px;
+  --space-10: 64px;
+  --space-11: 96px;
+
+  /* ---- radius ladder ----
+     linear.app.linear-pipeline-motion-study.json radiusLadder
+     [4,6,8,12,16,50,9999] corroborated by vercel.com.geist-design-system.json
+     radiusLadder [6,50,pill]. */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-pill: 9999px;
+
+  /* ---- motion ---- see .omd/motion-spec.md for the full per-scene citation table */
+  --duration-instant: 150ms; /* warp.dev.warp-nav-anatomy + resend.com.resend-motion-study */
+  --duration-fast: 200ms; /* vercel.com.geist-design-system */
+  --duration-base: 250ms; /* apple.com.apple-scroll-motion-study */
+  --duration-scene: 320ms; /* apple.com.apple-scroll-motion-study (scroll-tied capture) */
+  --duration-list: 280ms; /* core/motion/recipes/stagger-orchestrator.md */
+  --duration-hero-entrance: 800ms; /* stripe.com.stripe-motion-study — the one 800ms
+    value in that capture's duration set, reserved for the single first-load moment;
+    every other duration on the page stays in the 150-320ms band. See motion-spec.md. */
+
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1); /* core/motion/easing.md */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1); /* core/motion/easing.md */
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1); /* core/motion/easing.md */
+  --ease-in-out-quint: cubic-bezier(0.83, 0, 0.17, 1); /* core/motion/easing.md */
+
+  --stagger-hero: 60ms;
+  --stagger-list: 55ms;
+  --stagger-table: 28ms;
+
+  --measure-body: 62ch;
+  --measure-narrow: 58ch;
+  --section-max: 920px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--lh-body);
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: var(--weight-semibold);
+}
+
+/* Korean text nodes exist (footer language link) — apply the base rule locally
+   rather than project-wide, since English is the primary language (copy-deck.md
+   F-010) and *-level keep-all would be a no-op everywhere else. */
+[lang="ko"],
+.i18n-ko {
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+a {
+  color: inherit;
+}
+
+code {
+  font-family: var(--font-mono);
+}
+
+::selection {
+  /* finish-pass.md item 1: derive from --color-accent, never default browser blue */
+  background: var(--color-accent);
+  color: var(--color-paper);
+}
+
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  /* finish-pass.md item 2: two-layer box-shadow ring, never bare outline suppression */
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-accent);
+  border-radius: var(--radius-sm);
+}
+
+/* finish-pass.md item 3: standards-track scrollbar styling first, webkit fallback */
+html {
+  scrollbar-color: var(--color-rule-strong) transparent;
+  scrollbar-width: thin;
+}
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-rule-strong);
+  border-radius: var(--radius-pill);
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+section,
+footer.site-footer {
+  max-width: var(--section-max);
+  margin: 0 auto;
+  padding: 0 var(--space-6);
+}
+
+@media (max-width: 480px) {
+  section,
+  footer.site-footer {
+    padding: 0 var(--space-5);
+  }
+}
+
+/* ============================================================
+   Motion layer — prefers-reduced-motion wraps everything.
+   In its absence nothing moves outside this block's rules.
+   ============================================================ */
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    transform: translateY(16px);
+    transition:
+      opacity var(--duration-base) var(--ease-out-expo),
+      transform var(--duration-base) var(--ease-out-expo);
+  }
+  .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+  }
+
+  .stagger > * {
+    opacity: 0;
+    transform: translateY(16px);
+    transition:
+      opacity var(--duration-list) var(--ease-out-quint),
+      transform var(--duration-list) var(--ease-out-quint);
+  }
+  .stagger.is-visible > * {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* The hero is the one first-load moment the motion budget is spent on
+     (system prompt: "spend itself where it earns the most — the first-load
+     entrance"). Every other stagger scene on the page stays on --duration-list
+     (280ms); the hero alone gets the slower, deliberate --duration-hero-entrance
+     (800ms, stripe.com.stripe-motion-study). More specific selector overrides
+     the shared .stagger > * rule above. */
+  .hero.stagger > * {
+    transition:
+      opacity var(--duration-hero-entrance) var(--ease-out-expo),
+      transform var(--duration-hero-entrance) var(--ease-out-expo);
+  }
+
+  .anchor-swap {
+    transition: opacity var(--duration-scene) var(--ease-in-out-quint);
+  }
+
+  .stage-state,
+  .stage-num {
+    transition:
+      background-color var(--duration-fast) var(--ease-standard),
+      border-color var(--duration-fast) var(--ease-standard),
+      color var(--duration-fast) var(--ease-standard);
+  }
+
+  .cta,
+  .nav-cta,
+  .chip,
+  .code-copy {
+    transition:
+      background-color var(--duration-instant) var(--ease-standard),
+      color var(--duration-instant) var(--ease-standard),
+      border-color var(--duration-instant) var(--ease-standard),
+      transform var(--duration-instant) var(--ease-standard);
+  }
+
+  .copy-label-swap {
+    transition: opacity var(--duration-instant) var(--ease-standard);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .stagger > *,
+  .anchor-swap,
+  .stage-state,
+  .stage-num,
+  .cta,
+  .nav-cta,
+  .chip,
+  .code-copy,
+  .copy-label-swap {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .anchor-track {
+    position: static !important;
+  }
+}

--- a/example/src/main.ko.tsx
+++ b/example/src/main.ko.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@fontsource/geist-sans/400.css";
+import "@fontsource/geist-sans/500.css";
+import "@fontsource/geist-sans/600.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/500.css";
+import "./index.css";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App locale="ko" />
+  </StrictMode>,
+);

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@fontsource/geist-sans/400.css";
+import "@fontsource/geist-sans/500.css";
+import "@fontsource/geist-sans/600.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/500.css";
+import "./index.css";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/example/src/vite-env.d.ts
+++ b/example/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Served as a GitHub Pages project site at https://3x-haust.github.io/oh-my-design/.
+// The base is applied to asset URLs and exposed to the app via import.meta.env.BASE_URL.
+export default defineConfig({
+  base: "/oh-my-design/",
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        ko: resolve(__dirname, "ko/index.html"),
+      },
+    },
+  },
+});


### PR DESCRIPTION
example/ is the deployed GitHub Pages landing source, linked from both READMEs. It was accidentally swept into #90's commit as an unrelated working-tree deletion. Restored verbatim from ba2b57e.