### PR TITLE
feat: omd usage — report a run's elapsed time + token total from the host session log

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -240,6 +240,19 @@ async function cmdCraft(sub: string | undefined, opts: Opts): Promise<never> {
   throw new Error('usage: omd craft checkpoint ... | omd craft status [--json]');
 }
 
+async function cmdUsage(opts: Opts): Promise<never> {
+  const { computeRunUsage, formatRunUsage } = await import('../core/usage/index.ts');
+  const u = computeRunUsage(process.cwd());
+  if (!u) {
+    if (opts.json) process.stdout.write('null');
+    else console.log('실행 사용량: 호스트 세션 로그를 찾지 못했습니다 (Claude Code / Codex 세션 로그 없음).');
+    process.exit(0);
+  }
+  if (opts.json) process.stdout.write(JSON.stringify(u));
+  else console.log(formatRunUsage(u));
+  process.exit(0);
+}
+
 /**
  * Cross-page site consistency check: `omd check --site <dir>`.
  *
@@ -1647,6 +1660,7 @@ function usage(): never {
     + '  slop scan [root] [--json]                   read-only source candidate scan\n'
     + '  stack [--json]                              deterministic stack routing (blank greenfield -> React+Vite+TS)\n'
     + '  coach                                        trends across `omd check` history\n'
+    + '  usage [--json]                              this run\'s elapsed time + token total (host session log)\n'
     + '\n'
     + '  frame show\n'
     + '  frame set --problem P --reframe R --why EVIDENCE\n'
@@ -1726,6 +1740,7 @@ async function main(): Promise<never> {
   if (cmd === 'slop') return cmdSlop(sub, parseArgs(args.slice(2)));
   if (cmd === 'lighthouse') return cmdLighthouse(parseArgs(args.slice(1)));
   if (cmd === 'coach') return cmdCoach();
+  if (cmd === 'usage') return cmdUsage(parseArgs(args.slice(1)));
   if (cmd === 'config') return cmdConfig(sub, parseArgs(args.slice(2)));
   if (cmd === 'craft') return cmdCraft(sub, parseArgs(args.slice(2)));
 

--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -425,6 +425,7 @@ These gates are part of every applicable production run, not optional polish:
   the finalizer runs the validator-backed report formatter from
   `protocol/reference-assembly.md` before the final chat handback. The finalizer pastes the
   formatter's exact bilingual Markdown and does not replace it with a vague inspiration claim.
+- Close the final chat handback with this run's usage: run `omd usage` and include its elapsed-time and token total in the final message. It reads the host session log (Claude Code or Codex) and sums the run's threads; when no log is found it prints a short unavailable note that is simply omitted, never replaced by a fabricated number.
 - Walk `craft/finish-pass.md`. Complete applicable items and record a concrete reason for
   every skipped item.
 - When `.omd/design.md` exists, run `omd design --check` and resolve its findings.

--- a/core/usage/index.ts
+++ b/core/usage/index.ts
@@ -1,0 +1,336 @@
+import { homedir } from 'node:os';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Run usage: wall-clock time + token totals for the current design run.
+ *
+ * OMD runs inside a host agent (Claude Code or Codex). Neither exposes a token
+ * meter to a skill directly, but both persist per-turn usage to a local session
+ * log. This module reads that log for the current working directory and sums it.
+ * The parsers are pure (they take the log lines); only the discovery layer
+ * touches the filesystem, so the summation is unit-tested against real fixtures.
+ */
+export interface RunUsage {
+  host: 'claude' | 'codex';
+  /** Total tokens processed (input + cache + output), summed across the run's threads. */
+  totalTokens: number;
+  /** Output (generated) tokens only. */
+  outputTokens: number;
+  /** Wall-clock milliseconds from first to last logged event. */
+  elapsedMs: number;
+  /** Tool invocations, when the log records them. */
+  toolUses: number;
+  /** True when the figure is known to be partial (e.g. Codex subagent rollouts not found). */
+  approximate: boolean;
+  /** Human note about scope/source. */
+  note: string;
+}
+
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : Number(v) || 0);
+
+function parseTs(...candidates: unknown[]): number {
+  for (const c of candidates) {
+    if (typeof c !== 'string') continue;
+    const t = Date.parse(c);
+    if (Number.isFinite(t)) return t;
+  }
+  return NaN;
+}
+
+// ── Claude Code session transcript (one JSON object per line) ───────────────────
+//
+// Assistant `usage` repeats on every content-block line of the SAME message, so
+// tokens are deduped by message id. Tool-use blocks are deduped by their own id.
+// A subagent's total is surfaced to the parent as a `<usage>subagent_tokens: N
+// tool_uses: N duration_ms: N</usage>` block inside a tool_result — its tokens are
+// NOT in the parent's per-message usage, so they are added, not double-counted.
+export function parseClaudeSession(lines: string[]): RunUsage | null {
+  const byMsg = new Map<string, { total: number; output: number }>();
+  const toolIds = new Set<string>();
+  let first = Infinity;
+  let last = -Infinity;
+  let anyEvent = false;
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const rec = obj as Record<string, any>;
+    anyEvent = true;
+    const ts = parseTs(rec.timestamp, rec?.message?.timestamp);
+    if (Number.isFinite(ts)) {
+      if (ts < first) first = ts;
+      if (ts > last) last = ts;
+    }
+    const msg = rec.message;
+    const usage = msg?.usage;
+    if (msg?.id && usage && typeof usage === 'object') {
+      const total = num(usage.input_tokens) + num(usage.cache_creation_input_tokens)
+        + num(usage.cache_read_input_tokens) + num(usage.output_tokens);
+      byMsg.set(msg.id, { total, output: num(usage.output_tokens) });
+    }
+    const content = msg?.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block?.type === 'tool_use' && typeof block.id === 'string') toolIds.add(block.id);
+      }
+    }
+  }
+
+  if (!anyEvent) return null;
+
+  let totalTokens = 0;
+  let outputTokens = 0;
+  for (const v of byMsg.values()) {
+    totalTokens += v.total;
+    outputTokens += v.output;
+  }
+  let toolUses = toolIds.size;
+
+  // Subagent completion summaries live in tool_result text; dedup identical blocks.
+  const joined = lines.join('\n');
+  const subUsage = new Set<string>();
+  for (const m of joined.matchAll(/subagent_tokens:\s*(\d+)\s*(?:\\n|\s)+tool_uses:\s*(\d+)\s*(?:\\n|\s)+duration_ms:\s*(\d+)/g)) {
+    const key = `${m[1]}:${m[2]}:${m[3]}`;
+    if (subUsage.has(key)) continue;
+    subUsage.add(key);
+    totalTokens += Number(m[1]);
+    toolUses += Number(m[2]);
+  }
+
+  const elapsedMs = Number.isFinite(first) && Number.isFinite(last) && last > first ? last - first : 0;
+  return {
+    host: 'claude',
+    totalTokens,
+    outputTokens,
+    elapsedMs,
+    toolUses,
+    approximate: false,
+    note: subUsage.size > 0 ? 'claude 세션 로그 (서브에이전트 포함)' : 'claude 세션 로그',
+  };
+}
+
+// ── Codex rollout (one JSON object per line) ────────────────────────────────────
+//
+// Each `token_count` event carries a per-thread cumulative
+// `total_token_usage.total_tokens`; the last one is that thread's total. A run's
+// subagents are separate rollout files parented to the main thread's session id.
+export interface CodexRollout {
+  cwd: string | null;
+  sessionId: string | null;
+  parentThreadId: string | null;
+  isSubagent: boolean;
+  totalTokens: number;
+  outputTokens: number;
+  first: number;
+  last: number;
+  hadTokenCount: boolean;
+}
+
+export function parseCodexRollout(lines: string[]): CodexRollout | null {
+  let cwd: string | null = null;
+  let sessionId: string | null = null;
+  let parentThreadId: string | null = null;
+  let isSubagent = false;
+  let totalTokens = 0;
+  let outputTokens = 0;
+  let first = Infinity;
+  let last = -Infinity;
+  let hadTokenCount = false;
+  let any = false;
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const rec = obj as Record<string, any>;
+    any = true;
+    const ts = parseTs(rec.timestamp);
+    if (Number.isFinite(ts)) {
+      if (ts < first) first = ts;
+      if (ts > last) last = ts;
+    }
+    const p = rec.payload;
+    if (rec.type === 'session_meta' && p) {
+      cwd = p.cwd ?? cwd;
+      sessionId = p.session_id ?? p.id ?? sessionId;
+      parentThreadId = p.parent_thread_id
+        ?? p?.source?.subagent?.thread_spawn?.parent_thread_id
+        ?? parentThreadId;
+      if (p.thread_source === 'subagent' || parentThreadId) isSubagent = true;
+    }
+    if (p?.type === 'token_count') {
+      const info = p.info?.total_token_usage;
+      if (info && typeof info.total_tokens === 'number') {
+        totalTokens = info.total_tokens; // cumulative — last wins
+        outputTokens = num(info.output_tokens);
+        hadTokenCount = true;
+      }
+    }
+  }
+
+  if (!any) return null;
+  return { cwd, sessionId, parentThreadId, isSubagent, totalTokens, outputTokens, first, last, hadTokenCount };
+}
+
+/** Combine a main Codex rollout with its subagent rollouts into one RunUsage. */
+export function combineCodexRollouts(main: CodexRollout, children: CodexRollout[]): RunUsage {
+  let totalTokens = main.totalTokens;
+  let outputTokens = main.outputTokens;
+  let first = main.first;
+  let last = main.last;
+  for (const c of children) {
+    totalTokens += c.totalTokens;
+    outputTokens += c.outputTokens;
+    if (c.first < first) first = c.first;
+    if (c.last > last) last = c.last;
+  }
+  const elapsedMs = Number.isFinite(first) && Number.isFinite(last) && last > first ? last - first : 0;
+  return {
+    host: 'codex',
+    totalTokens,
+    outputTokens,
+    elapsedMs,
+    toolUses: 0,
+    approximate: false,
+    note: children.length > 0
+      ? `codex 롤아웃 (서브에이전트 ${children.length}개 포함)`
+      : 'codex 롤아웃 (메인 스레드)',
+  };
+}
+
+// ── Discovery (filesystem) ──────────────────────────────────────────────────────
+
+function claudeSlug(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, '-');
+}
+
+function newestFile(paths: string[]): string | null {
+  let best: string | null = null;
+  let bestMtime = -Infinity;
+  for (const p of paths) {
+    try {
+      const m = statSync(p).mtimeMs;
+      if (m > bestMtime) {
+        bestMtime = m;
+        best = p;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  return best;
+}
+
+function readClaudeUsage(cwd: string, home: string): RunUsage | null {
+  const dir = join(home, '.claude', 'projects', claudeSlug(cwd));
+  if (!existsSync(dir)) return null;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir).filter((f) => f.endsWith('.jsonl')).map((f) => join(dir, f));
+  } catch {
+    return null;
+  }
+  const file = newestFile(entries);
+  if (!file) return null;
+  return parseClaudeSession(readFileSync(file, 'utf8').split('\n'));
+}
+
+function listCodexRollouts(home: string, sinceMs: number): string[] {
+  const base = join(home, '.codex', 'sessions');
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    let items: string[];
+    try {
+      items = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const item of items) {
+      const full = join(dir, item);
+      let st: ReturnType<typeof statSync>;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) walk(full);
+      else if (item.startsWith('rollout-') && item.endsWith('.jsonl') && st.mtimeMs >= sinceMs) out.push(full);
+    }
+  };
+  walk(base);
+  return out;
+}
+
+function readCodexUsage(cwd: string, home: string): RunUsage | null {
+  // Bound the scan to recent rollouts to avoid reading the whole archive.
+  const sinceMs = Date.now() - 24 * 60 * 60 * 1000;
+  const files = listCodexRollouts(home, sinceMs);
+  if (files.length === 0) return null;
+
+  const parsed: Array<{ file: string; mtime: number; roll: CodexRollout }> = [];
+  for (const file of files) {
+    let roll: CodexRollout | null;
+    try {
+      roll = parseCodexRollout(readFileSync(file, 'utf8').split('\n'));
+    } catch {
+      continue;
+    }
+    if (!roll || roll.cwd !== cwd) continue;
+    parsed.push({ file, mtime: statSync(file).mtimeMs, roll });
+  }
+  if (parsed.length === 0) return null;
+
+  // Main = newest non-subagent rollout for this cwd; else newest of any.
+  parsed.sort((a, b) => b.mtime - a.mtime);
+  const mainEntry = parsed.find((p) => !p.roll.isSubagent) ?? parsed[0]!;
+  const main = mainEntry.roll;
+  const rootId = main.sessionId;
+  const children = parsed
+    .filter((p) => p !== mainEntry && rootId && p.roll.parentThreadId === rootId)
+    .map((p) => p.roll);
+  return combineCodexRollouts(main, children);
+}
+
+/**
+ * Compute usage for the current run from the host session log. Returns null when
+ * no readable host log is found (e.g. an unknown host or a fresh worktree with no
+ * session yet) — callers fall back to a time-only or "unavailable" report.
+ */
+export function computeRunUsage(cwd: string, home: string = homedir()): RunUsage | null {
+  return readClaudeUsage(cwd, home) ?? readCodexUsage(cwd, home);
+}
+
+// ── Formatting ──────────────────────────────────────────────────────────────────
+
+export function formatElapsed(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}초`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  if (m < 60) return rem ? `${m}분 ${rem}초` : `${m}분`;
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  return mm ? `${h}시간 ${mm}분` : `${h}시간`;
+}
+
+export function formatRunUsage(u: RunUsage): string {
+  const n = (x: number): string => x.toLocaleString('en-US');
+  const lines = [
+    '## 실행 사용량 (이 세션)',
+    `- 소요 시간: ${formatElapsed(u.elapsedMs)}`,
+    `- 토큰: 총 ${n(u.totalTokens)}${u.outputTokens ? ` (출력 ${n(u.outputTokens)})` : ''}${u.approximate ? ' (근사)' : ''}`,
+  ];
+  if (u.toolUses > 0) lines.push(`- 도구 호출: ${n(u.toolUses)}회`);
+  lines.push(`- 출처: ${u.note}`);
+  return lines.join('\n');
+}

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -505,6 +505,7 @@ scan was rerun after repairs. When reference assembly applies, hand off the pass
 `reference-usage-v1` ledger to the finalizer, which calls `generateReferenceReport(root)`, persists
 `.omd/reference-report.md`, and pastes the formatter's exact Korean-first bilingual Markdown into
 the final chat. Everything is clean or has an evidence-backed deliberate overrule.
+Regardless of whether reference assembly applied, close the final chat response with this run's usage: run `omd usage` and include its elapsed-time and token total in your final message to the user. It reads the host session log (Claude Code or Codex); if no log is found it prints a short unavailable note, which you simply omit rather than fabricating a number.
 When the run is an iteration with a before/after pair, form the pairwise blind-choose verdict:
 blind-choose is the visual distinction signal only; applicable task probes, accessibility checks, and
 declared viewport task evidence remain independent passing UX gates. Record the comparison; it never

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -505,6 +505,7 @@ scan was rerun after repairs. When reference assembly applies, hand off the pass
 `reference-usage-v1` ledger to the finalizer, which calls `generateReferenceReport(root)`, persists
 `.omd/reference-report.md`, and pastes the formatter's exact Korean-first bilingual Markdown into
 the final chat. Everything is clean or has an evidence-backed deliberate overrule.
+Regardless of whether reference assembly applied, close the final chat response with this run's usage: run `omd usage` and include its elapsed-time and token total in your final message to the user. It reads the host session log (Claude Code or Codex); if no log is found it prints a short unavailable note, which you simply omit rather than fabricating a number.
 When the run is an iteration with a before/after pair, form the pairwise blind-choose verdict:
 blind-choose is the visual distinction signal only; applicable task probes, accessibility checks, and
 declared viewport task evidence remain independent passing UX gates. Record the comparison; it never

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -516,3 +516,11 @@ test('scout researches the real subject first and lets its identity anchor gover
   assert.match(proto, /## Subject anchor/i);
   assert.match(proto, /it governs the colour and motif every other lane serves/i);
 });
+
+test('the run closes by reporting usage (elapsed + tokens) in the final chat, never fabricated', () => {
+  const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
+  assert.match(loop, /Close the final chat handback with this run's usage: run `omd usage`/i);
+  assert.match(loop, /never replaced by a fabricated number/i);
+  const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
+  assert.match(skill, /close the final chat response with this run's usage: run `omd usage`/i);
+});

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseClaudeSession,
+  parseCodexRollout,
+  combineCodexRollouts,
+  formatElapsed,
+  formatRunUsage,
+} from '../core/usage/index.ts';
+
+const jl = (obj: unknown): string => JSON.stringify(obj);
+
+test('parseClaudeSession dedups per-message usage, adds subagent totals, counts tools', () => {
+  const lines = [
+    // same message id on two content-block lines — usage must count once
+    jl({ timestamp: '2026-07-21T08:00:00.000Z', message: { id: 'm1', role: 'assistant', usage: { input_tokens: 2, cache_creation_input_tokens: 100, cache_read_input_tokens: 0, output_tokens: 50 }, content: [{ type: 'thinking' }] } }),
+    jl({ timestamp: '2026-07-21T08:00:01.000Z', message: { id: 'm1', role: 'assistant', usage: { input_tokens: 2, cache_creation_input_tokens: 100, cache_read_input_tokens: 0, output_tokens: 50 }, content: [{ type: 'tool_use', id: 'tu1' }] } }),
+    jl({ timestamp: '2026-07-21T08:00:02.000Z', message: { id: 'm2', role: 'assistant', usage: { input_tokens: 2, cache_creation_input_tokens: 0, cache_read_input_tokens: 100, output_tokens: 30 }, content: [{ type: 'tool_use', id: 'tu2' }] } }),
+    // subagent completion summary lives in a tool_result text block
+    jl({ timestamp: '2026-07-21T08:01:02.000Z', type: 'user', message: { role: 'user', content: [{ type: 'tool_result', content: [{ type: 'text', text: '<usage>subagent_tokens: 1000\ntool_uses: 5\nduration_ms: 60000</usage>' }] }] } }),
+  ];
+  const u = parseClaudeSession(lines);
+  assert.ok(u);
+  assert.equal(u.host, 'claude');
+  // m1 = 152 (counted once, not twice), m2 = 132, +1000 subagent
+  assert.equal(u.totalTokens, 152 + 132 + 1000);
+  assert.equal(u.outputTokens, 80);
+  assert.equal(u.toolUses, 2 + 5); // tu1, tu2, + 5 subagent tool_uses
+  assert.equal(u.elapsedMs, 62_000); // 08:00:00 -> 08:01:02
+  assert.match(u.note, /서브에이전트 포함/);
+});
+
+test('parseClaudeSession returns null with no parseable events', () => {
+  assert.equal(parseClaudeSession(['', '   ']), null);
+  assert.equal(parseClaudeSession(['not json']), null);
+});
+
+test('parseCodexRollout keeps the last cumulative total and thread lineage', () => {
+  const main = parseCodexRollout([
+    jl({ timestamp: '2026-07-19T09:00:00.000Z', type: 'session_meta', payload: { cwd: '/x', session_id: 'root', thread_source: 'main' } }),
+    jl({ timestamp: '2026-07-19T09:00:01.000Z', type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { total_tokens: 500, output_tokens: 20 } } } }),
+    jl({ timestamp: '2026-07-19T09:00:05.000Z', type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { total_tokens: 1500, output_tokens: 60 } } } }),
+  ]);
+  assert.ok(main);
+  assert.equal(main.cwd, '/x');
+  assert.equal(main.sessionId, 'root');
+  assert.equal(main.isSubagent, false);
+  assert.equal(main.totalTokens, 1500); // last cumulative, not the sum of events
+  assert.equal(main.outputTokens, 60);
+});
+
+test('combineCodexRollouts sums main plus subagent rollouts', () => {
+  const main = parseCodexRollout([
+    jl({ timestamp: '2026-07-19T09:00:00.000Z', type: 'session_meta', payload: { cwd: '/x', session_id: 'root' } }),
+    jl({ timestamp: '2026-07-19T09:00:10.000Z', type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { total_tokens: 1500, output_tokens: 60 } } } }),
+  ]);
+  const child = parseCodexRollout([
+    jl({ timestamp: '2026-07-19T09:00:02.000Z', type: 'session_meta', payload: { cwd: '/x', session_id: 'child', parent_thread_id: 'root', thread_source: 'subagent' } }),
+    jl({ timestamp: '2026-07-19T09:00:20.000Z', type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { total_tokens: 800, output_tokens: 40 } } } }),
+  ]);
+  assert.ok(main && child);
+  assert.equal(child.isSubagent, true);
+  assert.equal(child.parentThreadId, 'root');
+  const u = combineCodexRollouts(main, [child]);
+  assert.equal(u.host, 'codex');
+  assert.equal(u.totalTokens, 2300);
+  assert.equal(u.outputTokens, 100);
+  assert.equal(u.elapsedMs, 20_000); // 09:00:00 -> 09:00:20
+  assert.match(u.note, /서브에이전트 1개 포함/);
+});
+
+test('parseCodexRollout returns null on empty input', () => {
+  assert.equal(parseCodexRollout(['', 'garbage']), null);
+});
+
+test('formatElapsed renders seconds, minutes, hours', () => {
+  assert.equal(formatElapsed(45_000), '45초');
+  assert.equal(formatElapsed(90_000), '1분 30초');
+  assert.equal(formatElapsed(120_000), '2분');
+  assert.equal(formatElapsed(3_600_000), '1시간');
+  assert.equal(formatElapsed(3_900_000), '1시간 5분');
+});
+
+test('formatRunUsage renders a bilingual-safe usage block', () => {
+  const out = formatRunUsage({ host: 'claude', totalTokens: 2_847_193, outputTokens: 128_441, elapsedMs: 1_294_000, toolUses: 216, approximate: false, note: 'claude 세션 로그 (서브에이전트 포함)' });
+  assert.match(out, /실행 사용량/);
+  assert.match(out, /소요 시간: 21분 34초/);
+  assert.match(out, /토큰: 총 2,847,193 \(출력 128,441\)/);
+  assert.match(out, /도구 호출: 216회/);
+});


### PR DESCRIPTION
Both Claude Code and Codex persist per-turn token usage to a local session log (Claude: ~/.claude/projects/<slug>/*.jsonl per-message usage + inline subagent_tokens; Codex: rollout token_count cumulative). New core/usage with pure, unit-tested parsers (Claude dedups per-message usage by id + adds subagent totals; Codex keeps last cumulative + combines main with subagent rollouts by parent id). New `omd usage [--json]` prints elapsed + tokens (verified live: ~7.8M tokens / 412 tool calls on a 1h40m run). ultradesign SKILL + human-design-loop finalize now close the final chat with `omd usage`; missing log is omitted, never fabricated. Built in an isolated worktree to not disturb the concurrent example run.