### PR TITLE
fix: sketches must diverge by macro-layout family, not reskin one single-column stack

### DIFF
--- a/agents/sketch.md
+++ b/agents/sketch.md
@@ -25,7 +25,10 @@ representative data density, and structural boxes. When the contract's surface g
 realistic row/item density in the first viewport, the shell/navigation region, and the
 structural footprint of the spine's reachable states (empty, error, loading) as grayscale
 zones — never a hero band the contract rejected. Preserve the approved typography roles
-and both contracts exactly; vary only the assigned structural axis. Preserve the dominant
+and both contracts exactly; vary only the assigned structural axis. Realize that axis as its named
+macro-layout family — a genuinely different top-level spatial organization, never a cosmetic reskin of
+the default single-column stack (the same stacked flow at a different margin, column width, type scale,
+or spacing is not a candidate, it is the divergence failure). Preserve the dominant
 anchor's morphology and value/proof/CTA relationship at both viewports. A visible CTA and
 predictable path to completion proves reach; do not crowd the first viewport with the
 terminal form/control surface or treat its visibility as an advantage. Represent the

--- a/core/protocol/composition-contract.md
+++ b/core/protocol/composition-contract.md
@@ -114,8 +114,15 @@ production evidence still renders 1280x900 and 390x844.
 
 ## Candidate axes
 
-Define at least two genuinely different structural axes that can satisfy the same spine,
-copy, type, and acceptance criteria. Axes vary spatial relationships, not content truth.
+Define at least two structurally divergent candidate axes that can satisfy the same spine, copy,
+type, and acceptance criteria. Genuine divergence is a different macro-layout family — the top-level
+spatial organization changes (single-column stack, asymmetric split, multi-column or modular grid,
+sidebar/rail, centered canvas, full-bleed alternating bands) or the dominant anchor's placement and
+reading path changes — not the same layout at different sizes. Axes vary spatial relationships, not
+content truth. Two candidates that share one macro-layout family and differ only cosmetically — margin,
+column width, type scale, or the vertical spacing of the same single-column stack — are one axis, not
+two, and are a divergence failure, not a candidate set. Name each axis's macro-layout family so the
+difference is legible before any sketch is built.
 
 ## Transfer boundary
 

--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -334,6 +334,7 @@ The sharp eye receives only sanitized multi-axis observed rules, adaptations, an
 Structural divergence is conditional, not ceremonial: default to two independent sketches;
 use three for showpiece work or high structural uncertainty/impact. Skip only when structure
 is already supplied (for example, a Figma frame or explicit visual target), and record why.
+Divergence is measured, not assumed: the candidate set must realize genuinely different macro-layout families — a different top-level spatial organization, or a different placement and orientation of the dominant anchor and reading path — never one stacked single-column flow reskinned with different margins, column width, type scale, or spacing. A candidate set that collapses to a single macro-layout family has not diverged; the blind selector, which sees every candidate render, treats it as a contract-level no-winner (the Candidate axes were not genuinely different) and returns it to a fresh composer to re-derive divergent axes, even when one candidate would otherwise pass.
 Every sketch produces four proofs: fixed desktop 1280x900, fixed mobile 390x844, full-page
 desktop continuity, and full-page mobile continuity. Full-page evidence is supplemental and
 never replaces fixed-viewport acceptance.

--- a/src/agents/sketch.agent.yaml
+++ b/src/agents/sketch.agent.yaml
@@ -32,7 +32,10 @@ instructions: |
   realistic row/item density in the first viewport, the shell/navigation region, and the
   structural footprint of the spine's reachable states (empty, error, loading) as grayscale
   zones — never a hero band the contract rejected. Preserve the approved typography roles
-  and both contracts exactly; vary only the assigned structural axis. Preserve the dominant
+  and both contracts exactly; vary only the assigned structural axis. Realize that axis as its named
+  macro-layout family — a genuinely different top-level spatial organization, never a cosmetic reskin of
+  the default single-column stack (the same stacked flow at a different margin, column width, type scale,
+  or spacing is not a candidate, it is the divergence failure). Preserve the dominant
   anchor's morphology and value/proof/CTA relationship at both viewports. A visible CTA and
   predictable path to completion proves reach; do not crowd the first viewport with the
   terminal form/control surface or treat its visibility as an advantage. Represent the

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -594,3 +594,19 @@ test('the framer and the loop require research gathering to run in parallel', ()
   const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
   assert.match(loop, /issues its independent searches, captures, and lookups in parallel, not one at a time/i);
 });
+test('candidate axes must be genuinely divergent macro-layouts, not one stack reskinned', () => {
+  const composition = read('core/protocol/composition-contract.md').replace(/\s+/g, ' ');
+  const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
+  const sketch = read('src/agents/sketch.agent.yaml').replace(/\s+/g, ' ');
+  // Divergence is a different macro-layout family, named per axis.
+  assert.match(composition, /Genuine divergence is a different macro-layout family/i);
+  assert.match(composition, /Name each axis's macro-layout family/i);
+  // A single-column stack reskinned with cosmetic differences is one axis, a divergence failure.
+  assert.match(composition, /share one macro-layout family and differ only cosmetically[\s\S]*are one axis, not\s+two, and are a divergence failure/i);
+  // The blind selector rejects a non-divergent candidate set as a contract-level no-winner.
+  assert.match(loop, /A candidate set that collapses to a single macro-layout family has not diverged/i);
+  assert.match(loop, /treats it as a contract-level no-winner/i);
+  // Each isolated sketch realizes its axis as a distinct macro-layout, not a reskin of the default stack.
+  assert.match(sketch, /Realize that axis as its named\s+macro-layout family/i);
+  assert.match(sketch, /never a cosmetic reskin of\s+the default single-column stack/i);
+});


### PR DESCRIPTION
## The defect (user-reported)
sketch-a and sketch-b came out **near-identical** — same single-column vertical stack, same section order, same anchor, differing only in margin / column width / type scale. The isolated-structure stage must produce *genuinely different structural axes* ("candidate structures built without seeing each other"), but the divergence requirement had **no teeth**:
- composition-contract's Candidate axes said only *"at least two genuinely different structural axes … spatial relationships, not content truth"* (prose);
- sketch said *"vary only the assigned axis"*;
- `omd composition --check` validates section presence / ABI / freshness — **nothing measures whether the axes actually diverge**.

So two cosmetic variants of one stack pass. That is exactly the screenshot.

## The fix (teeth, no ABI/example break)
- **composition-contract 'Candidate axes'**: genuine divergence is now a different **macro-layout family** (single-column stack, asymmetric split, multi-column/modular grid, sidebar/rail, centered canvas, full-bleed bands) or a different dominant-anchor placement + reading path. Two candidates sharing one family that differ only cosmetically are **one axis, a divergence failure, not a candidate set**; each axis names its family.
- **human-design-loop (divergence/selection)**: divergence is measured, not assumed. A candidate set that collapses to a single macro-layout family has not diverged; the **blind selector — which sees every candidate render — treats it as a contract-level no-winner** and returns it to a fresh composer to re-derive divergent axes, even when one candidate would otherwise pass. The teeth live at the one stage that sees all candidates.
- **sketch.agent.yaml**: each isolated sketch realizes its axis as its named macro-layout family, never a cosmetic reskin of the default stack.

## Validation
prompt-contract + composition-contract + phase1 + phase3 suites **86/86** (incl. 1 new divergence test); build clean; diff --check clean. No release.