### PR TITLE
fix: expand 3-digit hex custom properties before token-name inversion

### DIFF
--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -16,6 +16,15 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
     return `#${h(r)}${h(g)}${h(b)}`.toUpperCase();
   };
 
+  // A minifier (e.g. Vite/esbuild in a production build) shortens a 6-digit hex custom
+  // property to its 3-digit form when the channels repeat (#ffffff -> #fff). The computed
+  // background-color of a consumer always resolves to the full 6-digit form via toHex, so
+  // comparing the two without expanding the shorthand first produces a false token mismatch.
+  const expandHex = (v: string): string => {
+    const m = /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/.exec(v);
+    return m ? `#${m[1]}${m[1]}${m[2]}${m[2]}${m[3]}${m[3]}` : v;
+  };
+
   // A design token is a CSS custom property on :root. Inverting value -> name is what
   // lets us tell `background: var(--surface)` apart from a hand-typed #FEFEFE.
   const tokenByValue: Record<string, string> = {};
@@ -23,7 +32,7 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
   for (const prop of Array.from(rootStyle)) {
     if (!prop.startsWith('--')) continue;
     const raw = rootStyle.getPropertyValue(prop).trim();
-    const value = raw.startsWith('rgb') ? toHex(raw) : raw.toUpperCase();
+    const value = raw.startsWith('rgb') ? toHex(raw) : expandHex(raw).toUpperCase();
     if (value && !(value in tokenByValue)) tokenByValue[prop.slice(2)] = value;
   }
   const nameOf = (value: string): string | null =>

--- a/test/fixtures/token-hex.html
+++ b/test/fixtures/token-hex.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>token hex normalization fixture</title>
+    <style>
+      :root {
+        --surface: #fff;
+        --brand: #1f9d55;
+      }
+      body { margin: 0; background: #ffffff; }
+      .box { width: 200px; height: 120px; padding: 16px; font-family: sans-serif; }
+      #tokened { background: var(--surface); }
+      #branded { background: var(--brand); }
+      #literal { background: #fefefe; }
+    </style>
+  </head>
+  <body>
+    <div id="tokened" class="box">tokened surface</div>
+    <div id="branded" class="box">branded accent</div>
+    <div id="literal" class="box">hand-typed literal</div>
+  </body>
+</html>

--- a/test/token-hex.test.ts
+++ b/test/token-hex.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { extractIr, parseViewport } from '../core/render/index.ts';
+
+// Regression guard for the token->name inversion in core/ir/dom.ts. A production minifier
+// (Vite/esbuild) collapses a repeating 6-digit custom property (--surface: #ffffff) to its
+// 3-digit form (#fff). A consumer's computed background still resolves to 6-digit via toHex,
+// so the inversion must expand the shorthand before comparing or it drops the token name.
+const FIXTURE = fileURLToPath(new URL('./fixtures/token-hex.html', import.meta.url));
+const viewport = parseViewport('390x844');
+
+test('a minified 3-digit design token still resolves to its 6-digit value and name', async () => {
+  const ir = await extractIr(FIXTURE, { viewport });
+
+  // Positive: the shorthand --surface: #fff is expanded to the canonical 6-digit form, so it
+  // matches the consumer's computed #FFFFFF and keeps its token identity.
+  assert.equal(ir.tokens?.surface, '#FFFFFF');
+  assert.ok(
+    ir.nodes.some((node) => node.fill?.token === 'surface'),
+    'a consumer of the minified token must carry the token name, not a false mismatch',
+  );
+
+  // Control: an already 6-digit token with distinct channels is unaffected by the expansion.
+  assert.equal(ir.tokens?.brand, '#1F9D55');
+  assert.ok(ir.nodes.some((node) => node.fill?.token === 'brand'));
+});
+
+test('expanding token shorthand does not fabricate a token name for a hand-typed literal', async () => {
+  const ir = await extractIr(FIXTURE, { viewport });
+  const literal = ir.nodes.filter((node) => node.fill?.value === '#FEFEFE');
+  assert.ok(literal.length > 0, 'the hand-typed #fefefe surface must be captured');
+  assert.ok(
+    literal.every((node) => node.fill?.token === null),
+    'a non-token literal must stay token: null even after shorthand expansion',
+  );
+});


### PR DESCRIPTION
## Problem
Vite/esbuild minifies a repeating 6-digit CSS custom property (`--paper: #ffffff`) down to its 3-digit shorthand (`#fff`) in a production build. The IR token->name inversion in `core/ir/dom.ts` compared that raw custom-property value against a consumer's **computed** `background-color`, which always resolves to the full 6-digit form via `toHex`. So a minified design token read as a false mismatch and silently lost its token name — a real bug in the design checker, not a page defect.

## Fix
Expand a 3-digit hex shorthand to its canonical 6-digit form before the value->name comparison. Ten lines; no behavior change for any already-6-digit or `rgb()` value.

## Tests (positive + negative, per repo convention)
New `test/token-hex.test.ts` renders a real fixture through the browser IR path:
- **Positive**: a minified `--surface: #fff` resolves to `#FFFFFF` and a consumer keeps `token: 'surface'` (fails without the fix).
- **Control**: an already-6-digit `--brand: #1f9d55` is unaffected.
- **Negative**: a hand-typed `#fefefe` literal stays `token: null` — no fabricated attribution.

## Validation
`npm run typecheck` clean · `token-hex` 2/2 · `ir` + `blueprint` 49/49 · `npm run build` clean · `git diff --check` clean.

Branched from `main`; no release.