### PR TITLE
fix: transfer boundary permits per-section layout fidelity, forbids only whole-page identity

### DIFF
--- a/core/protocol/composition-contract.md
+++ b/core/protocol/composition-contract.md
@@ -119,10 +119,17 @@ copy, type, and acceptance criteria. Axes vary spatial relationships, not conten
 
 ## Transfer boundary
 
-Permitted transfer: attributed relationships, measured invariants, and principles abstracted
-from trusted evidence. Forbidden transfer: source identity in shipped UI, copy, assets,
-literal tokens, full section order, pixels, recognizable silhouette, or unique interaction
-and motion. An exact transplant is allowed only when the user explicitly requested that
+The boundary is drawn around the source's identity, not its structure. Permitted transfer:
+attributed relationships, measured invariants, principles abstracted from trusted evidence, and —
+at section granularity — an assigned reference part's layout, composition, and treatment, rebuilt
+faithfully with the destination's own copy, assets, and tokens. This per-section fidelity is the
+point (see `reference-assembly.md`): reproducing the assigned section's layout is expected, and
+`omd ref distance`'s high per-part closeness is the intended outcome, not a warning. Forbidden
+transfer is the source's identity and its whole-page gestalt: its brand/wordmark, copy, photographs
+and assets, literal token values, unique interaction and motion, and — across the entire page — its
+full section order and overall silhouette. Faithfully rebuilding one assigned section is lawful;
+tracing a whole reference page section-by-section into your whole page is the derivative failure.
+An exact whole-page or identity transplant is allowed only when the user explicitly requested that
 specific transplant; record the request and attribution.
 
 ## Reference synthesis

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -154,6 +154,17 @@ test('references are composed section by section from parts across references, n
   assert.match(assembly, /Different sections may draw parts from different references/i);
   assert.match(composition, /different sections may draw from different references/i);
 });
+test('the transfer boundary permits per-section layout fidelity and forbids only whole-page identity', () => {
+  const composition = read('core/protocol/composition-contract.md').replace(/\s+/g, ' ');
+  // Faithfully rebuilding an assigned section's layout is permitted and expected.
+  assert.match(composition, /an assigned reference part's layout, composition, and treatment, rebuilt\s+faithfully/i);
+  assert.match(composition, /reproducing the assigned section's layout is expected/i);
+  assert.match(composition, /Faithfully rebuilding one assigned section is lawful/i);
+  // What is forbidden is the source's identity and its whole-page gestalt, not a single section.
+  assert.match(composition, /Forbidden\s+transfer is the source's identity and its whole-page gestalt/i);
+  assert.match(composition, /across the entire page[\s\S]*full section order and overall silhouette/i);
+  assert.match(composition, /tracing a whole reference page section-by-section into your whole page is the derivative failure/i);
+});
 test('roles keep composer downstream of the chosen draft without image-generation duties', () => {
   const scout = read('src/agents/scout.agent.yaml');
   const composer = read('src/agents/composer.agent.yaml');


### PR DESCRIPTION
## The gap
#109 made section-by-section composition the default and **per-section image-to-code fidelity** the point (`reference-assembly.md`, composition-contract intro). But composition-contract's `## Transfer boundary` still globally forbade *"pixels, recognizable silhouette"* and allowed an *"exact transplant"* only on explicit request — which **contradicts** the per-section-fidelity rule and would make OMD hesitate to faithfully rebuild a single assigned section.

This is exactly the behavior the user called out: pull a specific section (e.g. Resend's landing hero) and rebuild **that section** with the same layout — while composing other sections from other references.

## The fix
Draw the boundary around the source's **identity, not its structure**:
- **Permitted** now explicitly includes, at section granularity, an assigned reference part's **layout, composition, and treatment rebuilt faithfully** with the destination's own copy/assets/tokens. Per-section fidelity is the point; high per-part `ref distance` closeness is the **intended outcome**.
- **Forbidden** is the source's identity and its **whole-page gestalt**: brand/wordmark, copy, photographs/assets, literal tokens, unique interaction/motion, and — across the **entire page** — full section order and overall silhouette.
- Faithfully rebuilding **one** assigned section is lawful; tracing a **whole** reference page section-by-section into your whole page is the derivative failure.

Matches how a human works: study whole references → pull each section's best-fit part from possibly different references → rebuild that section faithfully.

## Validation
prompt-contract + composition-contract suites **71/71** (incl. 1 new boundary test); build clean; diff --check clean. No release.