### PR TITLE
feat: SLOP-DIVIDER-SPAM flags a rule between every row (the divider-line AI tell)

### DIFF
--- a/core/ir/dom.ts
+++ b/core/ir/dom.ts
@@ -238,6 +238,14 @@ export function extractInPage(maxNodes: number, selector?: string | null): RawIr
       if (color) node.color = color;
     }
     if (radius > 0) node.radius = { value: radius, token: nameOf(String(radius) + 'PX') };
+    // A divider: a visible rule on the top and/or bottom edge, but not a full four-side box (that is a
+    // card, not a rule). Captures the "a line between every row" pattern (SLOP-DIVIDER-SPAM).
+    const edge = (w: string, s: string, c: string): boolean => (parseFloat(w) || 0) > 0 && s !== 'none' && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent';
+    const et = edge(cs.borderTopWidth, cs.borderTopStyle, cs.borderTopColor);
+    const eb = edge(cs.borderBottomWidth, cs.borderBottomStyle, cs.borderBottomColor);
+    const el2 = edge(cs.borderLeftWidth, cs.borderLeftStyle, cs.borderLeftColor);
+    const er = edge(cs.borderRightWidth, cs.borderRightStyle, cs.borderRightColor);
+    if ((et || eb) && !(el2 && er)) node.divider = true;
     if (isInteractive(el)) node.interactive = true;
     if (cs.display === 'inline') node.inline = true;
 

--- a/core/rules/builtin/slop.yaml
+++ b/core/rules/builtin/slop.yaml
@@ -128,6 +128,20 @@
   value: "(() => { const marks = new Set(); for (const n of ir.nodes) { if (n.type !== 'TEXT' || !n.text) continue; const m = /^\\s*([\\u{25A0}-\\u{25FF}])(?:\\s|$)/u.exec(n.text); if (m) marks.add(m[1]); } return marks.size >= 2 ? [...marks] : null; })()"
   assert: "value === null"
   message: "Decorative geometric-glyph ornament: {value} are distinct shape glyphs used as leading markers on this page. A different little diamond, square, or triangle before each card is ornament assembled to look designed, not an icon system — the shapes encode nothing and the variety is the tell. Use one consistent, meaningful marker that maps to the content, or clean typography and spacing, and let the hierarchy carry itself."
+# Divider spam: a rule between every row. A generator separates a list, a stat stack, or a numbered
+# index by giving each sibling a top/bottom border, so the page fills with thin horizontal lines. It is
+# the heaviest, noisiest separator (theory/craft.md § Borders vs background contrast) and reads as
+# machine-made. dom.ts marks a node `divider` when it has a top/bottom rule but is not a full box (a card
+# is not a divider). Fires page-level when one parent has four or more divider children — a line between
+# every item — so a single hairline, a data table, or a couple of bordered inputs never fire.
+- id: SLOP-DIVIDER-SPAM
+  layer: 1
+  category: slop
+  severity: warn
+  when: "node.parent === null"
+  value: "(() => { const byParent = {}; for (const n of ir.nodes) { if (!n.divider) continue; const p = n.parent || 'root'; (byParent[p] = byParent[p] || 0); byParent[p] += 1; } const worst = Math.max(0, ...Object.values(byParent)); return worst >= 4 ? worst : null; })()"
+  assert: "value === null"
+  message: "Divider spam: {value} sibling items in one group are each separated by a rule. A line between every row is the heaviest, noisiest way to separate content and the one a generator reaches for by default (theory/craft.md § Borders vs background contrast). Separate rows with space or a subtle background-contrast band instead; reserve real borders for form inputs, data tables, and code blocks, where the line carries structure the spacing cannot."
 - id: SLOP-COPY
   layer: 1
   category: slop

--- a/core/types.ts
+++ b/core/types.ts
@@ -32,6 +32,8 @@ export interface RawNode {
   layout?: Layout;
   fill?: Styled;
   radius?: Styled;
+  /** True when the node carries a rule border on top and/or bottom but not a full box — a divider between rows. */
+  divider?: boolean;
   color?: Hex;
   interactive?: boolean;
   inline?: boolean;

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1027,3 +1027,15 @@ test('SLOP-ORNAMENT-GLYPH does not fire on one consistent marker or functional a
   ];
   assert.ok(!check(normalize({ nodes: arrows }), builtin, { categories: ['slop'] }).some((x) => x.id === 'SLOP-ORNAMENT-GLYPH'), 'functional arrows (U+2190–21FF) must not fire');
 });
+// ── SLOP-DIVIDER-SPAM ─────────────────────────────────────────────────────────
+test('SLOP-DIVIDER-SPAM fires when four or more sibling rows each carry a rule', () => {
+  const rows = Array.from({ length: 6 }, (_u, i) => makeChildNode('root', { id: `r${i}`, type: 'FRAME', divider: true, box: { x: 0, y: i * 60, w: 800, h: 56 } }, i));
+  const root = makeRootNode({ children: rows.map((r) => r.id) });
+  assert.ok(runSlop([root, ...rows]).some((x) => x.id === 'SLOP-DIVIDER-SPAM'), 'a line between every row is divider spam');
+});
+test('SLOP-DIVIDER-SPAM does not fire on a few dividers or on non-divider siblings', () => {
+  const three = Array.from({ length: 3 }, (_u, i) => makeChildNode('root', { id: `r${i}`, divider: true }, i));
+  assert.ok(!runSlop([makeRootNode({ children: three.map((r) => r.id) }), ...three]).some((x) => x.id === 'SLOP-DIVIDER-SPAM'), 'three dividers are not spam');
+  const plain = Array.from({ length: 6 }, (_u, i) => makeChildNode('root', { id: `c${i}` }, i));
+  assert.ok(!runSlop([makeRootNode({ children: plain.map((c) => c.id) }), ...plain]).some((x) => x.id === 'SLOP-DIVIDER-SPAM'), 'siblings with no rule are not spam');
+});


### PR DESCRIPTION
## User feedback (running example)
A numbered index (01–09) with a **thin horizontal line between every row** plus a vertical rule — a gratuitous divider grid that reads as machine-made. `craft.md` already says borders are the heaviest separator (reserve them for inputs/tables/code; prefer space or background contrast), but there was **no machine signal**, so 'separate every row with a line' shipped uncaught.

## The fix
The IR carried no per-node border data, so this adds it minimally:
- **`dom.ts`** marks a node `divider` when it has a visible rule on **top and/or bottom** but is **not a full four-side box** (a card is not a divider). `RawNode` gains an optional `divider` boolean — it flows through `normalize`'s node spread unchanged, so the ir/blueprint contracts are untouched.
- **`SLOP-DIVIDER-SPAM`** — a page-level `warn` that fires when one parent has **four or more** divider children (a line between every item), so a single hairline, a data table, or a couple of bordered inputs never trip it.

Verified on a **real render**: a 5-row `border-top` list captures 5 divider nodes and fires the rule.

## Validation
rules + ir + blueprint suites **132/132** (fires on `>=4` divider siblings; passes on 3 or non-divider siblings; real-render capture confirmed); typecheck + build clean; diff --check clean. No release.