### PR TITLE
feat(scroll-motion 2b/1c): enforce showpiece scroll-scene evidence in final-evidence-v2

### DIFF
--- a/core/evidence/final-v2.ts
+++ b/core/evidence/final-v2.ts
@@ -30,6 +30,7 @@ import {
 import { validateArtDirectionPointer, validateArtDirectionRecord } from '../art-direction/schema.ts';
 import { validateStaticDirectionEvidenceV1 } from '../art-direction/static-evidence.ts';
 import { validateMotionEvidenceV2 } from '../render/index.ts';
+import { SCROLL_SCENE_EVIDENCE_SCHEMA, validateScrollSceneEvidence } from '../render/scroll-scene-evidence.ts';
 import { hasHostBoundLocalProjectWriteAuthority, requireHostPayloadAuthorization } from '../runtime/activation.ts';
 import { requireFinalEvidenceManifestAuthorization, requireStaticEvidenceResultAuthorization, type ProjectRunInvocation } from '../runtime/invocation.ts';
 export const FINAL_EVIDENCE_V2_SCHEMA = 'final-evidence-v2';
@@ -48,6 +49,7 @@ export type FinalEvidenceV2FaultPoint =
 export type FinalEvidenceV2Bindings = FinalEvidenceV2Graph;
 export type MotionEvidenceV2Binding = ArtifactReceipt & Readonly<{ schema: 'motion-evidence-v2' }>;
 export type StaticDirectionEvidenceV1Binding = ArtifactReceipt & Readonly<{ schema: 'static-direction-evidence-v1' }>;
+export type ScrollSceneEvidenceBinding = ArtifactReceipt & Readonly<{ schema: typeof SCROLL_SCENE_EVIDENCE_SCHEMA }>;
 export interface FinalEvidenceV2Manifest {
   schema: typeof FINAL_EVIDENCE_V2_SCHEMA;
   motionDecision: MotionDecision;
@@ -55,6 +57,8 @@ export interface FinalEvidenceV2Manifest {
   graphRootHash?: string;
   motionEvidence?: MotionEvidenceV2Binding;
   staticEvidence?: StaticDirectionEvidenceV1Binding;
+  // Optional showpiece escalation: a scroll-position-scrubbed journey that accompanies the one load scene.
+  scrollSceneEvidence?: ScrollSceneEvidenceBinding;
 }
 
 export interface FinalEvidenceV2Pointer {
@@ -134,9 +138,10 @@ function fileName(value: unknown): string {
 /** Validates receipt descriptors. Files are validated only by the publisher/checker against the project root. */
 export function validateFinalEvidenceV2Manifest(value: unknown): FinalEvidenceV2Manifest {
   const manifest = object(value, 'manifest');
-  exact(manifest, ['schema', 'motionDecision', 'graph', 'graphRootHash', 'motionEvidence', 'staticEvidence'].filter((key) => key in manifest), 'manifest');
+  exact(manifest, ['schema', 'motionDecision', 'graph', 'graphRootHash', 'motionEvidence', 'staticEvidence', 'scrollSceneEvidence'].filter((key) => key in manifest), 'manifest');
   if (manifest.schema !== FINAL_EVIDENCE_V2_SCHEMA) fail('unsupported manifest schema');
   if (manifest.motionDecision !== 'none' && manifest.motionDecision !== 'one') fail('motionDecision must be none or one');
+  if (manifest.scrollSceneEvidence !== undefined && manifest.motionDecision !== 'one') fail('a scroll-scene sequence is a showpiece escalation that accompanies the one load scene');
   const graph = validateFinalEvidenceV2Graph(manifest.graph);
   if (manifest.graphRootHash !== undefined) digest(manifest.graphRootHash, 'graphRootHash');
   const receipt = (value: unknown, label: string, schema: string): ArtifactReceipt & { schema: typeof schema } => {
@@ -148,7 +153,7 @@ export function validateFinalEvidenceV2Manifest(value: unknown): FinalEvidenceV2
   };
   if (manifest.motionDecision === 'one') {
     if (manifest.staticEvidence !== undefined || manifest.motionEvidence === undefined) fail('one requires exactly one motion evidence and no static evidence');
-    return { schema: FINAL_EVIDENCE_V2_SCHEMA, motionDecision: 'one', graph, ...(manifest.graphRootHash === undefined ? {} : { graphRootHash: manifest.graphRootHash as string }), motionEvidence: receipt(manifest.motionEvidence, 'motionEvidence', 'motion-evidence-v2') as MotionEvidenceV2Binding };
+    return { schema: FINAL_EVIDENCE_V2_SCHEMA, motionDecision: 'one', graph, ...(manifest.graphRootHash === undefined ? {} : { graphRootHash: manifest.graphRootHash as string }), motionEvidence: receipt(manifest.motionEvidence, 'motionEvidence', 'motion-evidence-v2') as MotionEvidenceV2Binding, ...(manifest.scrollSceneEvidence === undefined ? {} : { scrollSceneEvidence: receipt(manifest.scrollSceneEvidence, 'scrollSceneEvidence', SCROLL_SCENE_EVIDENCE_SCHEMA) as ScrollSceneEvidenceBinding }) };
   }
   if (manifest.motionEvidence !== undefined || manifest.staticEvidence === undefined) fail('none requires exactly one static evidence and no motion evidence');
   return { schema: FINAL_EVIDENCE_V2_SCHEMA, motionDecision: 'none', graph, ...(manifest.graphRootHash === undefined ? {} : { graphRootHash: manifest.graphRootHash as string }), staticEvidence: receipt(manifest.staticEvidence, 'staticEvidence', 'static-direction-evidence-v1') as StaticDirectionEvidenceV1Binding };
@@ -318,6 +323,23 @@ function validateBackedManifest(root: string, fs: FinalEvidenceV2FileSystem, val
       observationRoot: root,
       invocation,
     });
+  }
+  // A scroll journey is a showpiece-only escalation that must carry its own scroll-position-scrubbed
+  // evidence, bound to the same immutable art direction as the load scene.
+  if (manifest.scrollSceneEvidence !== undefined) {
+    if (artDirection.decision.selectedRegister !== 'showpiece') fail('a scroll-scene sequence is a showpiece-only escalation');
+    const scrollPath = resolve(root, manifest.scrollSceneEvidence.path);
+    const scrollOutside = relative(root, scrollPath);
+    if (scrollOutside === '' || scrollOutside.startsWith('..') || resolve(root, scrollOutside) !== scrollPath) fail('scroll-scene evidence escapes the project root');
+    requireRealAncestors(root, scrollPath, fs, 'scroll-scene evidence');
+    regular(fs, scrollPath);
+    const scrollBytes = fs.readFile(scrollPath);
+    if (hash(scrollBytes) !== manifest.scrollSceneEvidence.sha256) fail('scroll-scene evidence hash changed');
+    const scrollObject = object(readJson(fs, scrollPath, 'scroll-scene evidence'), 'scroll-scene evidence');
+    requireRealNestedProjectPaths(root, scrollObject, fs, 'scroll-scene evidence');
+    if (scrollObject.schema !== manifest.scrollSceneEvidence.schema) fail('scroll-scene evidence schema changed');
+    if (scrollObject.artDirectionHash !== graph.bindings.artDirectionSha256) fail('scroll-scene evidence does not bind the selected semantic art direction');
+    validateScrollSceneEvidence(scrollObject);
   }
   return manifest;
 }

--- a/test/final-evidence-v2.test.ts
+++ b/test/final-evidence-v2.test.ts
@@ -201,7 +201,7 @@ const copyDeckV2 = (
 | --- | --- |
 ${beatIds.map((beatId) => `| ${beatId} | F-001 |`).join('\n')}
 `;
-const manifest = (directory: string, decision: 'none' | 'one' = 'none'): FinalEvidenceV2Manifest => {
+const manifest = (directory: string, decision: 'none' | 'one' = 'none', motionRegister: 'confident' | 'showpiece' = 'confident'): FinalEvidenceV2Manifest => {
   const invocation = finalEvidenceInvocation(directory);
   const current = invocation.current;
   const activation = receipt(directory, 'activation', 'activation-context-v2', { schemaVersion: 'activation-context-v2', buildSha256: current.buildSha256, loadedSkillSha256: current.loadedSkillSha256, briefSha256: current.briefSha256, hostCapability: { host: 'local' } });
@@ -239,7 +239,7 @@ const manifest = (directory: string, decision: 'none' | 'one' = 'none'): FinalEv
     { register: 'confident', subjectIdentityFit: 'Confident framing fits the subject.', staticReferenceSlotIds: ['static'], motionReferenceSlotIds: decision === 'one' ? ['motion-reference'] : [], conceptRole: 'Launch transition', macroCompositionHypothesis: 'Layered promotional composition.', motionHypothesis: 'one', uxAccessibilityPerformanceRisks: ['Reduced motion remains available.'], lawfulImplementationPath: 'CSS and SVG implementation.', rejectionCondition: 'Another evidenced direction better fits the launch.' },
     { register: 'showpiece', subjectIdentityFit: 'Showpiece framing fits the subject.', staticReferenceSlotIds: ['static'], motionReferenceSlotIds: decision === 'one' ? ['motion-reference'] : [], conceptRole: 'Signature reveal', macroCompositionHypothesis: 'Layered promotional composition.', motionHypothesis: 'one', uxAccessibilityPerformanceRisks: ['Reduced motion remains available.'], lawfulImplementationPath: 'CSS and SVG implementation.', rejectionCondition: 'Another evidenced direction better fits the launch.' },
   ] as const;
-  const selected = decision === 'none' ? alternatives[0] : alternatives[1];
+  const selected = decision === 'none' ? alternatives[0] : (motionRegister === 'showpiece' ? alternatives[2] : alternatives[1]);
   const authorInvocationSha256 = sha('author-invocation');
   const authorPayloadSha256 = sha('author-payload');
   const authorResultSha256 = sha('author-result');
@@ -913,4 +913,85 @@ test('project writes reject an existing symlink leaf target', () => {
     }));
     assert.equal(readFileSync(outsideTarget, 'utf8'), 'original');
   } finally { clean(directory); clean(outside); }
+});
+const scrollMotionFixture = `<!doctype html><html data-omd-production-boundary="whole-page"><style>
+      html, body { width: 100%; height: 100%; margin: 0; }
+      html { background: #111; animation: production-scene 1000ms linear 100ms forwards; }
+      body { min-height: 100%; }
+      @keyframes production-scene { to { background: #eee; } }
+      @media (prefers-reduced-motion: reduce) { html { background: #eee; animation: none !important; } }
+    </style><body>motion</body></html>`;
+async function captureLoadScene(directory: string, input: FinalEvidenceV2Manifest): Promise<{ path: string; schema: 'motion-evidence-v2'; sha256: string }> {
+  const artDirectionHash = artDirectionSha256(JSON.parse(readFileSync(join(directory, input.graph.artDirection.path), 'utf8')));
+  const buildHash = (JSON.parse(readFileSync(join(directory, input.graph.activation.path), 'utf8')) as { buildSha256: string }).buildSha256;
+  const target = join(directory, 'motion.html');
+  writeFileSync(target, scrollMotionFixture);
+  const observationDirectory = join(directory, '.omd', 'motion-observations', 'run-1');
+  const adapter = createTestProjectWriteAdapter(directory);
+  adapter.mkdir('.omd/motion-observations/run-1');
+  const motion = projectRelativePaths(directory, await captureMotionEvidenceV2(target, {
+    viewport: { width: 390, height: 300 }, outDir: observationDirectory, runId: 'run-1', buildHash,
+    artDirectionHash, referenceSlotId: 'motion-reference', selector: 'html', trigger: 'load', intervalMs: 160, adapter,
+  }));
+  const sourceSealValue = createSourceSeal(directory, '2026-01-01T00:00:00.000Z');
+  writeFileSync(join(directory, '.omd', 'source-seal.json'), `${canonical(sourceSealValue)}\n`);
+  (input.graph.sourceSeal as { sha256: string }).sha256 = sha(readFileSync(join(directory, '.omd', 'source-seal.json')));
+  return receipt(directory, 'motion-one', 'motion-evidence-v2', motion);
+}
+const scrollScenesEvidence = (artDirectionHash: string): Record<string, unknown> => ({
+  schema: 'scroll-scene-evidence-v1', artDirectionHash, register: 'showpiece', perfBudgetDeclared: true, reducedMotionComplete: true,
+  scenes: [
+    { sceneId: 'reveal-a', scrollFraction: 0.4, roiSelector: '#a', settle: { settledEnergy: 0, noiseFloor: 0.002 }, stateChangeEnergy: 0.2, reducedMotion: { behavior: 'static-equivalent' } },
+    { sceneId: 'reveal-b', scrollFraction: 0.85, roiSelector: '#b', settle: { settledEnergy: 0.001, noiseFloor: 0.002 }, stateChangeEnergy: 0.15, reducedMotion: { behavior: 'removed' } },
+  ],
+});
+test('a showpiece one manifest carries a scroll-position-scrubbed journey; wrong binding and tampered bytes are rejected', async () => {
+  const directory = root(); try {
+    const input = manifest(directory, 'one', 'showpiece');
+    const artDirectionHash = artDirectionSha256(JSON.parse(readFileSync(join(directory, input.graph.artDirection.path), 'utf8')));
+    const motionEvidence = await captureLoadScene(directory, input);
+    const scrollValue = scrollScenesEvidence(artDirectionHash);
+    const publish = (scroll: { path: string; schema: string; sha256: string }) => {
+      const cwd = process.cwd();
+      try { process.chdir(directory); return publishFinalEvidenceV2(directory, { ...input, motionEvidence, scrollSceneEvidence: scroll }); }
+      finally { process.chdir(cwd); }
+    };
+    // Scroll evidence must bind the same immutable art direction as the load scene.
+    const wrongBinding = receipt(directory, 'scroll-wrong', 'scroll-scene-evidence-v1', { ...scrollValue, artDirectionHash: sha('unrelated-art-direction') });
+    assert.throws(() => publish(wrongBinding), /bind the selected semantic art direction/);
+    // The scroll evidence bytes are content-addressed: a tampered file cannot publish.
+    const scrollReceipt = receipt(directory, 'scroll', 'scroll-scene-evidence-v1', scrollValue);
+    writeFileSync(join(directory, scrollReceipt.path), `${canonical({ ...scrollValue, scenes: (scrollValue.scenes as unknown[]).slice(0, 1) })}\n`);
+    assert.throws(() => publish(scrollReceipt), /scroll-scene evidence hash changed/);
+    writeFileSync(join(directory, scrollReceipt.path), `${canonical(scrollValue)}\n`);
+    // A well-formed, bound scroll journey publishes and is returned by the checker.
+    assert.doesNotThrow(() => publish(scrollReceipt));
+    const cwd = process.cwd();
+    try {
+      process.chdir(directory);
+      assert.equal(checkFinalEvidenceV2(directory).scrollSceneEvidence?.schema, 'scroll-scene-evidence-v1');
+    } finally { process.chdir(cwd); }
+  } finally { clean(directory); }
+});
+test('a scroll journey is a showpiece one escalation: none decisions and confident registers are rejected', async () => {
+  {
+    const directory = root(); try {
+      const base = manifest(directory, 'none');
+      const scroll = receipt(directory, 'scroll-none', 'scroll-scene-evidence-v1', scrollScenesEvidence(sha('any-art-direction')));
+      assert.throws(() => validateFinalEvidenceV2Manifest({ ...base, scrollSceneEvidence: scroll }), /showpiece escalation that accompanies the one load scene/);
+    } finally { clean(directory); }
+  }
+  {
+    const directory = root(); try {
+      const input = manifest(directory, 'one');
+      const artDirectionHash = artDirectionSha256(JSON.parse(readFileSync(join(directory, input.graph.artDirection.path), 'utf8')));
+      const motionEvidence = await captureLoadScene(directory, input);
+      const scroll = receipt(directory, 'scroll', 'scroll-scene-evidence-v1', scrollScenesEvidence(artDirectionHash));
+      const cwd = process.cwd();
+      try {
+        process.chdir(directory);
+        assert.throws(() => publishFinalEvidenceV2(directory, { ...input, motionEvidence, scrollSceneEvidence: scroll }), /showpiece-only escalation/);
+      } finally { process.chdir(cwd); }
+    } finally { clean(directory); }
+  }
 });


### PR DESCRIPTION
Increment **1c (enforcement half)** of the staged showpiece scroll-motion evidence protocol. 1a (#110) defined a verifiable scroll scene, 1b (#111) observed it in a real browser; this makes the signed immutable **final-evidence-v2** manifest **gate** it — a claimed scroll journey cannot ship without validated, art-direction-bound evidence.

## What changes
`final-evidence-v2` gains an **optional** `scrollSceneEvidence` receipt branch:
- **Additive / backward-compatible.** The exact-key filter admits it only when present; every existing `none`/`one` manifest validates unchanged and the `none|one` motion-decision enum is **untouched**.
- **Strict showpiece escalation.** Rejected unless `motionDecision === 'one'` **and** the immutable art-direction register is `showpiece`.
- **Content-addressed + bound.** Path-safe, hash-bound receipt; must carry `schema: scroll-scene-evidence-v1`, bind the same semantic art-direction hash as the graph, and pass `validateScrollSceneEvidence`. The whole manifest (incl. the new field) is signed exactly as before.

## Why enforcement first
The gate exists **before** the composer is told it may produce scroll journeys — permission without enforcement would be unverifiable guidance, which is the trap the single-load-scene contract avoided.

## Validation
Full `final-evidence-v2` suite **26/26** (24 pre-existing backward-compat + 2 new): a showpiece `one` manifest publishes a bound scroll journey and the checker returns it; wrong art-direction binding, tampered bytes, `none` decisions, and `confident` registers are all rejected. typecheck + build clean; diff --check clean. No release.