### PR TITLE
feat(flow-probe 2): browser executor that observes dead ends and state loss across screens

### DIFF
--- a/core/probe/flow.ts
+++ b/core/probe/flow.ts
@@ -15,7 +15,10 @@
 // is NOT yet wired into a browser executor or the evals — capture and wiring are later increments — so
 // the existing single-screen probe is untouched.
 
-import { validateProbeExpectation, validateProbeStep } from './index.ts';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { checkExpectation, type Expectation, type Step, validateProbeExpectation, validateProbeStep } from './index.ts';
 
 export const PROBE_FLOW_SCHEMA = 'probe-flow-v1' as const;
 
@@ -135,4 +138,135 @@ export function validateProbeFlow(input: unknown): ProbeFlow {
   }
 
   return input as ProbeFlow;
+}
+
+// ── Browser executor (increment 2): run a validated flow and observe dead ends and state loss ──
+
+export type FlowStepResult = { readonly action: string; readonly ok: boolean; readonly expectations: readonly { readonly ok: boolean }[] };
+export type FlowScreenResult = {
+  readonly screenId: string;
+  readonly route: string;
+  /** Did the browser actually reach this screen? A false here is a runtime dead end. */
+  readonly arrivalOk: boolean;
+  readonly steps: readonly FlowStepResult[];
+};
+export type FlowCarryResult = StateCarry & {
+  /** Was the earlier value still present, unchanged, on the later screen? */
+  readonly preserved: boolean;
+  readonly observed: { readonly from: string | null; readonly to: string | null };
+};
+export type ProbeFlowWarning = { readonly id: 'FLOW-DEAD-END' | 'FLOW-STATE-LOSS'; readonly severity: 'warn'; readonly message: string };
+export type ProbeFlowResult = {
+  readonly schema: typeof PROBE_FLOW_SCHEMA;
+  readonly name: string;
+  readonly base: string;
+  readonly screens: readonly FlowScreenResult[];
+  readonly carries: readonly FlowCarryResult[];
+  readonly warnings: readonly ProbeFlowWarning[];
+};
+
+/** Resolve the first screen's route to a real URL. Later screens are reached by their own navigation. */
+function resolveScreenUrl(base: string, route: string): string {
+  if (/^https?:\/\//.test(base)) {
+    const url = new URL(base);
+    if (!['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)) throw new Error('flow probe refuses remote targets');
+    url.pathname = route;
+    return url.href;
+  }
+  const path = resolve(base, `${route.replace(/^\//, '')}.html`);
+  if (!existsSync(path)) throw new Error(`no such screen page: ${path}`);
+  return pathToFileURL(path).href;
+}
+
+async function captureValue(page: import('playwright').Page, locator: string): Promise<string | null> {
+  const el = page.locator(locator).first();
+  if ((await el.count()) === 0) return null; // absent — never auto-wait 30s for an element on another screen
+  const input = await el.inputValue({ timeout: 1000 }).catch(() => null);
+  if (input !== null && input.trim() !== '') return input.trim();
+  const text = await el.textContent({ timeout: 1000 }).catch(() => null);
+  return text === null ? null : text.trim();
+}
+
+/**
+ * Runs a validated multi-screen flow in a real headless browser. It navigates the first screen, then
+ * follows each screen's own steps into the next; a screen whose arrival expectations fail was never
+ * reached — that transition is a runtime DEAD END (FLOW-DEAD-END) and the run stops there. Declared
+ * state carries are captured on the earlier screen (after each step, so a filled value is seen before it
+ * navigates away) and compared on the later screen; a value that did not survive forward is STATE LOSS
+ * (FLOW-STATE-LOSS). It reuses the single-screen step execution and expectation checks, and never fills
+ * a credential or runs a destructive action (the plan is validated first).
+ */
+export async function runProbeFlow(
+  base: string,
+  flow: unknown,
+  viewport = { width: 390, height: 844 },
+): Promise<ProbeFlowResult> {
+  const validated = validateProbeFlow(flow);
+  const { chromium } = await import('playwright');
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({ viewport });
+    const screens: FlowScreenResult[] = [];
+    const carries: FlowCarryResult[] = [];
+    const warnings: ProbeFlowWarning[] = [];
+    const captured = new Map<number, string>(); // carry index → last-seen from-value (before navigation)
+
+    for (let i = 0; i < validated.screens.length; i += 1) {
+      const screen = validated.screens[i] as ProbeScreen;
+      if (i === 0) await page.goto(resolveScreenUrl(base, screen.route), { waitUntil: 'networkidle' });
+      else await page.waitForLoadState('domcontentloaded', { timeout: 8000 }).catch(() => {});
+
+      // Arrival: did we actually land on this screen? A failure is a dead end.
+      let arrivalOk = true;
+      for (const exp of screen.arrival as readonly Expectation[]) {
+        if (!(await checkExpectation(page, exp))) arrivalOk = false;
+      }
+      if (!arrivalOk) {
+        screens.push({ screenId: screen.screenId, route: screen.route, arrivalOk: false, steps: [] });
+        warnings.push({ id: 'FLOW-DEAD-END', severity: 'warn', message: `screen '${screen.screenId}' (${screen.route}) was not reached — the transition into it is a dead end` });
+        break;
+      }
+
+      // Compare any carries that land on this screen against the value captured earlier.
+      for (let index = 0; index < validated.carries.length; index += 1) {
+        const carry = validated.carries[index] as StateCarry;
+        if (carry.toScreen !== screen.screenId) continue;
+        const to = await captureValue(page, carry.toLocator);
+        const from = captured.get(index) ?? null;
+        const preserved = from !== null && to !== null && from === to;
+        carries.push({ ...carry, preserved, observed: { from, to } });
+        if (!preserved) warnings.push({ id: 'FLOW-STATE-LOSS', severity: 'warn', message: `state '${carry.fromLocator}' from '${carry.fromScreen}' did not survive to '${carry.toLocator}' on '${carry.toScreen}' (from=${JSON.stringify(from)}, to=${JSON.stringify(to)})` });
+      }
+
+      const captureFroms = async (): Promise<void> => {
+        for (let index = 0; index < validated.carries.length; index += 1) {
+          const carry = validated.carries[index] as StateCarry;
+          if (carry.fromScreen !== screen.screenId) continue;
+          const value = await captureValue(page, carry.fromLocator);
+          if (value !== null && value !== '') captured.set(index, value);
+        }
+      };
+      await captureFroms();
+
+      const stepResults: FlowStepResult[] = [];
+      for (const step of screen.steps as readonly Step[]) {
+        let ok = true;
+        try {
+          if (step.action === 'click') await page.locator(step.selector!).click();
+          else if (step.action === 'fill') await page.locator(step.selector!).fill(step.value!);
+          else if (step.selector) await page.locator(step.selector).press(step.key!);
+          else await page.keyboard.press(step.key!);
+        } catch { ok = false; }
+        const expectations: { ok: boolean }[] = [];
+        for (const exp of step.expect ?? []) expectations.push({ ok: await checkExpectation(page, exp) });
+        stepResults.push({ action: step.action, ok, expectations });
+        await captureFroms(); // re-capture after each step, so a filled value is seen before it navigates away
+      }
+      screens.push({ screenId: screen.screenId, route: screen.route, arrivalOk: true, steps: stepResults });
+    }
+
+    return { schema: PROBE_FLOW_SCHEMA, name: validated.name, base, screens, carries, warnings };
+  } finally {
+    await browser.close();
+  }
 }

--- a/core/probe/index.ts
+++ b/core/probe/index.ts
@@ -3,12 +3,12 @@ import { resolve } from 'node:path';
 import { type ProjectWriteAdapter, requireProjectWriteAdapter } from '../runtime/project-write.ts';
 import { pathToFileURL } from 'node:url';
 
-type Expectation =
+export type Expectation =
   | { type: 'visible' | 'hidden'; selector: string }
   | { type: 'text'; selector: string; value: string }
   | { type: 'url'; value: string }
   | { type: 'attribute'; selector: string; name: string; value: string };
-type Step = { action: 'click' | 'fill' | 'press'; selector?: string; value?: string; key?: string; expect?: Expectation[] };
+export type Step = { action: 'click' | 'fill' | 'press'; selector?: string; value?: string; key?: string; expect?: Expectation[] };
 export interface ProbePlan {
   name: string;
   destructive: false;
@@ -37,7 +37,7 @@ const PRESS_KEYS = new Set([
 ]);
 const CREDENTIAL_SELECTOR = /password|token|secret|credential|auth/i;
 
-function localUrl(target: string): string {
+export function localUrl(target: string): string {
   if (!/^https?:\/\//.test(target)) {
     const path = resolve(target);
     if (!existsSync(path)) throw new Error(`no such page: ${target}`);
@@ -117,7 +117,7 @@ export function readProbePlan(path: string): ProbePlan {
   return validateProbePlan(JSON.parse(readFileSync(path, 'utf8')) as unknown);
 }
 
-async function checkExpectation(page: import('playwright').Page, exp: Expectation): Promise<boolean> {
+export async function checkExpectation(page: import('playwright').Page, exp: Expectation): Promise<boolean> {
   if (exp.type === 'url') return page.url().includes(exp.value);
   const el = page.locator(exp.selector).first();
   if (exp.type === 'visible') return el.isVisible().catch(() => false);

--- a/test/probe-flow-run.test.ts
+++ b/test/probe-flow-run.test.ts
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runProbeFlow, PROBE_FLOW_SCHEMA } from '../core/probe/flow.ts';
+
+// A three-screen fixture: login → dashboard → settings, carrying the entered email forward through the
+// URL (file:// localStorage is per-file-origin, so a query param is the portable carrier). The DOM
+// values are what the flow compares; the carrier is incidental.
+function writeFlowFixture(dir: string, opts: { brokenContinue?: boolean; brokenSettings?: boolean } = {}): void {
+  writeFileSync(join(dir, 'login.html'), `<!doctype html><html><body>
+    <form id="login-form"><input id="email" /></form>
+    <button id="continue" type="button">Continue</button>
+    <script>document.getElementById('continue').addEventListener('click', function(){
+      ${opts.brokenContinue ? '/* dead end: this control leads nowhere */' : "location.href = 'dashboard.html?email=' + encodeURIComponent(document.getElementById('email').value);"}
+    });</script>
+  </body></html>`);
+  writeFileSync(join(dir, 'dashboard.html'), `<!doctype html><html><body>
+    <div data-region="dashboard">Dashboard</div>
+    <a id="open-settings" href="settings.html">Open settings</a>
+    <script>document.getElementById('open-settings').addEventListener('click', function(e){ e.preventDefault(); location.href = 'settings.html' + location.search; });</script>
+  </body></html>`);
+  writeFileSync(join(dir, 'settings.html'), `<!doctype html><html><body>
+    <div id="settings"><input id="account-email" /></div>
+    <script>document.getElementById('account-email').value = ${opts.brokenSettings ? "''" : "new URLSearchParams(location.search).get('email') || ''"};</script>
+  </body></html>`);
+}
+
+const flowPlan = () => ({
+  schema: PROBE_FLOW_SCHEMA,
+  name: 'onboarding',
+  destructive: false as const,
+  screens: [
+    { screenId: 'login', route: '/login', arrival: [{ type: 'visible', selector: '#login-form' }],
+      steps: [
+        { action: 'fill', selector: '#email', value: 'user@example.com', expect: [{ type: 'attribute', selector: '#email', name: 'value', value: 'user@example.com' }] },
+        { action: 'click', selector: '#continue', expect: [{ type: 'url', value: 'dashboard' }] },
+      ], advancesTo: 'dashboard' },
+    { screenId: 'dashboard', route: '/dashboard', arrival: [{ type: 'visible', selector: '[data-region="dashboard"]' }],
+      steps: [{ action: 'click', selector: '#open-settings', expect: [{ type: 'url', value: 'settings' }] }], advancesTo: 'settings' },
+    { screenId: 'settings', route: '/settings', arrival: [{ type: 'visible', selector: '#settings' }], steps: [] },
+  ],
+  carries: [{ fromScreen: 'login', fromLocator: '#email', toScreen: 'settings', toLocator: '#account-email' }],
+});
+
+test('a healthy flow reaches every screen and carries the entered value forward', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omd-flow-'));
+  writeFlowFixture(dir);
+  const result = await runProbeFlow(dir, flowPlan());
+  assert.equal(result.schema, PROBE_FLOW_SCHEMA);
+  assert.equal(result.screens.length, 3);
+  assert.ok(result.screens.every((s) => s.arrivalOk), 'every screen was reached');
+  assert.equal(result.carries.length, 1);
+  assert.equal(result.carries[0]!.preserved, true);
+  assert.deepEqual(result.carries[0]!.observed, { from: 'user@example.com', to: 'user@example.com' });
+  assert.deepEqual(result.warnings, []);
+});
+
+test('a control that leads nowhere is reported as a dead end and stops the flow', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omd-flow-deadend-'));
+  writeFlowFixture(dir, { brokenContinue: true });
+  const result = await runProbeFlow(dir, flowPlan());
+  assert.equal(result.screens[0]!.arrivalOk, true, 'login itself is reached');
+  assert.equal(result.screens.length, 2, 'the flow stops at the unreached screen');
+  assert.equal(result.screens[1]!.arrivalOk, false, 'dashboard was never reached');
+  assert.ok(result.warnings.some((w) => w.id === 'FLOW-DEAD-END'), 'a dead end is reported');
+});
+
+test('a value that does not survive to a later screen is reported as state loss', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omd-flow-loss-'));
+  writeFlowFixture(dir, { brokenSettings: true });
+  const result = await runProbeFlow(dir, flowPlan());
+  assert.ok(result.screens.every((s) => s.arrivalOk), 'no dead end — every screen is reachable');
+  assert.equal(result.carries[0]!.preserved, false, 'the carried value was lost');
+  assert.equal(result.carries[0]!.observed.from, 'user@example.com');
+  assert.ok(result.warnings.some((w) => w.id === 'FLOW-STATE-LOSS'), 'state loss is reported');
+});
+
+test('the executor validates and refuses an unsafe flow before launching a browser', async () => {
+  await assert.rejects(() => runProbeFlow('/nowhere', { schema: PROBE_FLOW_SCHEMA, name: 'x', destructive: false, screens: [], carries: [] }), /at least two screens/);
+});


### PR DESCRIPTION
## Increment 2 — make the contract RUN
`runProbeFlow(base, flow)` navigates the first screen, then follows each screen's own steps into the next.
- **Dead end** — a screen whose `arrival` expectations fail was never reached; that transition is a runtime `FLOW-DEAD-END` and the run stops.
- **State loss** — declared carries are captured on the earlier screen (re-captured after each step, so a filled value is seen *before* it navigates away) and compared on the later screen; a value that did not survive forward is `FLOW-STATE-LOSS`.

Reuses the single-screen step execution + expectation checks (`checkExpectation`, `localUrl` now exported additively) and the validated plan's security (non-destructive, no credential fills).

## Two real-browser fixes made during development
- Value capture uses `count()` + a **bounded 1s timeout**, so it never auto-waits 30s for an element that lives on a *later* screen (this was making the healthy run take ~62s).
- Post-navigation waits use `domcontentloaded`, not `networkidle`, so a click-driven navigation settles immediately.

## Validation
3-page fixture (login → dashboard → settings, email carried via URL): a healthy flow reaches every screen and preserves the value; a broken control is a **dead end** that stops the flow; a settings page that drops the value is **state loss**. probe-flow + probe-flow-run + existing probe suites all green (4 browser + 6 validator + 10 single-screen); typecheck + build clean; diff --check clean.

Increment 3 (evals expansion to real 3–5 step flows) is the remaining step. No release.