### PR TITLE
fix: forbid production writes (incl. scaffolding) before framing and research

### DIFF
--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -33,6 +33,7 @@ stack. Before the hand's first write it reads the brief, package.json when prese
 representative existing surface/component when present, then records the stack choice and evidence
 with `omd decision`. Framework scaffold dependencies (when a framework is chosen) are allowed; existing
 projects receive no unnecessary dependencies.
+Deciding the stack is not permission to build it: no production write — including creating `package.json`, `tsconfig`, `vite.config`, or any framework skeleton — happens before framing and the scout's research are complete. An explicit stack request records the `omd stack`/`omd decision` choice only; scaffolding and every other production write remain owned by the hand phase, after the frame, copy, composition, and sketch selection. Building or scaffolding first because the stack is pre-named is a routing defect, not a lawful shortcut.
 Immediately after scaffold/dependency resolution, resolve every newly introduced import/export
 against the exact installed versions, parse generated configuration with its owning tool, and run
 focused typecheck, build, and test-discovery. Repeat this smoke verification after every

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -59,6 +59,14 @@ is OMD's own leftover output — not a user stack, and it never pins the stack. 
 before its first production write, records the choice and evidence with `omd decision`, and builds
 accordingly. Framework scaffold dependencies (when a framework is chosen) are allowed; existing
 projects receive no unnecessary dependencies.
+**Deciding the stack is not permission to build it.** No production write happens before the frame
+is set and the scout's research is gathered. Creating `package.json`, `tsconfig`, `vite.config`, or
+any framework skeleton is a production write owned by the hand phase, never a setup step you run
+first. An explicit stack request — even a precise one like `React + Vite + TypeScript` — only records
+the `omd stack`/`omd decision` choice; it never licenses scaffolding or building ahead of framing and
+research. The framer and the scout always run first: interrogate the brief and gather evidence before
+a single file is written. "The stack is already decided, so let me scaffold the project now" is a
+routing defect, not a lawful shortcut.
 
 Run `omd config show`. `checkpoint: none` is the default and means no approval waits.
 Only `concept`, `structure`, or `both` opt into a human pause at that named point.

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -59,6 +59,14 @@ is OMD's own leftover output — not a user stack, and it never pins the stack. 
 before its first production write, records the choice and evidence with `omd decision`, and builds
 accordingly. Framework scaffold dependencies (when a framework is chosen) are allowed; existing
 projects receive no unnecessary dependencies.
+**Deciding the stack is not permission to build it.** No production write happens before the frame
+is set and the scout's research is gathered. Creating `package.json`, `tsconfig`, `vite.config`, or
+any framework skeleton is a production write owned by the hand phase, never a setup step you run
+first. An explicit stack request — even a precise one like `React + Vite + TypeScript` — only records
+the `omd stack`/`omd decision` choice; it never licenses scaffolding or building ahead of framing and
+research. The framer and the scout always run first: interrogate the brief and gather evidence before
+a single file is written. "The stack is already decided, so let me scaffold the project now" is a
+routing defect, not a lawful shortcut.
 
 Run `omd config show`. `checkpoint: none` is the default and means no approval waits.
 Only `concept`, `structure`, or `both` opt into a human pause at that named point.

--- a/test/phase1-visual-prompts.test.ts
+++ b/test/phase1-visual-prompts.test.ts
@@ -60,6 +60,19 @@ test('a restrained-colour marketing surface carries its register through scale, 
   assert.match(composer, /One systematic detail layer may reinforce the anchor[\s\S]*never a decorative catalogue and never a substitute for the one signature moment/i);
 });
 
+test('deciding the stack is not permission to build before framing and research', () => {
+  const skill = read('src/skills/omd-ultradesign/SKILL.md');
+  const protocol = read('core/protocol/human-design-loop.md');
+  for (const source of [skill, protocol]) {
+    // No production write — scaffolding included — before the frame and the scout's research.
+    assert.match(source, /Deciding the stack is not permission to build it/i);
+    assert.match(source, /no production write[\s\S]*before[\s\S]*fram/i);
+    // An explicit stack request records the decision only; it never licenses building first.
+    assert.match(source, /explicit stack request[\s\S]*omd decision/i);
+    assert.match(source, /routing defect, not a lawful shortcut/i);
+  }
+});
+
 test('art direction is evidence-bound autonomous none|one with carrier and decision-fit floors', () => {
   const protocol = read('core/protocol/human-design-loop.md');
   const hand = read('src/agents/hand.agent.yaml');


### PR DESCRIPTION
OMD exists to stop an agent from jumping straight from the request to a finished UI, but ultradesign runs were **scaffolding the project (writing `package.json`/`tsconfig`/`vite.config`) as their first action** when the brief named a stack (e.g. `React + Vite + TypeScript`) \u2014 skipping framing and the scout entirely. The ordering existed in prose (the hand owns production writes, after frame \u2192 research \u2192 compose \u2192 sketch) but nothing forbade treating scaffolding as a 'step 0 project setup'.\n\n## Fix (guidance-only)\nAn explicit hard gate in `src/skills/omd-ultradesign/SKILL.md` and `core/protocol/human-design-loop.md`: **deciding the stack is not permission to build it.** No production write \u2014 `package.json`, `tsconfig`, `vite.config`, or any framework skeleton \u2014 happens before framing and the scout's research are complete. An explicit stack request only records the `omd stack`/`omd decision` choice; it never licenses scaffolding or building first. Building/scaffolding first because the stack is pre-named is a routing defect, not a lawful shortcut.\n\n## Test\nNew positive prompt-contract test asserts the gate in both the skill and the protocol.\n\n## Validation\nFull `npm test` 1540 pass / 0 fail / 1 platform-skip \u00b7 typecheck + build clean \u00b7 diff --check clean. No release.