### PR TITLE
feat: omd ref audit — deterministic warn when references were captured sequentially, not batched

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -93,6 +93,9 @@ only the missing categories rather than rebuilding it), and capture references i
 reference. Capture a motion study (the default energy pass) only where motion matters; for
 typography, layout, colour, and voice references set `noEnergy` (or `omd ref add --no-energy`) to
 skip the second browser launch — it does not affect a non-motion reference's usefulness.
+After capture, run `omd ref audit`: it reads the recorded capture times and fails when several
+references were captured one at a time (a separate browser launch each) instead of batched. A serial
+research pass is the defect to avoid — capture the known set in one `omd ref add-batch` so it parallelises.
 
 Preserve contamination defenses: reject a non-user source only when it is derivative or
 convergent — an SEO/content-farm summary, a near-duplicate, or a page whose repeated

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -884,6 +884,14 @@ async function cmdRefCandidates(opts: Opts): Promise<never> {
   process.stdout.write(formatReferenceCandidates(artifacts.raw, artifacts.assembly));
   process.exit(0);
 }
+
+async function cmdRefAudit(opts: Opts): Promise<never> {
+  const { auditCaptureParallelism } = await import('../core/ref/capture-audit.ts');
+  const a = auditCaptureParallelism(process.cwd());
+  if (opts.json) process.stdout.write(`${JSON.stringify(a)}\n`);
+  else console.log(`capture audit: ${a.ok ? 'OK' : 'SEQUENTIAL'} (${a.refs} refs) — ${a.reason}`);
+  process.exit(a.ok ? 0 : 1);
+}
 async function cmdRefSelect(opts: Opts): Promise<never> {
   if (opts.out !== undefined) throw new Error('omd ref select does not accept --out');
   const candidateId = opts._[0]; if (candidateId === undefined || opts._[1] !== undefined) throw new Error('usage: omd ref select <candidate-id> [--json]');
@@ -1683,6 +1691,7 @@ function usage(): never {
     + '  ref import-image <input.json> [--json]      save a provenance-bound image fragment\n'
     + '  ref candidates [manifest]                   print chat-ready Korean-first candidate Markdown\n'
     + '  ref select <candidate-id> [--json]          bind a closed candidate selection to its evidence\n'
+    + '  ref audit [--json]                          warn when references were captured sequentially (use ref add-batch)\n'
     + '\n'
     + '  design                                       discover evidence and create/refresh .omd/design.md\n'
     + '  design --check                              validate design.md section coverage\n'
@@ -1787,6 +1796,7 @@ async function main(): Promise<never> {
     if (sub === 'import-image') return cmdRefImportImage(opts);
     if (sub === 'candidates') return cmdRefCandidates(opts);
     if (sub === 'select') return cmdRefSelect(opts);
+    if (sub === 'audit') return cmdRefAudit(opts);
     return usage();
   }
 

--- a/core/ref/capture-audit.ts
+++ b/core/ref/capture-audit.ts
@@ -1,0 +1,63 @@
+import { loadRefs } from './store.ts';
+
+/**
+ * Deterministic capture-parallelism audit.
+ *
+ * Every saved reference carries a `capturedAt` timestamp. `omd ref add-batch` captures a whole set
+ * concurrently over one browser, so their timestamps cluster within seconds; a sequential run of
+ * `omd ref add` launches a separate browser per reference, so the timestamps spread out by tens of
+ * seconds or minutes. The scout is told to batch known references in parallel — this measures whether
+ * it actually did, from the recorded times, so the guidance can bite instead of being ignored.
+ *
+ * A warn, not a hard defect of the design: it reports a slow, serial research pass, not a broken build.
+ */
+export interface CaptureAudit {
+  readonly ok: boolean;
+  readonly refs: number;
+  readonly medianGapSeconds: number;
+  readonly reason: string;
+}
+
+/** Only judge captures from the current run (batching a week-old cached inventory is moot). */
+const RECENT_MS = 6 * 60 * 60 * 1000;
+/** A median gap this large between consecutive captures means a separate browser launch each. */
+const SEQUENTIAL_GAP_MS = 15_000;
+/** Batching is only material once several references were captured. */
+const MIN_REFS = 4;
+
+/** Pure core: judge a list of `capturedAt` strings. */
+export function auditCaptureTimes(capturedAt: readonly string[], now: number = Date.now()): CaptureAudit {
+  const times = capturedAt
+    .map((s) => Date.parse(s))
+    .filter((t) => Number.isFinite(t) && t <= now && now - t <= RECENT_MS)
+    .sort((a, b) => a - b);
+
+  if (times.length < MIN_REFS) {
+    return { ok: true, refs: times.length, medianGapSeconds: 0, reason: `fewer than ${MIN_REFS} recent captures — batching is not material yet` };
+  }
+
+  const gaps = times.slice(1).map((t, i) => t - times[i]!).sort((a, b) => a - b);
+  const median = gaps[Math.floor(gaps.length / 2)]!;
+  const medianSeconds = Math.round(median / 1000);
+
+  if (median >= SEQUENTIAL_GAP_MS) {
+    return {
+      ok: false,
+      refs: times.length,
+      medianGapSeconds: medianSeconds,
+      reason: `${times.length} references were captured sequentially — a median ${medianSeconds}s between captures, i.e. a separate browser launch each. Capture the known set in one pass with \`omd ref add-batch <manifest.json>\` (one browser for the whole batch) so the research runs in parallel. A lone late straggler is fine; an all-sequential pass is not.`,
+    };
+  }
+
+  return {
+    ok: true,
+    refs: times.length,
+    medianGapSeconds: medianSeconds,
+    reason: `${times.length} references captured in a tight window (median ${medianSeconds}s between captures) — batched or parallel`,
+  };
+}
+
+/** Read the saved reference records for `cwd` and audit their capture times. */
+export function auditCaptureParallelism(cwd: string, now: number = Date.now()): CaptureAudit {
+  return auditCaptureTimes(loadRefs(cwd).map((r) => r.capturedAt), now);
+}

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -75,6 +75,8 @@ product's own domain, its real competitors, and its audience's language; a famou
 when the brief's real problem points to it. Run independent searches and captures in parallel — batch
 captures with `omd ref add-batch <manifest.json>`, never a sequential `omd ref add` per reference when
 several are already known.
+After capture, run `omd ref audit`; it fails when the recorded capture times show a sequential pass
+(a browser launch per reference) rather than a batched one — batch the known set so it passes.
 
 Whole-page captures establish rhythm or product feel; tight selectors establish component
 anatomy; type and motion studies establish measured behavior; image references support only

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -101,6 +101,9 @@ instructions: |
   reference. Capture a motion study (the default energy pass) only where motion matters; for
   typography, layout, colour, and voice references set `noEnergy` (or `omd ref add --no-energy`) to
   skip the second browser launch — it does not affect a non-motion reference's usefulness.
+  After capture, run `omd ref audit`: it reads the recorded capture times and fails when several
+  references were captured one at a time (a separate browser launch each) instead of batched. A serial
+  research pass is the defect to avoid — capture the known set in one `omd ref add-batch` so it parallelises.
 
   Preserve contamination defenses: reject a non-user source only when it is derivative or
   convergent — an SEO/content-farm summary, a near-duplicate, or a page whose repeated

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -75,6 +75,8 @@ product's own domain, its real competitors, and its audience's language; a famou
 when the brief's real problem points to it. Run independent searches and captures in parallel — batch
 captures with `omd ref add-batch <manifest.json>`, never a sequential `omd ref add` per reference when
 several are already known.
+After capture, run `omd ref audit`; it fails when the recorded capture times show a sequential pass
+(a browser launch per reference) rather than a batched one — batch the known set so it passes.
 
 Whole-page captures establish rhythm or product feel; tight selectors establish component
 anatomy; type and motion studies establish measured behavior; image references support only

--- a/test/capture-audit.test.ts
+++ b/test/capture-audit.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { auditCaptureTimes } from '../core/ref/capture-audit.ts';
+
+const NOW = Date.parse('2026-07-21T12:00:00.000Z');
+const iso = (msAgo: number): string => new Date(NOW - msAgo).toISOString();
+
+test('auditCaptureTimes flags a sequential capture pass (large median gap)', () => {
+  // four captures ~60s apart — a separate browser launch each
+  const a = auditCaptureTimes([iso(300_000), iso(240_000), iso(180_000), iso(120_000)], NOW);
+  assert.equal(a.ok, false);
+  assert.equal(a.refs, 4);
+  assert.ok(a.medianGapSeconds >= 15, `expected a large median gap, got ${a.medianGapSeconds}s`);
+  assert.match(a.reason, /captured sequentially/i);
+});
+
+test('auditCaptureTimes passes a batched capture (tight cluster)', () => {
+  const a = auditCaptureTimes([iso(10_000), iso(8_000), iso(6_000), iso(4_000)], NOW);
+  assert.equal(a.ok, true);
+  assert.equal(a.refs, 4);
+});
+
+test('auditCaptureTimes passes when fewer than four recent captures', () => {
+  const a = auditCaptureTimes([iso(300_000), iso(240_000), iso(180_000)], NOW);
+  assert.equal(a.ok, true);
+  assert.equal(a.refs, 3);
+});
+
+test('auditCaptureTimes ignores captures older than the recent window', () => {
+  const sevenHours = 7 * 60 * 60 * 1000;
+  const a = auditCaptureTimes(
+    [iso(sevenHours + 300_000), iso(sevenHours + 240_000), iso(sevenHours + 180_000), iso(sevenHours + 120_000)],
+    NOW,
+  );
+  assert.equal(a.ok, true);
+  assert.equal(a.refs, 0);
+});
+
+test('auditCaptureTimes tolerates a lone late straggler among a batched set', () => {
+  // three tight captures + one much later — median gap stays small, so it passes
+  const a = auditCaptureTimes([iso(600_000), iso(12_000), iso(10_000), iso(8_000)], NOW);
+  assert.equal(a.ok, true);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -548,3 +548,10 @@ test('a landing page for a tool is classified marketing, not product', () => {
   assert.match(framer, /OMD's own landing is `marketing`/i);
   assert.match(framer, /A tool's operating UI — the dashboard, console, or editor the user works in after adopting it — is `product`/i);
 });
+
+test('the scout audits capture parallelism with omd ref audit', () => {
+  const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(scout, /After capture, run `omd ref audit`/i);
+  const skill = read('src/skills/omd-scout/SKILL.md').replace(/\s+/g, ' ');
+  assert.match(skill, /After capture, run `omd ref audit`/i);
+});


### PR DESCRIPTION
Makes the scout's 'batch captures in parallel' guidance bite. Every saved reference has a capturedAt timestamp; a batched pass clusters, a sequential pass spreads. New omd ref audit flags 4+ recent captures with a median gap >=15s (a separate browser launch each), tolerating a lone straggler and ignoring cache older than 6h. Wired into the scout agent+skill; pos/neg tests + lock.