### PR TITLE
feat(flow-probe 3): wire omd flow-probe into the loop as a RED cross-screen UX gate

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -410,6 +410,37 @@ async function cmdProbe(opts: Opts): Promise<never> {
   process.exit(result.warnings.length ? 1 : 0);
 }
 
+async function cmdFlowProbe(opts: Opts): Promise<never> {
+  const base = opts._[0];
+  if (!base) throw new Error('usage: omd flow-probe <base-url-or-dir> [--plan path] [--json] [--out path]');
+  const { runProbeFlow } = await import('../core/probe/flow.ts');
+  const { writeProbeResult } = await import('../core/probe/index.ts');
+  const planPath = resolve(opts.plan ?? join(process.cwd(), '.omd', 'probes', 'flow.json'));
+  if (!existsSync(planPath)) throw new Error(`flow plan not found: ${planPath}`);
+  const result = await runProbeFlow(base, JSON.parse(readFileSync(planPath, 'utf8')) as unknown);
+  const safe = result.name.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-|-$/g, '') || 'flow';
+  const out = resolve(opts.out ?? join(process.cwd(), '.omd', '.cache', 'probes', `${safe}-flow.json`));
+  const command = 'omd flow-probe';
+  const fromProject = relative(process.cwd(), out);
+  if (fromProject === '' || (!fromProject.startsWith('..') && !fromProject.startsWith('/'))) {
+    writeProbeResult(process.cwd(), fromProject, result as never, projectWriterFromActivation(opts, command));
+  } else {
+    writeExternalObservationFile({
+      projectRoot: process.cwd(),
+      absolutePath: opts.out ?? out,
+      content: JSON.stringify(result, null, 2),
+      invocation: invocationFromActivation(opts, command),
+      kind: 'probe-cache',
+    });
+  }
+  if (opts.json) process.stdout.write(JSON.stringify(result));
+  else {
+    for (const warning of result.warnings) console.log(`[${warning.severity}] ${warning.id}: ${warning.message}`);
+    console.log(out);
+  }
+  process.exit(result.warnings.length ? 1 : 0);
+}
+
 async function cmdConfig(sub: string | undefined, opts: Opts): Promise<never> {
   const { readConfig, setCheckpoint } = await import('../core/config/index.ts');
   if (sub === 'show') {
@@ -2481,6 +2512,7 @@ async function main(): Promise<never> {
   if (cmd === 'ir') return cmdIr(parseArgs(args.slice(1)));
   if (cmd === 'render') return cmdRender(parseArgs(args.slice(1)));
   if (cmd === 'probe') return cmdProbe(parseArgs(args.slice(1)));
+  if (cmd === 'flow-probe') return cmdFlowProbe(parseArgs(args.slice(1)));
   if (cmd === 'check') return cmdCheck(parseArgs(args.slice(1)));
   if (cmd === 'slop') return cmdSlop(sub, parseArgs(args.slice(2)));
   if (cmd === 'lighthouse') return cmdLighthouse(parseArgs(args.slice(1)));

--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -390,6 +390,8 @@ with reasons. `static` records both probes N/A with reasons. Never add fake erro
 recovery UI to make an inapplicable gate look complete. An eye makes interaction claims only
 from supplied probe evidence.
 
+A `stateful` surface that spans two or more reachable screens — a login → onboarding → dashboard sequence, a multi-step form or wizard — additionally supplies `.omd/probes/flow.json` and runs `omd flow-probe`, which walks the declared screen sequence in one browser. A screen that is never reached, because a control leads nowhere, is a dead end (`FLOW-DEAD-END`); a value entered early that does not survive forward to a later screen is state loss (`FLOW-STATE-LOSS`). On a `product`/`mixed` surface both are RED — a real UX failure, not advisory — because a broken cross-screen path fails the task no matter how correct each single screen is in isolation. The eye makes cross-screen navigation and state-continuity claims only from this flow-probe evidence, never from inspecting one screen; a single-screen surface records the flow probe N/A with a reason.
+
 ## UX acceptance contract
 
 Every applicable surface names and verifies the primary task, most frequent action,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -224,3 +224,46 @@ test('omd pack <missing-file> exits non-zero with an error message', () => {
   assert.notEqual(r.status, 0);
   assert.match(r.stderr, /not found/);
 });
+test('omd flow-probe walks the declared screen sequence and reports a clean flow', () => {
+  const dir = project();
+  writeFileSync(join(dir, 'login.html'), `<!doctype html><html><body>
+    <form id="login-form"><input id="email" /></form>
+    <button id="continue" type="button">Continue</button>
+    <script>document.getElementById('continue').addEventListener('click', function(){
+      location.href = 'dashboard.html?email=' + encodeURIComponent(document.getElementById('email').value);
+    });</script></body></html>`);
+  writeFileSync(join(dir, 'dashboard.html'), `<!doctype html><html><body>
+    <div data-region="dashboard">Dashboard</div>
+    <a id="open-settings" href="settings.html">Settings</a>
+    <script>document.getElementById('open-settings').addEventListener('click', function(e){ e.preventDefault(); location.href = 'settings.html' + location.search; });</script></body></html>`);
+  writeFileSync(join(dir, 'settings.html'), `<!doctype html><html><body>
+    <div id="settings"><input id="account-email" /></div>
+    <script>document.getElementById('account-email').value = new URLSearchParams(location.search).get('email') || '';</script></body></html>`);
+  mkdirSync(join(dir, '.omd', 'probes'), { recursive: true });
+  writeFileSync(join(dir, '.omd', 'probes', 'flow.json'), JSON.stringify({
+    schema: 'probe-flow-v1', name: 'onboarding', destructive: false,
+    screens: [
+      { screenId: 'login', route: '/login', arrival: [{ type: 'visible', selector: '#login-form' }],
+        steps: [
+          { action: 'fill', selector: '#email', value: 'user@example.com', expect: [{ type: 'attribute', selector: '#email', name: 'value', value: 'user@example.com' }] },
+          { action: 'click', selector: '#continue', expect: [{ type: 'url', value: 'dashboard' }] },
+        ], advancesTo: 'dashboard' },
+      { screenId: 'dashboard', route: '/dashboard', arrival: [{ type: 'visible', selector: '[data-region="dashboard"]' }],
+        steps: [{ action: 'click', selector: '#open-settings', expect: [{ type: 'url', value: 'settings' }] }], advancesTo: 'settings' },
+      { screenId: 'settings', route: '/settings', arrival: [{ type: 'visible', selector: '#settings' }], steps: [] },
+    ],
+    carries: [{ fromScreen: 'login', fromLocator: '#email', toScreen: 'settings', toLocator: '#account-email' }],
+  }));
+  const r = run(['flow-probe', dir, '--json'], dir);
+  assert.equal(r.status, 0, r.stderr);
+  const result = JSON.parse(r.stdout) as { screens: unknown[]; warnings: unknown[] };
+  assert.equal(result.screens.length, 3);
+  assert.deepEqual(result.warnings, []);
+});
+
+test('omd flow-probe fails closed when no flow plan exists', () => {
+  const dir = project();
+  const r = run(['flow-probe', dir], dir);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /flow plan not found/);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -625,3 +625,11 @@ test('the AI-SaaS tells name decorative geometric-glyph ornament, flagged as SLO
   assert.match(expressive, /A marker system is consistent and meaningful or it is absent/i);
   assert.match(expressive, /`SLOP-ORNAMENT-GLYPH`/);
 });
+test('a multi-screen stateful surface runs omd flow-probe with dead-end and state-loss as RED', () => {
+  const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
+  assert.match(loop, /spans two or more reachable screens[\s\S]*supplies `\.omd\/probes\/flow\.json` and runs `omd flow-probe`/i);
+  assert.match(loop, /a dead end \(`FLOW-DEAD-END`\)/i);
+  assert.match(loop, /state loss \(`FLOW-STATE-LOSS`\)/i);
+  assert.match(loop, /On a `product`\/`mixed` surface both are RED/i);
+  assert.match(loop, /makes cross-screen navigation and state-continuity claims only from this flow-probe evidence/i);
+});


### PR DESCRIPTION
## Increment 3 — make the loop RUN it
- **CLI**: `omd flow-probe <base> [--plan .omd/probes/flow.json]` (mirrors `omd probe`) — reads the flow plan, runs `runProbeFlow`, writes a disposable result, prints `FLOW-DEAD-END`/`FLOW-STATE-LOSS`, and **exits non-zero** when any fire.
- **Loop gate** (`human-design-loop.md`): a `stateful` surface spanning **two or more reachable screens** (login → onboarding → dashboard, a multi-step form/wizard) supplies `.omd/probes/flow.json` and runs `omd flow-probe`. A screen never reached is a **dead end**; a value that does not survive forward is **state loss**; on a `product`/`mixed` surface **both are RED** — a real UX failure, not advisory — because a broken cross-screen path fails the task no matter how correct each single screen is. The eye makes cross-screen claims only from this flow-probe evidence.

## Validation
cli + prompt-contract suites **69/69** (CLI E2E walks a real 3-screen login→dashboard→settings flow clean; fails closed with no plan; loop gate pinned); typecheck + build clean; diff --check clean.

This completes **#1** as **define** (validator, #126) + **observe** (browser executor, #127) + **wire** (CLI + loop gate, this PR). Optional follow-on: a benchmark multi-screen scenario in `evals/product-ux` (measures the harness, not new capability). No release.