### PR TITLE
feat: quarterly slop-pattern intake routine so the taxonomy tracks aesthetic drift

### DIFF
--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -17,6 +17,11 @@
 # Each is a heuristic and each can be wrong about a deliberate choice. So they warn, they
 # never error, and every message says what to do instead rather than merely what is wrong.
 #
+# The pattern set is not static: AI aesthetics drift on a 6–12 month cycle, so a rule that catches
+# today's tell can become tomorrow's noise, and a new default can appear that no rule sees. New rules
+# are added and stale ones retired only with a documented case, through the quarterly intake routine in
+# `core/rules/slop-intake.md`.
+#
 # Whole-page rules fire once, on the root node, and read ir.stats.
 
 # Matched by hue, not by a list of hex codes: a blocklist of Tailwind's indigo-500 misses

--- a/core/rules/slop-intake.md
+++ b/core/rules/slop-intake.md
@@ -1,0 +1,73 @@
+# Slop pattern intake routine
+
+The slop taxonomy is a snapshot of the machine-default aesthetic at the time each rule was written.
+That aesthetic is not static: it drifts on a roughly 6–12 month cycle as models, tools, and imitation
+move the average. A rule that sharply caught a 2024 tell can, by 2026, catch a deliberate choice
+instead — and a new default (yesterday's departure become this year's cliché) can appear that no rule
+sees. `slop.yaml`'s discipline is "widen only with a case"; this routine is how a case is gathered,
+turned into a rule, and — just as importantly — how a stale rule is retired. Aesthetics move both ways,
+so the taxonomy must too.
+
+This is a maintenance routine, not a shipped feature. It runs on the repository, not on a user's run.
+
+## Cadence
+
+Quarterly. A drift cycle is months, not weeks, so a scan more often than quarterly mostly re-reads the
+same field; less often than yearly lets the taxonomy fall behind the current default.
+
+## Sources to scan
+
+Each source is read for *the current common pattern*, not for a rule to copy verbatim:
+
+- **Slop/AI-aesthetic critique** — Maggie Appleton and design-writing on "AI slop", the "AI-SaaS landing"
+  critiques, and running community catalogues of the generated look.
+- **Model-vendor cookbooks and system cards** — the Anthropic cookbook, OpenAI/others' design-adjacent
+  guidance — because the patterns they encourage become the next common default.
+- **Vibe-coding / no-design communities** — r/vibecoding and similar, where the unaugmented model default
+  ships unedited and the current tells are most visible.
+- **Award commentary** — Awwwards / FWA / GDWEB jury notes and design-Twitter on "this now reads as
+  templated" — the leading edge of what has become average.
+- The repository's own `theory/expressive.md` § "The AI-SaaS landing tells" and the
+  `# the machine-default aesthetic, measured` section of `slop.yaml`, updated as the field moves.
+
+## The evidence bar — a "case"
+
+A candidate rule (new or a widening) ships only with a documented case:
+
+1. **The pattern** — one sentence naming the convergence, and which family it belongs to (visual
+   convergence-to-the-mean, or prose no native owner would write).
+2. **A real positive** — at least one concrete generated example that exhibits it, with a note on why a
+   fluent reader/designer clocks it as machine-made.
+3. **A false-positive analysis** — the deliberate, legitimate uses that look similar and must NOT fire,
+   written as negative test cases. A rule with no defensible negatives is too broad to ship.
+4. **The lever** — whether it is machine-detectable from the IR/source (a `slop.yaml`/`core/slop` rule)
+   or a judgment call (eye/theory guidance). Not every tell is a machine rule.
+
+No case, no rule. A hand-picked threshold with no positive it was written to catch is exactly the
+brittleness `slop.yaml`'s header warns against.
+
+## Retirement
+
+A rule is retired with the same rigor. A pattern that has diffused so far it is now unremarkable, or one
+whose false-positive rate on deliberate work now exceeds its catch rate, is a stale rule. Record the
+case for retirement — the drift that made it noise — and remove it with its tests, rather than leaving a
+rule that punishes a choice that is no longer a tell.
+
+## Flow
+
+Scan (quarterly) → for each candidate, write the case above → draft the rule with positive **and**
+negative prompt-contract/rules tests (repo convention) → open a PR that carries the case in its
+description → review and merge. A candidate without tests, or without the false-positive analysis, is
+sent back, not merged.
+
+## Candidate template
+
+```md
+### Candidate: <SLOP-ID or eye-guidance name>
+- Family: visual convergence | prose (no native owner)
+- Pattern: <one sentence>
+- Positive: <a real generated example + why it reads as machine-made>
+- Must-not-fire (negatives): <deliberate legitimate uses that look similar>
+- Lever: machine rule (IR/source) | eye/theory guidance
+- Source(s): <where the current pattern was observed>
+```

--- a/test/slop-intake.test.ts
+++ b/test/slop-intake.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const intake = join(root, 'core', 'rules', 'slop-intake.md');
+const slopYaml = join(root, 'core', 'rules', 'builtin', 'slop.yaml');
+
+test('the slop intake routine document exists', () => {
+  assert.ok(existsSync(intake), `slop-intake.md not found at ${intake}`);
+});
+
+test('the intake routine names a cadence, sources, an evidence bar, retirement, and a candidate template', () => {
+  const md = readFileSync(intake, 'utf8');
+  for (const heading of ['## Cadence', '## Sources to scan', '## The evidence bar', '## Retirement', '## Flow', '## Candidate template']) {
+    assert.ok(md.includes(heading), `slop-intake.md missing "${heading}"`);
+  }
+  const flat = md.replace(/\s+/g, ' ');
+  // Aesthetics drift both ways: new rules added AND stale ones retired, each only with a documented case.
+  assert.match(flat, /drift[\s\S]*6.12 month cycle/i);
+  assert.match(flat, /No case, no rule/i);
+  assert.match(flat, /false-positive analysis/i);
+  assert.match(flat, /retired with the same rigor|retired only with a documented case/i);
+  // Positive AND negative tests are required by repo convention.
+  assert.match(flat, /positive \*\*and\*\* negative|negative prompt-contract\/rules tests/i);
+});
+
+test('slop.yaml points at the intake routine so the taxonomy stays current', () => {
+  const yaml = readFileSync(slopYaml, 'utf8');
+  assert.match(yaml, /`core\/rules\/slop-intake\.md`/);
+  assert.match(yaml, /drift on a 6.12 month cycle/i);
+});


### PR DESCRIPTION
## Report gap #3
`slop.yaml`'s *"widen only with a case"* is good discipline against brittle rules, but there was **no formal channel** for new slop patterns to enter or stale ones to leave. AI aesthetics drift on a **6–12 month cycle** — yesterday's departure becomes this year's cliché, and a rule that caught a 2024 tell can by 2026 punish a deliberate choice. A static taxonomy falls behind.

## What ships
**`core/rules/slop-intake.md`** — a maintenance routine (on the repo, not a user's run):
- **Quarterly cadence** (drift is months, not weeks).
- **Sources to scan** for the *current* pattern: AI-slop critique, model-vendor cookbooks, vibe-coding communities, award jury commentary, plus the repo's own tells sections.
- **An evidence bar** — a "case" requires the pattern + a real positive + a **false-positive analysis written as negatives** + the lever (machine rule vs eye/theory). No case, no rule.
- **Symmetric retirement** — a pattern diffused into the unremarkable, or whose false-positive rate now exceeds its catch rate, is removed *with its tests*.
- The scan → case → pos+neg tests → PR flow, and a candidate template.

`slop.yaml`'s header now points at it.

## Validation
slop-intake + rules suites **84/84** (doc sections; drift / no-case-no-rule / retirement / false-positive assertions; slop.yaml reference; all builtin rules still load); build clean; diff --check clean. No release.