### PR TITLE
chore: release v0.19.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "omd",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "interface": {
     "displayName": "Oh My Design"
   },
@@ -16,7 +16,7 @@
         "authentication": "ON_FIRST_USE"
       },
       "category": "design",
-      "version": "0.18.0"
+      "version": "0.19.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
   "owner": {
     "name": "3x-haust"
   },
-  "version": "0.18.0",
+  "version": "0.19.0",
   "plugins": [
     {
       "name": "oh-my-design",
       "description": "The design cognition loop: doubt the brief, measure real references (type and motion included), build once, look at the render, reframe. Plus a deterministic slop linter and a de-AI copy pass.",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "author": {
         "name": "3x-haust"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem. Ships a slop linter that makes 'looks AI-generated' a checkable claim.",
   "author": {
     "name": "3x-haust",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-design",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Design cognition loop for coding agents — frame the problem, study measured references, commit to a structure, look at what actually rendered, and let what you see rewrite the problem.",
   "author": {
     "name": "3x-haust",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@3xhaust/oh-my-design",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@3xhaust/oh-my-design",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.61.1",
@@ -16,7 +16,8 @@
       },
       "bin": {
         "oh-my-design": "bin/omd-install.mjs",
-        "omd": "bin/omd.mjs"
+        "omd": "bin/omd.mjs",
+        "omd-reviewer-evidence-proxy": "bin/omd-reviewer-evidence-proxy.mjs"
       },
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3xhaust/oh-my-design",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Design cognition loop for Codex and Claude Code — frame, diverge, see, reframe",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Version bump **0.18.0 -> 0.19.0** across all five manifests + `package-lock.json` via `scripts/bump.ts`. Merging this to `main` changes `.claude-plugin/plugin.json`'s version, which triggers the **Release** workflow to tag `v0.19.0` and cut the GitHub release with the merged-PR changelog.

Ships the harness-quality work merged since v0.18.0 (#102-#117): token-hex normalization; marketing register/ambition, colour+material carrier, free-license photography floors; frame-before-build gate; Awwwards/FWA scout + showpiece load-scene ambition; section-granular reference composition + per-section-fidelity transfer boundary; the staged showpiece **scroll-scene evidence protocol** (contract → browser capture → final-evidence enforcement → composer permission); macro-layout **sketch divergence**; the **SLOP-COLORLESS** colour-commitment machine check; and genuinely-divergent **visual-direction** enumeration.

Full suite **1566 pass / 0 fail / 1 skip**; build + typecheck clean.