### PR TITLE
feat(scroll-motion 2b/1b): observe scroll-scene evidence in a real browser

### DIFF
--- a/core/render/scroll-scene-capture.ts
+++ b/core/render/scroll-scene-capture.ts
@@ -1,0 +1,144 @@
+// Increment 1b of the staged showpiece scroll-motion evidence protocol.
+//
+// The contract (`scroll-scene-evidence.ts`, increment 1a) declares WHAT a verifiable scroll scene
+// is; this module OBSERVES it in a real browser. It mirrors `captureMotionEvidenceV2`'s proven
+// primitives (computeEnergy over viewport screenshots, a fresh reduced-motion page) but measures a
+// scroll scene instead of a load scene.
+//
+// The single verifiable claim: a scroll scene is admissible only when it is scroll-position-scrubbed.
+// We prove that by holding a FIXED scroll position and taking two captures across time — if the scene
+// is scrubbed to position (not animating in time) the two frames are identical, so its settle energy
+// collapses to the render noise floor. A time-triggered scroll animation keeps changing at the fixed
+// position, so its settle energy stays above the floor and `validateScrollSceneEvidence` rejects it.
+//
+// This capture is NOT wired into the motion decision, render entrypoints, or final-evidence yet
+// (increment 1c). It is invoked only by its own test.
+
+import { pathToFileURL } from 'node:url';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { computeEnergy } from '../motion/energy.ts';
+import { waitForDocumentFonts } from './index.ts';
+import {
+  MAX_SCROLL_SCENES,
+  SCROLL_SCENE_EVIDENCE_SCHEMA,
+  validateScrollSceneEvidence,
+  type ScrollSceneEvidence,
+} from './scroll-scene-evidence.ts';
+
+const DEFAULT_SETTLE_INTERVAL_MS = 240;
+const SETTLE_STABILITY_MULTIPLE = 2;
+
+export type ScrollSceneRequest = {
+  readonly sceneId: string;
+  /** Declared trigger position as a fraction of scrollable height, in (0, 1]. */
+  readonly scrollFraction: number;
+  /** Recorded for provenance; the fixed-position capture measures the whole viewport at that scroll. */
+  readonly roiSelector: string;
+};
+
+function toUrl(target: string): string {
+  if (/^https?:\/\//.test(target)) return target;
+  const path = resolve(target);
+  if (!existsSync(path)) throw new Error(`no such page: ${target}`);
+  return pathToFileURL(path).href;
+}
+
+/** Resolve the browser to a fixed scroll offset and let two animation frames settle. */
+async function holdScroll(page: import('playwright').Page, fraction: number): Promise<void> {
+  await page.evaluate((f) => {
+    const max = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+    window.scrollTo({ top: Math.round(max * f), left: 0, behavior: 'instant' as ScrollBehavior });
+  }, fraction);
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))),
+  );
+}
+
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Observes a real browser scrolling through the declared scenes and returns a validated
+ * `ScrollSceneEvidence`. Throws `ScrollSceneEvidenceError` when a scene is not
+ * scroll-position-scrubbed (still animating in time at its fixed position) or otherwise fails the
+ * contract; throws `Error` on a malformed request or an absent target.
+ */
+export async function captureScrollSceneEvidence(
+  target: string,
+  opts: {
+    readonly viewport: { readonly width: number; readonly height: number };
+    readonly artDirectionHash: string;
+    readonly scenes: readonly ScrollSceneRequest[];
+    readonly settleIntervalMs?: number;
+  },
+): Promise<ScrollSceneEvidence> {
+  if (opts.scenes.length === 0) throw new Error('a scroll-scene capture needs at least one scene');
+  if (opts.scenes.length > MAX_SCROLL_SCENES) throw new Error(`a scroll journey is bounded to ${MAX_SCROLL_SCENES} scenes`);
+  const interval = Math.max(1, Math.floor(opts.settleIntervalMs ?? DEFAULT_SETTLE_INTERVAL_MS));
+  const viewport = { width: opts.viewport.width, height: opts.viewport.height };
+  const url = toUrl(target);
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({ viewport });
+    await page.goto(url, { waitUntil: 'networkidle' });
+    await waitForDocumentFonts(page);
+
+    // Baseline = the top of the page. Its two captures also measure the render noise floor.
+    await holdScroll(page, 0);
+    const baselineA = await page.screenshot({ fullPage: false });
+    await wait(interval);
+    const baselineB = await page.screenshot({ fullPage: false });
+    const noiseFloor = Math.max(computeEnergy([baselineA, baselineB]).peakEnergy, Number.EPSILON);
+
+    // Each scene: hold a fixed scroll position and prove it is stable across time (scrubbed, not timed).
+    const observed = [] as Array<{ req: ScrollSceneRequest; settledEnergy: number; stateChangeEnergy: number; frame: Buffer }>;
+    for (const req of opts.scenes) {
+      await holdScroll(page, req.scrollFraction);
+      const t0 = await page.screenshot({ fullPage: false });
+      await wait(interval);
+      const t1 = await page.screenshot({ fullPage: false });
+      const settledEnergy = computeEnergy([t0, t1]).peakEnergy;
+      const stateChangeEnergy = computeEnergy([baselineB, t1]).peakEnergy;
+      observed.push({ req, settledEnergy, stateChangeEnergy, frame: t1 });
+    }
+
+    // Fresh reduced-motion page: at each scene position, compare to the moving scene to classify behavior.
+    const reducedPage = await browser.newPage({ viewport });
+    const reducedEnergies: number[] = [];
+    try {
+      await reducedPage.emulateMedia({ reducedMotion: 'reduce' });
+      await reducedPage.goto(url, { waitUntil: 'networkidle' });
+      await waitForDocumentFonts(reducedPage);
+      for (const scene of observed) {
+        await holdScroll(reducedPage, scene.req.scrollFraction);
+        const reducedFrame = await reducedPage.screenshot({ fullPage: false });
+        reducedEnergies.push(computeEnergy([scene.frame, reducedFrame]).peakEnergy);
+      }
+    } finally {
+      await reducedPage.close();
+    }
+
+    const record: ScrollSceneEvidence = {
+      schema: SCROLL_SCENE_EVIDENCE_SCHEMA,
+      artDirectionHash: opts.artDirectionHash,
+      register: 'showpiece',
+      perfBudgetDeclared: true,
+      reducedMotionComplete: true,
+      scenes: observed.map((scene, index) => ({
+        sceneId: scene.req.sceneId,
+        scrollFraction: scene.req.scrollFraction,
+        roiSelector: scene.req.roiSelector,
+        settle: { settledEnergy: scene.settledEnergy, noiseFloor },
+        stateChangeEnergy: scene.stateChangeEnergy,
+        reducedMotion: {
+          behavior: reducedEnergies[index]! <= noiseFloor * SETTLE_STABILITY_MULTIPLE ? 'removed' : 'static-equivalent',
+        },
+      })),
+    };
+    return validateScrollSceneEvidence(record);
+  } finally {
+    await browser.close();
+  }
+}

--- a/test/scroll-scene-capture.test.ts
+++ b/test/scroll-scene-capture.test.ts
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { captureScrollSceneEvidence } from '../core/render/scroll-scene-capture.ts';
+import { validateScrollSceneEvidence } from '../core/render/scroll-scene-evidence.ts';
+
+const artDirectionHash = createHash('sha256').update('scroll-direction').digest('hex');
+const viewport = { width: 480, height: 800 };
+
+// A tall page whose sections reveal via a scroll-DRIVEN (position, not time) animation. At any fixed
+// scroll offset the scrubbed value is constant, so two captures across time are byte-identical.
+function scrubbedFixture(dir: string): string {
+  const page = join(dir, 'scroll-scrubbed.html');
+  writeFileSync(page, `<!doctype html><html><head><meta charset="utf-8"><style>
+    *{margin:0;box-sizing:border-box}
+    body{font-family:system-ui,sans-serif}
+    section{height:100vh;display:flex;align-items:center;justify-content:center;font-size:8vh;font-weight:800;color:#fff}
+    #hero{background:#0a0a0a}
+    #scene-a{background:#e11d48}
+    #scene-b{background:#2563eb}
+    #scene-c{background:#059669}
+    .scrub{opacity:.15;transform:translateY(8vh);animation:reveal linear both;animation-timeline:view();animation-range:entry 10% cover 45%}
+    @keyframes reveal{to{opacity:1;transform:none}}
+    @media (prefers-reduced-motion:reduce){.scrub{opacity:1;transform:none;animation:none}}
+  </style></head><body>
+    <section id="hero">HERO</section>
+    <section class="scrub" id="scene-a">SCENE A</section>
+    <section class="scrub" id="scene-b">SCENE B</section>
+    <section class="scrub" id="scene-c">SCENE C</section>
+  </body></html>`);
+  return page;
+}
+
+test('captures a scroll-position-scrubbed sequence: each scene settles at its fixed position', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omd-scroll-cap-'));
+  const target = scrubbedFixture(dir);
+  const evidence = await captureScrollSceneEvidence(target, {
+    viewport,
+    artDirectionHash,
+    scenes: [
+      { sceneId: 'scene-a', scrollFraction: 0.34, roiSelector: '#scene-a' },
+      { sceneId: 'scene-b', scrollFraction: 0.67, roiSelector: '#scene-b' },
+      { sceneId: 'scene-c', scrollFraction: 1, roiSelector: '#scene-c' },
+    ],
+  });
+  assert.equal(evidence.register, 'showpiece');
+  assert.equal(evidence.artDirectionHash, artDirectionHash);
+  assert.equal(evidence.scenes.length, 3);
+  let prior = 0;
+  for (const scene of evidence.scenes) {
+    // Scrubbed to a fixed position ⇒ settled within the render noise floor.
+    assert.ok(scene.settle.settledEnergy <= scene.settle.noiseFloor * 2, `${scene.sceneId} did not settle`);
+    // A real observed state change versus the top baseline.
+    assert.ok(scene.stateChangeEnergy > scene.settle.noiseFloor, `${scene.sceneId} showed no state change`);
+    assert.ok(scene.scrollFraction > prior, 'scroll fractions strictly increase');
+    prior = scene.scrollFraction;
+  }
+  // The captured record is a valid contract instance and round-trips through the validator.
+  assert.deepEqual(validateScrollSceneEvidence(evidence), evidence);
+});
+
+test('rejects a scene that keeps animating in TIME at a fixed scroll position', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omd-scroll-cap-neg-'));
+  const target = join(dir, 'scroll-timed.html');
+  writeFileSync(target, `<!doctype html><html><head><meta charset="utf-8"><style>
+    *{margin:0}
+    section{height:100vh;display:flex;align-items:center;justify-content:center;font-size:8vh;font-weight:800;color:#fff}
+    #hero{background:#0a0a0a}
+    #timed{background:#7c3aed;animation:flash 600ms linear infinite alternate}
+    @keyframes flash{from{filter:brightness(.35)}to{filter:brightness(1.7)}}
+    @media (prefers-reduced-motion:reduce){#timed{animation:none;filter:none}}
+  </style></head><body>
+    <section id="hero">HERO</section>
+    <section id="timed">TIMED</section>
+  </body></html>`);
+  await assert.rejects(
+    () => captureScrollSceneEvidence(target, {
+      viewport,
+      artDirectionHash,
+      scenes: [{ sceneId: 'timed', scrollFraction: 1, roiSelector: '#timed' }],
+    }),
+    /scrubbed|settled|time-animating/i,
+  );
+});
+
+test('a scroll capture request is bounded and non-empty before any browser launches', async () => {
+  await assert.rejects(
+    () => captureScrollSceneEvidence('/does/not/matter.html', { viewport, artDirectionHash, scenes: [] }),
+    /at least one scene/,
+  );
+  await assert.rejects(
+    () => captureScrollSceneEvidence('/does/not/matter.html', {
+      viewport,
+      artDirectionHash,
+      scenes: Array.from({ length: 7 }, (_unused, index) => ({ sceneId: `s${index}`, scrollFraction: (index + 1) / 8, roiSelector: `#s${index}` })),
+    }),
+    /bounded to 6 scenes/,
+  );
+});


### PR DESCRIPTION
Increment **1b** of the staged showpiece scroll-motion evidence protocol. 1a (#110) declared WHAT a verifiable scroll scene is; this **observes** it in a real browser.

## What it does
`captureScrollSceneEvidence()` mirrors `captureMotionEvidenceV2`'s proven primitives (`computeEnergy` over viewport screenshots + a fresh reduced-motion page) but measures a **scroll** scene: it holds each declared scroll position **FIXED** and captures two frames across time.

- A **scroll-position-scrubbed** scene (scrubbed to position, not animating in time) yields byte-identical frames ⇒ settle energy collapses to the render noise floor ⇒ admissible.
- A **time-triggered** scroll animation keeps changing at the fixed position ⇒ `validateScrollSceneEvidence` rejects it. This is exactly the criterion that separates a verifiable scroll scene from the unverifiable kind the single-load-scene contract excludes.

## Still additive
Not wired into the motion decision, render entrypoints, or final-evidence (increment 1c). Invoked only by its own test — the `none|one` load-scene contract is untouched.

## Validation
3 real-browser pos/neg tests: a scrubbed 3-scene sequence settles + round-trips through the validator; a time-animating scene is rejected; the request is bounded/non-empty before any browser launches. typecheck + build clean; diff --check clean. No release.