### PR TITLE
feat: compose references section by section from parts, never trace one reference whole

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -64,6 +64,10 @@ A gallery image's local capture lives under `.omd/refs/`; the hand builds agains
 code fidelity and copying it is allowed with attribution. For a Pinterest-like or gallery image, capture the user-selected region through
 browser-rs, retain source-page provenance and rights notes, and import only the resulting local
 PNG with `omd ref import-image <input.json>`; never scrape, hotlink, or ship remote source bytes.
+Capture and use references at part granularity: study the whole reference, then take only the
+section or component each of your page's sections needs, and compose the page from parts across
+several references — each section assigned its own best-fit reference part. Tracing one reference's
+whole page layout and section order wholesale is a derivative failure, not fidelity.
 Capture strictly per decision: for each decision the design must make, capture until you have enough
 independent evidence to settle it, then move on. Stop when another capture would not change any
 remaining decision. Never choose, target, estimate, or announce a number or range of references

--- a/core/protocol/composition-contract.md
+++ b/core/protocol/composition-contract.md
@@ -6,8 +6,11 @@ copy a reference page or prescribe one visual answer.
 
 The composer receives a sanitized frame/concept, clean copy deck, sanitized approved type
 contract, and the scout's distilled transferable principles/invariants with source trust.
-It may plan a build that reproduces a reference's layout, section order, and treatment — the hand
-builds against the reference image with image-to-code fidelity. It still writes the product's own copy
+It composes section by section: each section is assigned the single best-fit reference part for that
+section's job, and different sections may draw from different references, so the page is a deliberate
+composition of parts — not one reference reproduced whole. The hand builds each section against its
+assigned reference part with image-to-code fidelity; tracing one reference's entire page layout and
+section order wholesale is a derivative failure, not fidelity. It still writes the product's own copy
 and uses its own real assets rather than lifting the source's literal text or photographs. Read `theory/layout.md` and
 `theory/ux.md` exactly before writing.
 

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -90,10 +90,13 @@ references from the build. Composer starts after the coordinator has chosen its 
 the capable route it receives the canonical v2 selection, current motion-resolution projection,
 decision-bound composer receipt, selected assembly, and coordinator-chosen draft; on the unavailable
 route it receives those same bound artifacts plus the CSS/SVG fallback. Copying is allowed and
-encouraged: the hand opens the selected reference's local part-image(s) under `.omd/refs/` and builds
-against them with image-to-code fidelity — reproducing a reference's layout, composition, and
-treatment is the point, not a violation. `omd ref distance` measures how close the build is to each
-chosen reference; high closeness is the intended outcome, not a warning. Every used reference is
+encouraged, but at part granularity: the hand opens each section's assigned reference part-image(s)
+under `.omd/refs/` and builds that section against them with image-to-code fidelity — reproducing an
+assigned part's layout, composition, and treatment is the point. Different sections may draw parts from
+different references; the page is composed from parts, and tracing one reference's whole page layout and
+section order wholesale is a derivative failure, not fidelity — study the whole reference, take only the
+part each section needs. `omd ref distance` measures how close each section is to its assigned part;
+high per-part closeness is the intended outcome, not a warning. Every used reference is
 recorded with attribution in `.omd/attribution.md`, and the product's own copy is written rather than
 lifting the source's words. The eye and selector still score renders against the composition contract
 without seeing authorship — that blindness is about unbiased scoring, not about hiding the reference

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -72,6 +72,10 @@ instructions: |
   code fidelity and copying it is allowed with attribution. For a Pinterest-like or gallery image, capture the user-selected region through
   browser-rs, retain source-page provenance and rights notes, and import only the resulting local
   PNG with `omd ref import-image <input.json>`; never scrape, hotlink, or ship remote source bytes.
+  Capture and use references at part granularity: study the whole reference, then take only the
+  section or component each of your page's sections needs, and compose the page from parts across
+  several references — each section assigned its own best-fit reference part. Tracing one reference's
+  whole page layout and section order wholesale is a derivative failure, not fidelity.
   Capture strictly per decision: for each decision the design must make, capture until you have enough
   independent evidence to settle it, then move on. Stop when another capture would not change any
   remaining decision. Never choose, target, estimate, or announce a number or range of references

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -139,6 +139,21 @@ test('reference synthesis ABI has one owner and roles route sanitized multi-axis
   assert.match(loop, /list→detail workspace[\s\S]*non-default, non-first object[\s\S]*object-local state/i);
   assert.match(loop, /declared temporal compatibility window[\s\S]*within that window[\s\S]*expired-window reply/i);
 });
+
+test('references are composed section by section from parts across references, never traced whole', () => {
+  const assembly = read('core/protocol/reference-assembly.md').replace(/\s+/g, ' ');
+  const composition = read('core/protocol/composition-contract.md').replace(/\s+/g, ' ');
+  const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
+  for (const source of [assembly, composition, scout]) {
+    // The page is composed from parts, each section assigned its own best-fit reference part.
+    assert.match(source, /composed from parts|composition of parts|compose the page from parts/i);
+    // Tracing one whole reference wholesale is a derivative failure, not fidelity.
+    assert.match(source, /tracing one reference's (entire|whole) page layout and section order wholesale is a derivative failure, not fidelity/i);
+  }
+  // Different sections may draw from different references.
+  assert.match(assembly, /Different sections may draw parts from different references/i);
+  assert.match(composition, /different sections may draw from different references/i);
+});
 test('roles keep composer downstream of the chosen draft without image-generation duties', () => {
   const scout = read('src/agents/scout.agent.yaml');
   const composer = read('src/agents/composer.agent.yaml');


### PR DESCRIPTION
OMD's reference model is already a LEGO/parts assembly (component-granular fragment capture, reference-synthesis `Feature -> Destination selector` mapping), but the wording biased the build toward reproducing **one whole reference**: reference-assembly and composition-contract said 'reproducing a reference's layout, section order, and treatment is the point', and the scout gathers whole 'main-screen references'. Result: whole-reference wholesale tracing (an app reference copied end to end).\n\n## Fix (guidance-only)\nReframe to **section granularity**: the page is composed section by section, each section assigned the single **best-fit reference part** for its job, and **different sections may draw from different references**. Reproducing an assigned part faithfully (image-to-code) stays the point; **tracing one reference's entire page layout and section order wholesale is now a derivative failure, not fidelity** — study the whole reference, take only the part each section needs. `omd ref distance` is measured per-section against its assigned part.\n\nEdited `core/protocol/reference-assembly.md`, `core/protocol/composition-contract.md`, `src/agents/scout.agent.yaml`; new positive prompt-contract test. Preserves the existing image-to-code fidelity, `.omd/refs`, ref-distance-advisory, and reference-synthesis-ABI contracts.\n\n## Validation\nbuild + typecheck clean; prompt-contract 37/37; diff --check clean. No release.