### PR TITLE
feat: research gathering runs in parallel (framer + loop principle)

### DIFF
--- a/agents/framer.md
+++ b/agents/framer.md
@@ -54,6 +54,9 @@ link, plus any brand fact the source already ships (an existing wordmark, palett
 as a cited fact, not a style you choose. The scout derives the visual anchor from it. Never let the
 product category's default look ("a dev tool, so terminal green/mono") stand in for the subject's
 own identity.
+Run your own research in parallel, not one at a time: issue the independent web searches,
+repository/README reads, and evidence lookups (subject facts, competitor observations, user records)
+concurrently, then reconcile them. A serial gathering pass is wasted wall-clock, not thoroughness.
 
 Taste is admissible only when the coordinator explicitly provides `omd taste profile`
 output. That default profile contains explicit user records only. Never run `--all` and

--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -19,6 +19,8 @@ A request to fix or improve the UX of an existing surface is a reference-worthy 
 strong products solve that same UX problem — the specific flow, state, or component — before proposing
 changes, rather than applying generic UX rules from memory alone.
 
+Every research or data-gathering step — the framer's subject research and cited-evidence gathering, the scout's reference, gallery, and domain research — issues its independent searches, captures, and lookups in parallel, not one at a time. A serial gathering pass is a defect to avoid: gather concurrently, then reconcile.
+
 ## Stack routing
 
 Default to plain HTML/CSS/JS: a landing, marketing, or content page is a static page and needs no

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -59,6 +59,9 @@ instructions: |
   as a cited fact, not a style you choose. The scout derives the visual anchor from it. Never let the
   product category's default look ("a dev tool, so terminal green/mono") stand in for the subject's
   own identity.
+  Run your own research in parallel, not one at a time: issue the independent web searches,
+  repository/README reads, and evidence lookups (subject facts, competitor observations, user records)
+  concurrently, then reconcile them. A serial gathering pass is wasted wall-clock, not thoroughness.
 
   Taste is admissible only when the coordinator explicitly provides `omd taste profile`
   output. That default profile contains explicit user records only. Never run `--all` and

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -555,3 +555,10 @@ test('the scout audits capture parallelism with omd ref audit', () => {
   const skill = read('src/skills/omd-scout/SKILL.md').replace(/\s+/g, ' ');
   assert.match(skill, /After capture, run `omd ref audit`/i);
 });
+
+test('the framer and the loop require research gathering to run in parallel', () => {
+  const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(framer, /Run your own research in parallel, not one at a time/i);
+  const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
+  assert.match(loop, /issues its independent searches, captures, and lookups in parallel, not one at a time/i);
+});


### PR DESCRIPTION
Extends scout's parallel-research pattern to the framer (the other WebSearch/gathering agent) and adds a cross-cutting loop principle: every research/gathering step issues its independent searches, captures, and lookups in parallel, not one at a time. Writer is a transform (no gathering), so unchanged. Test locked.