### PR TITLE
feat(flow-probe 1): multi-screen flow plan validator (dead-end + state-loss contract)

### DIFF
--- a/core/probe/flow.ts
+++ b/core/probe/flow.ts
@@ -1,0 +1,138 @@
+// Multi-screen flow probe — plan validation (increment 1, additive and not yet browser-executed).
+//
+// `validateProbePlan` in ./index.ts validates a SINGLE-screen scenario: one `page.goto(url)` and a
+// list of click/fill/press steps on that one page. A real app is a sequence of screens — login →
+// onboarding → dashboard → settings — and the failures that hurt most are the ones that only appear
+// ACROSS screens: a dead end (a screen with no declared way forward), and state loss (a value entered
+// early that is gone by a later screen). Those were only an eye/advisory judgment. This is the
+// verifiable contract for a multi-screen flow: an ordered, linear sequence of screens, each proving it
+// actually loaded (an arrival expectation, so a broken transition is a dead end, not a silent pass),
+// each non-terminal screen declaring how it advances to the next, and declared state that must survive
+// forward across screens.
+//
+// It reuses ./index.ts's step and expectation validators verbatim, so a flow inherits the same security
+// constraints as a single-screen probe (non-destructive, no credential fills, safe key allowlist). It
+// is NOT yet wired into a browser executor or the evals — capture and wiring are later increments — so
+// the existing single-screen probe is untouched.
+
+import { validateProbeExpectation, validateProbeStep } from './index.ts';
+
+export const PROBE_FLOW_SCHEMA = 'probe-flow-v1' as const;
+
+/** A flow is a designed sequence, not an unbounded crawl. */
+export const MAX_FLOW_SCREENS = 8;
+
+export type ProbeScreen = {
+  readonly screenId: string;
+  /** Local production-reachable path, '/'-rooted. */
+  readonly route: string;
+  /** What must be present when this screen loads — proof the transition landed, not a dead end. */
+  readonly arrival: readonly unknown[];
+  /** click/fill/press steps on this screen (same vocabulary and security as a single-screen probe). */
+  readonly steps: readonly unknown[];
+  /** The next screenId this screen advances to; omitted only on the single terminal screen. */
+  readonly advancesTo?: string;
+};
+
+/** A value present on an earlier screen that must still be present on a later screen. */
+export type StateCarry = {
+  readonly fromScreen: string;
+  readonly fromLocator: string;
+  readonly toScreen: string;
+  readonly toLocator: string;
+};
+
+export type ProbeFlow = {
+  readonly schema: typeof PROBE_FLOW_SCHEMA;
+  readonly name: string;
+  readonly destructive: false;
+  readonly screens: readonly ProbeScreen[];
+  readonly carries: readonly StateCarry[];
+};
+
+const fail = (reason: string): never => { throw new Error(`probe flow is invalid: ${reason}`); };
+const nonEmpty = (v: unknown, reason: string): string => (typeof v === 'string' && v.trim() !== '' ? v : fail(reason));
+const object = (v: unknown, reason: string): Record<string, unknown> =>
+  v !== null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : fail(reason);
+const closedKeys = (record: Record<string, unknown>, allowed: readonly string[], reason: string): void => {
+  if (Object.keys(record).some((key) => !allowed.includes(key))) fail(reason);
+};
+
+/** A safe, local, production-reachable route: '/'-rooted, no scheme, no traversal, no backslash. */
+function safeRoute(value: unknown, reason: string): string {
+  const route = nonEmpty(value, reason);
+  if (!route.startsWith('/') || /^[a-z]+:\/\//i.test(route) || route.includes('\0') || route.includes('\\')) {
+    fail(`${reason} — must be a local '/'-rooted path`);
+  }
+  if (route.split('/').some((part) => part === '..' || part === '.')) fail(`${reason} — must not contain path traversal`);
+  return route;
+}
+
+/**
+ * Validates a multi-screen flow plan. Throws on any violation. A flow is valid only as a non-destructive,
+ * linear sequence of 2..MAX_FLOW_SCREENS screens with unique ids; each screen carries a safe local route,
+ * a non-empty arrival expectation, and steps that satisfy the single-screen step/security contract; every
+ * non-terminal screen advances to the next screen in order and has at least one step to advance with
+ * (a screen that declares no way forward is a dead end); exactly one terminal screen (the last) advances
+ * nowhere; and every declared state carry moves a value strictly forward from an earlier to a later screen.
+ */
+export function validateProbeFlow(input: unknown): ProbeFlow {
+  const raw = object(input, 'flow must be an object');
+  closedKeys(raw, ['schema', 'name', 'destructive', 'screens', 'carries'], 'flow has unknown or missing keys');
+  if (raw['schema'] !== PROBE_FLOW_SCHEMA) fail(`schema must be ${PROBE_FLOW_SCHEMA}`);
+  nonEmpty(raw['name'], 'name is required');
+  if (raw['destructive'] !== false) fail('a flow probe is never destructive');
+
+  const screens: unknown[] = Array.isArray(raw['screens']) ? raw['screens'] : fail('screens must be an array');
+  if (screens.length < 2) fail('a flow needs at least two screens — a single screen is the existing single-screen probe');
+  if (screens.length > MAX_FLOW_SCREENS) fail(`a flow is bounded to ${MAX_FLOW_SCREENS} screens`);
+
+  const ids: string[] = [];
+  for (let index = 0; index < screens.length; index += 1) {
+    const screen = object(screens[index], `screens[${index}] must be an object`);
+    closedKeys(screen, ['screenId', 'route', 'arrival', 'steps', 'advancesTo'], `screens[${index}] has unknown or missing keys`);
+    const screenId = nonEmpty(screen['screenId'], `screens[${index}].screenId is required`);
+    if (ids.includes(screenId)) fail(`duplicate screenId: ${screenId}`);
+    ids.push(screenId);
+    safeRoute(screen['route'], `screens[${index}].route is invalid`);
+    const arrival: unknown[] = Array.isArray(screen['arrival']) && screen['arrival'].length > 0
+      ? screen['arrival']
+      : fail(`screens[${index}].arrival must be a non-empty expectation list (it proves the transition landed)`);
+    for (const exp of arrival) validateProbeExpectation(exp);
+    const steps: unknown[] = Array.isArray(screen['steps']) ? screen['steps'] : fail(`screens[${index}].steps must be an array`);
+    for (const step of steps) validateProbeStep(step);
+  }
+
+  // Linear reachability + dead-end structure: each non-terminal screen advances to the next screen in
+  // order and must have a step to advance with; exactly the last screen is terminal.
+  for (let index = 0; index < screens.length; index += 1) {
+    const screen = screens[index] as Record<string, unknown>;
+    const isTerminal = index === screens.length - 1;
+    const advancesTo = screen['advancesTo'];
+    if (isTerminal) {
+      if (advancesTo !== undefined) fail(`the terminal screen (${ids[index]}) advances nowhere; remove advancesTo`);
+    } else {
+      const next = ids[index + 1];
+      if (advancesTo !== next) fail(`screens[${index}] (${ids[index]}) is a dead end — advancesTo must be the next screen '${next}'`);
+      if ((screen['steps'] as unknown[]).length === 0) fail(`screens[${index}] (${ids[index]}) advances to '${next}' but has no step to advance with`);
+    }
+  }
+
+  const carries: unknown[] = Array.isArray(raw['carries']) ? raw['carries'] : fail('carries must be an array');
+  const order = new Map(ids.map((id, index) => [id, index]));
+  for (let index = 0; index < carries.length; index += 1) {
+    const carry = object(carries[index], `carries[${index}] must be an object`);
+    closedKeys(carry, ['fromScreen', 'fromLocator', 'toScreen', 'toLocator'], `carries[${index}] has unknown or missing keys`);
+    const fromScreen = nonEmpty(carry['fromScreen'], `carries[${index}].fromScreen is required`);
+    const toScreen = nonEmpty(carry['toScreen'], `carries[${index}].toScreen is required`);
+    nonEmpty(carry['fromLocator'], `carries[${index}].fromLocator is required`);
+    nonEmpty(carry['toLocator'], `carries[${index}].toLocator is required`);
+    const fromIndex = order.get(fromScreen);
+    const toIndex = order.get(toScreen);
+    if (fromIndex === undefined) fail(`carries[${index}].fromScreen references unknown screen '${fromScreen}'`);
+    if (toIndex === undefined) fail(`carries[${index}].toScreen references unknown screen '${toScreen}'`);
+    if ((toIndex as number) <= (fromIndex as number)) fail(`carries[${index}] must carry state forward: '${toScreen}' must come after '${fromScreen}'`);
+  }
+
+  return input as ProbeFlow;
+}

--- a/core/probe/index.ts
+++ b/core/probe/index.ts
@@ -65,46 +65,52 @@ export function validateProbePlan(input: unknown): ProbePlan {
   if (tabOrder !== undefined && (!Array.isArray(tabOrder) || tabOrder.some((s) => typeof s !== 'string' || !s.trim()))) {
     throw new Error('expectedTabOrder must contain selectors');
   }
-  for (const value of raw['steps']) {
-    const step = value as Record<string, unknown>;
-    if (!step || typeof step !== 'object' || Object.keys(step).some((key) => !['action', 'selector', 'value', 'key', 'expect'].includes(key))) {
-      throw new Error('probe step contains unsupported or authenticated fields');
-    }
-    const action = step['action'];
-    if (typeof action !== 'string' || !['click', 'fill', 'press'].includes(action)) throw new Error(`unsafe probe action: ${String(action)}`);
-    const selector = step['selector'];
-    if (action !== 'press' && (typeof selector !== 'string' || !selector.trim())) throw new Error(`${action} requires selector`);
-    if (selector !== undefined && (typeof selector !== 'string' || !selector.trim())) throw new Error('probe selector must be non-empty');
-    if (action === 'click' && (step['value'] !== undefined || step['key'] !== undefined)) throw new Error('click contains unsupported fields');
-    if (action === 'fill') {
-      if (typeof step['value'] !== 'string' || !step['value'] || CREDENTIAL_SELECTOR.test(String(selector))) {
-        throw new Error('probe refuses credential or empty fills');
-      }
-      if (step['key'] !== undefined) throw new Error('fill contains unsupported fields');
-    }
-    if (action === 'press') {
-      if (typeof step['key'] !== 'string' || !PRESS_KEYS.has(step['key'])) throw new Error('press key is not in the safe navigation/activation allowlist');
-      if (step['value'] !== undefined) throw new Error('press contains unsupported fields');
-    }
-    const expects = step['expect'];
-    if (!Array.isArray(expects) || expects.length === 0) throw new Error('every probe action requires at least one declared expectation');
-    for (const value of expects) {
-      if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('unsupported probe expectation');
-      const exp = value as Record<string, unknown>;
-      const type = exp['type'];
-      if (typeof type !== 'string' || !['visible', 'hidden', 'text', 'url', 'attribute'].includes(type)) {
-        throw new Error('unsupported probe expectation');
-      }
-      const allowed = type === 'url' ? ['type', 'value']
-        : type === 'attribute' ? ['type', 'selector', 'name', 'value']
-          : type === 'text' ? ['type', 'selector', 'value'] : ['type', 'selector'];
-      if (Object.keys(exp).some((key) => !allowed.includes(key))) throw new Error('invalid probe expectation fields');
-      if (type !== 'url' && (typeof exp['selector'] !== 'string' || !exp['selector'].trim())) throw new Error('expectation requires selector');
-      if (['text', 'url', 'attribute'].includes(type) && (typeof exp['value'] !== 'string' || (type !== 'attribute' && !exp['value']))) throw new Error('expectation requires value');
-      if (type === 'attribute' && (typeof exp['name'] !== 'string' || !exp['name'].trim())) throw new Error('attribute expectation requires name');
-    }
-  }
+  for (const value of raw['steps']) validateProbeStep(value);
   return input as ProbePlan;
+}
+
+/** Validate one probe expectation (visible/hidden/text/url/attribute) with its closed field shape. */
+export function validateProbeExpectation(value: unknown): void {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('unsupported probe expectation');
+  const exp = value as Record<string, unknown>;
+  const type = exp['type'];
+  if (typeof type !== 'string' || !['visible', 'hidden', 'text', 'url', 'attribute'].includes(type)) {
+    throw new Error('unsupported probe expectation');
+  }
+  const allowed = type === 'url' ? ['type', 'value']
+    : type === 'attribute' ? ['type', 'selector', 'name', 'value']
+      : type === 'text' ? ['type', 'selector', 'value'] : ['type', 'selector'];
+  if (Object.keys(exp).some((key) => !allowed.includes(key))) throw new Error('invalid probe expectation fields');
+  if (type !== 'url' && (typeof exp['selector'] !== 'string' || !exp['selector'].trim())) throw new Error('expectation requires selector');
+  if (['text', 'url', 'attribute'].includes(type) && (typeof exp['value'] !== 'string' || (type !== 'attribute' && !exp['value']))) throw new Error('expectation requires value');
+  if (type === 'attribute' && (typeof exp['name'] !== 'string' || !exp['name'].trim())) throw new Error('attribute expectation requires name');
+}
+
+/** Validate one probe step (click/fill/press) with its security constraints and declared expectations. */
+export function validateProbeStep(value: unknown): void {
+  const step = value as Record<string, unknown>;
+  if (!step || typeof step !== 'object' || Object.keys(step).some((key) => !['action', 'selector', 'value', 'key', 'expect'].includes(key))) {
+    throw new Error('probe step contains unsupported or authenticated fields');
+  }
+  const action = step['action'];
+  if (typeof action !== 'string' || !['click', 'fill', 'press'].includes(action)) throw new Error(`unsafe probe action: ${String(action)}`);
+  const selector = step['selector'];
+  if (action !== 'press' && (typeof selector !== 'string' || !selector.trim())) throw new Error(`${action} requires selector`);
+  if (selector !== undefined && (typeof selector !== 'string' || !selector.trim())) throw new Error('probe selector must be non-empty');
+  if (action === 'click' && (step['value'] !== undefined || step['key'] !== undefined)) throw new Error('click contains unsupported fields');
+  if (action === 'fill') {
+    if (typeof step['value'] !== 'string' || !step['value'] || CREDENTIAL_SELECTOR.test(String(selector))) {
+      throw new Error('probe refuses credential or empty fills');
+    }
+    if (step['key'] !== undefined) throw new Error('fill contains unsupported fields');
+  }
+  if (action === 'press') {
+    if (typeof step['key'] !== 'string' || !PRESS_KEYS.has(step['key'])) throw new Error('press key is not in the safe navigation/activation allowlist');
+    if (step['value'] !== undefined) throw new Error('press contains unsupported fields');
+  }
+  const expects = step['expect'];
+  if (!Array.isArray(expects) || expects.length === 0) throw new Error('every probe action requires at least one declared expectation');
+  for (const exp of expects) validateProbeExpectation(exp);
 }
 
 export function readProbePlan(path: string): ProbePlan {

--- a/test/probe-flow.test.ts
+++ b/test/probe-flow.test.ts
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MAX_FLOW_SCREENS, PROBE_FLOW_SCHEMA, validateProbeFlow } from '../core/probe/flow.ts';
+
+const screen = (over: Record<string, unknown> = {}) => ({
+  screenId: 'login',
+  route: '/login',
+  arrival: [{ type: 'visible', selector: '#login-form' }],
+  steps: [{ action: 'click', selector: '#continue', expect: [{ type: 'url', value: '/dashboard' }] }],
+  advancesTo: 'dashboard',
+  ...over,
+});
+
+const flow = (over: Record<string, unknown> = {}) => ({
+  schema: PROBE_FLOW_SCHEMA,
+  name: 'onboarding flow',
+  destructive: false as const,
+  screens: [
+    screen({ screenId: 'login', route: '/login', advancesTo: 'dashboard', steps: [
+      { action: 'fill', selector: '#email', value: 'a@b.com', expect: [{ type: 'attribute', selector: '#email', name: 'value', value: 'a@b.com' }] },
+      { action: 'click', selector: '#continue', expect: [{ type: 'url', value: '/dashboard' }] },
+    ], arrival: [{ type: 'visible', selector: '#login-form' }] }),
+    screen({ screenId: 'dashboard', route: '/dashboard', advancesTo: 'settings',
+      arrival: [{ type: 'visible', selector: '[data-region="dashboard"]' }],
+      steps: [{ action: 'click', selector: '#open-settings', expect: [{ type: 'url', value: '/settings' }] }] }),
+    { screenId: 'settings', route: '/settings', arrival: [{ type: 'visible', selector: '#settings' }], steps: [] },
+  ],
+  carries: [{ fromScreen: 'login', fromLocator: '#email', toScreen: 'settings', toLocator: '#account-email' }],
+  ...over,
+});
+
+test('a linear multi-screen flow with arrivals, advances, and a forward state carry validates', () => {
+  const valid = flow();
+  assert.deepEqual(validateProbeFlow(valid), valid);
+});
+
+test('a flow is a bounded sequence of at least two screens', () => {
+  assert.throws(() => validateProbeFlow({ ...flow(), screens: [flow().screens[0]] }), /at least two screens/);
+  const many = Array.from({ length: MAX_FLOW_SCREENS + 1 }, (_u, i) => ({
+    screenId: `s${i}`, route: `/s${i}`, arrival: [{ type: 'visible', selector: '#x' }],
+    steps: i === MAX_FLOW_SCREENS ? [] : [{ action: 'click', selector: '#n', expect: [{ type: 'visible', selector: '#x' }] }],
+    ...(i === MAX_FLOW_SCREENS ? {} : { advancesTo: `s${i + 1}` }),
+  }));
+  assert.throws(() => validateProbeFlow({ ...flow(), screens: many, carries: [] }), new RegExp(`bounded to ${MAX_FLOW_SCREENS} screens`));
+});
+
+test('a non-terminal screen that advances nowhere, or to the wrong screen, is a dead end', () => {
+  const noAdvance = flow();
+  delete (noAdvance.screens[1] as Record<string, unknown>).advancesTo;
+  assert.throws(() => validateProbeFlow(noAdvance), /dead end/);
+  const wrongAdvance = flow();
+  (wrongAdvance.screens[0] as Record<string, unknown>).advancesTo = 'settings';
+  assert.throws(() => validateProbeFlow(wrongAdvance), /dead end[\s\S]*next screen 'dashboard'/);
+  const noStep = flow();
+  (noStep.screens[1] as Record<string, unknown>).steps = [];
+  assert.throws(() => validateProbeFlow(noStep), /no step to advance with/);
+  const terminalAdvances = flow();
+  (terminalAdvances.screens[2] as Record<string, unknown>).advancesTo = 'login';
+  assert.throws(() => validateProbeFlow(terminalAdvances), /terminal screen[\s\S]*advances nowhere/);
+});
+
+test('every screen must prove it loaded (a non-empty arrival) and use a safe local route', () => {
+  const noArrival = flow();
+  (noArrival.screens[1] as Record<string, unknown>).arrival = [];
+  assert.throws(() => validateProbeFlow(noArrival), /arrival must be a non-empty expectation list/);
+  for (const bad of ['dashboard', 'https://evil.example/x', '/../secret', '/a\\b']) {
+    const r = flow();
+    (r.screens[1] as Record<string, unknown>).route = bad;
+    assert.throws(() => validateProbeFlow(r), /route/);
+  }
+});
+
+test('a flow inherits the single-screen security contract (no credential fills, closed shapes)', () => {
+  const credential = flow();
+  (credential.screens[0] as Record<string, unknown>).steps = [
+    { action: 'fill', selector: '#password', value: 'hunter2', expect: [{ type: 'visible', selector: '#ok' }] },
+    { action: 'click', selector: '#continue', expect: [{ type: 'url', value: '/dashboard' }] },
+  ];
+  assert.throws(() => validateProbeFlow(credential), /credential/);
+  assert.throws(() => validateProbeFlow({ ...flow(), extra: 1 }), /unknown or missing keys/);
+  assert.throws(() => validateProbeFlow({ ...flow(), schema: 'nope' }), /schema must be/);
+  assert.throws(() => validateProbeFlow({ ...flow(), destructive: true }), /never destructive/);
+});
+
+test('a state carry must move a value strictly forward and reference real screens', () => {
+  const backward = flow();
+  backward.carries = [{ fromScreen: 'settings', fromLocator: '#a', toScreen: 'login', toLocator: '#b' }];
+  assert.throws(() => validateProbeFlow(backward), /carry state forward/);
+  const unknown = flow();
+  unknown.carries = [{ fromScreen: 'login', fromLocator: '#a', toScreen: 'nope', toLocator: '#b' }];
+  assert.throws(() => validateProbeFlow(unknown), /unknown screen 'nope'/);
+  const dupe = flow();
+  dupe.screens[1] = { ...(dupe.screens[1] as Record<string, unknown>), screenId: 'login' } as never;
+  assert.throws(() => validateProbeFlow(dupe), /duplicate screenId: login/);
+});


### PR DESCRIPTION
## Report gap #1 — the one genuinely-unaddressed gap
`omd probe` validates a **single screen**: one `page.goto(url)` plus click/fill/press steps. The failures that hurt most appear only **across** screens (login → onboarding → dashboard → settings): a **dead end** (a screen with no way forward) and **state loss** (a value entered early, gone by a later screen). Those were only eye/advisory.

## First increment (additive, not yet browser-executed)
- Refactored `core/probe/index.ts` to export `validateProbeStep`/`validateProbeExpectation` (**behavior identical**; existing probe tests 10/10), so a flow reuses the exact single-screen step vocabulary and security constraints (non-destructive, no credential fills, safe key allowlist).
- `core/probe/flow.ts` — `validateProbeFlow()` accepts a `probe-flow-v1` plan: a **linear sequence of 2..8 screens**, each with a safe local route, a non-empty **arrival** expectation (a broken transition is a dead end, not a silent pass), and reused steps; every non-terminal screen must **advance to the next and have a step to advance with** (declaring no way forward is a structural **dead end**); one **terminal** screen advances nowhere; every state **carry** must move a value **strictly forward**.

## Validation
probe-flow **6/6**; existing probe suites **10/10**; typecheck + build clean; diff --check clean. No release.