### PR TITLE
feat: craft names smooth in-page navigation (anchor jumps scroll, never hard-jump)

### DIFF
--- a/core/theory/craft.md
+++ b/core/theory/craft.md
@@ -251,6 +251,16 @@ unexpected element is what gets remembered.
 
 ---
 
+## Smooth in-page navigation
+
+An in-page anchor — a "jump to section" link, a "↓ see the nine steps" affordance, a table-of-contents entry — that hard-jumps the viewport to its target is a polish gap that separates generated work from designed work. The instantaneous jump gives the user no spatial continuity: they do not see that they moved down the page, so they lose their place and the relationship between where they were and where they landed. The award-tier version scrolls the viewport there smoothly, so the motion itself is the wayfinding — the user feels the distance travelled.
+
+The technique is one line: `scroll-behavior: smooth` on the scroll container (usually `html`), or, for control over duration and easing, `element.scrollIntoView({ behavior: 'smooth', block: 'start' })` on the anchor's click. The smooth scroll must resolve quickly; a long-distance smooth scroll that takes seconds is worse than a jump, because it holds the user hostage to the animation past the point where it informs.
+
+Condition → choice → reason: any in-page anchor or "scroll to the next section" affordance the design owns scrolls smoothly to its target rather than jumping. Under `prefers-reduced-motion: reduce` it reverts to an instant jump — the smooth motion is the enhancement and the destination is reached either way. Never override cross-page navigation or the browser's back/forward; this is only for same-page anchors.
+
+---
+
 ## Human calibration
 
 Every rule above is grounded in a named practitioner source, but the *verdict* on whether a finished render actually reads as designed is currently made by `omd-eye` — a blind reviewer, but still a language model judging a model's output. `theory/voice.md` closes this loop on the prose side: its "Calibration evidence" section measured a fully human-authored essay against a pipeline version on the same metrics and let the gaps rewrite the rules. Visual craft has no equivalent yet. That asymmetry is the one place "human-like" is still an LLM's opinion rather than a measurement.

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -633,3 +633,10 @@ test('a multi-screen stateful surface runs omd flow-probe with dead-end and stat
   assert.match(loop, /On a `product`\/`mixed` surface both are RED/i);
   assert.match(loop, /makes cross-screen navigation and state-continuity claims only from this flow-probe evidence/i);
 });
+test('craft names smooth in-page navigation with a reduced-motion fallback', () => {
+  const craft = read('core/theory/craft.md').replace(/\s+/g, ' ');
+  assert.match(craft, /## Smooth in-page navigation/);
+  assert.match(craft, /hard-jumps the viewport to its target is a polish gap/i);
+  assert.match(craft, /scroll-behavior: smooth[\s\S]*scrollIntoView\(\{ behavior: 'smooth'/i);
+  assert.match(craft, /Under `prefers-reduced-motion: reduce` it reverts to an instant jump/i);
+});


### PR DESCRIPTION
## User feedback (running example)
Clicking a '↓ 아홉 단계 보기' (see the nine steps) affordance **hard-jumps** the viewport instead of scrolling there smoothly. A hard jump gives no spatial continuity — the user does not see they moved down the page and loses the relationship between where they were and where they landed; the award-tier version scrolls smoothly, so the motion *is* the wayfinding.

## The fix
A `craft.md` decision entry: any in-page anchor or 'scroll to the next section' affordance the design owns **scrolls smoothly** to its target (`scroll-behavior: smooth` on the scroll container, or `element.scrollIntoView({ behavior: 'smooth' })` on click), resolving quickly; under `prefers-reduced-motion: reduce` it reverts to an instant jump (the smooth motion is the enhancement, the destination is reached either way); cross-page navigation and browser back/forward are never overridden.

Craft/eye guidance, **not a machine rule** — JS-based smooth scroll (`scrollIntoView`) is invisible to a static CSS check, so a rule would false-positive; the eye enforces it on review.

## Validation
prompt-contract + craft-calibration suites green (new smooth-nav assertion; `scroll-behavior`/`scrollIntoView` + reduced-motion fallback pinned); build clean; diff --check clean. No release.