### PR TITLE
feat: visual-craft human-calibration protocol, mirroring voice.md's prose calibration

### DIFF
--- a/core/theory/craft.md
+++ b/core/theory/craft.md
@@ -251,6 +251,25 @@ unexpected element is what gets remembered.
 
 ---
 
+## Human calibration
+
+Every rule above is grounded in a named practitioner source, but the *verdict* on whether a finished render actually reads as designed is currently made by `omd-eye` — a blind reviewer, but still a language model judging a model's output. `theory/voice.md` closes this loop on the prose side: its "Calibration evidence" section measured a fully human-authored essay against a pipeline version on the same metrics and let the gaps rewrite the rules. Visual craft has no equivalent yet. That asymmetry is the one place "human-like" is still an LLM's opinion rather than a measurement.
+
+Condition → choice → reason: keep visual craft honest by calibrating it against real people on the same cadence, not by trusting the model's self-report.
+
+**The protocol** (a maintenance routine on the repository, like `core/rules/slop-intake.md`, not a step in a user's run):
+
+1. **Sample** — a fixed, versioned set of OMD renders across registers (quiet/confident/showpiece) and surface types, plus the human-made references they were built toward.
+2. **Rate** — real human designers and target users rank or score them on named dimensions (hierarchy clarity, colour commitment, craft finish, "reads as designed vs generated"), blind to which are OMD's, using an A/B or forced-choice format so the signal is a preference, not a number pulled from the air.
+3. **Compare** — set the human verdicts beside `omd-eye`'s own verdicts on the same renders. The **divergences** — where the model eye and real designers disagree — are the evidence, exactly as the measured prose gaps were in `voice.md`.
+4. **Feed back** — each divergence becomes a candidate change to a craft entry, a slop rule (through the `slop-intake.md` evidence bar), or an eye instruction, carried in a PR with the data. A dimension where the eye already matches human preference is left alone.
+
+**Data format**: real human ratings are recorded the way explicit user taste already is — appended to `.omd/taste/preferences.jsonl` (`actor: 'user'`, with the subject, verbatim evidence, and the chosen render), kept strictly separate from the agent's own choices (Coach never reads `.omd/taste/`). A calibration run is a batch of such records tagged with the sample version.
+
+**Honest limitation**: no calibration dataset has been collected yet — this section defines the methodology and the standing loop, not a finished result. Until a dataset exists, `omd-eye`'s verdict is explicitly a proxy for human taste, not ground truth, and any claim that a render "reads as human-made" is the model's estimate. The prose side (`voice.md`) is the worked example of what this produces once the data is in; visual craft is expected to reach the same standard on the same quarterly cadence.
+
+---
+
 ## Sources
 
 - Wathan & Schoger, *Refactoring UI* (2018 / refactoringui.com) — two-shadow system,

--- a/test/craft-calibration.test.ts
+++ b/test/craft-calibration.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const craft = readFileSync(join(root, 'core', 'theory', 'craft.md'), 'utf8');
+const flat = craft.replace(/\s+/g, ' ');
+
+test('craft.md carries a Human calibration section that names the LLM-self-eval asymmetry', () => {
+  assert.ok(craft.includes('## Human calibration'), 'craft.md missing the Human calibration section');
+  // The verdict is currently an LLM judging a model — the gap voice.md already closed on the prose side.
+  assert.match(flat, /`omd-eye`[\s\S]*still a language model judging a model's output/i);
+  assert.match(flat, /`theory\/voice\.md`[\s\S]*Calibration evidence/i);
+  assert.match(flat, /Visual craft has no equivalent yet/i);
+});
+
+test('the calibration protocol samples, rates blind, compares to the eye, and feeds divergences back', () => {
+  assert.match(flat, /1\. \*\*Sample\*\*[\s\S]*versioned set of OMD renders/i);
+  assert.match(flat, /2\. \*\*Rate\*\*[\s\S]*real human designers[\s\S]*blind[\s\S]*A\/B or forced-choice/i);
+  assert.match(flat, /3\. \*\*Compare\*\*[\s\S]*divergences[\s\S]*where the model eye and real designers disagree[\s\S]*are the evidence/i);
+  assert.match(flat, /4\. \*\*Feed back\*\*[\s\S]*slop-intake\.md` evidence bar/i);
+});
+
+test('calibration data reuses .omd/taste/preferences.jsonl and stays honest about having no dataset yet', () => {
+  assert.match(flat, /`\.omd\/taste\/preferences\.jsonl`/);
+  assert.match(flat, /Coach never reads `\.omd\/taste\/`/i);
+  // The section must not overclaim: it is a methodology, and the eye is explicitly a proxy until data exists.
+  assert.match(flat, /no calibration dataset has been collected yet/i);
+  assert.match(flat, /`omd-eye`'s verdict is explicitly a proxy for human taste, not ground truth/i);
+});


### PR DESCRIPTION
## Report gap #4
"Human-like" visual judgment is still trapped in **LLM self-eval**: `omd-eye` is blind but still a language model judging a model's output. `theory/voice.md` already closes this loop on the **prose** side (its *Calibration evidence* section measured a fully human-authored essay against a pipeline version and let the measured gaps rewrite the rules). Visual craft had no equivalent — the one place "reads as human-made" is an opinion, not a measurement.

## What ships
`core/theory/craft.md` gains a **Human calibration** section — a repo maintenance routine, not a user-run step:
1. **Sample** a versioned set of OMD renders + their human references.
2. **Rate** them blind (A/B / forced-choice, named dimensions) with real designers/users.
3. **Compare** to `omd-eye`'s own verdicts on the same renders.
4. **Feed the divergences back** into craft entries, slop rules (via the `slop-intake.md` evidence bar), or eye instructions — in a PR with the data, exactly as voice.md's measured prose gaps were.

Data reuses `.omd/taste/preferences.jsonl` (`actor:'user'`, kept separate from agent choices; Coach never reads it).

## Honest by construction
No calibration dataset exists yet — the section defines the **methodology and standing loop, not a result**, and states plainly that until data exists `omd-eye`'s verdict is a **proxy** for human taste, not ground truth.

## Validation
craft-calibration suite **3/3**; build clean; diff --check clean. No release.