### PR TITLE
feat: domain-analysis is the first loop step — understand the request before framing

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -22,6 +22,7 @@ import { checkFinalEvidence } from '../core/evidence/final.ts';
 import { checkTaskEvidence, publishTaskEvidence } from '../core/evidence/task.ts';
 import { computeStack } from '../core/stack/index.ts';
 import { scanTextSlop } from '../core/slop/text-slop.ts';
+import { validateDomainBrief } from '../core/domain/domain-brief.ts';
 import { evaluateLighthouse, type LighthouseBudget } from '../core/perf/lighthouse.ts';
 import { evaluateVisualRichness } from '../core/composition-contract/visual-richness.ts';
 import type { VisualRichnessRegister } from '../core/composition-contract/visual-richness.ts';
@@ -1563,6 +1564,23 @@ function cmdComposition(opts: Opts): never {
   process.exit(findings.length > 0 ? 1 : 0);
 }
 
+/** Schema lint of the domain-analysis artifact; advisory-adjacent — exits 1 on an invalid brief. */
+function cmdDomain(mode: string | undefined, opts: Opts): never {
+  if (mode !== 'check') throw new Error('usage: omd domain check [--input <domain-brief.json>] [--json]');
+  const file = opts.input ?? join(process.cwd(), '.omd', 'domain-brief.json');
+  try {
+    validateDomainBrief(inputJson(file, 'omd domain check'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (opts.json) process.stdout.write(JSON.stringify({ ok: false, error: message }));
+    else console.error(`[error] ${message}`);
+    process.exit(1);
+  }
+  if (opts.json) process.stdout.write(JSON.stringify({ ok: true }));
+  else console.log('ok — domain-brief names the domain, its surfaces, core objects, audience, and per-role reference queries');
+  process.exit(0);
+}
+
 /** Final byte-freshness evidence only; this does not judge semantic copy/source fidelity. */
 function cmdSource(mode: string | undefined, opts: Opts): never {
   const sourceRoot = resolve(opts._[0] ?? process.cwd());
@@ -2477,6 +2495,7 @@ function usage(): never {
     + '\n'
     + '  art-direction check --input decision-check.json [--json]  persist the canonical selected direction before composition\n'
     + '  intent append --input trusted-intent.json [--json]  append trusted intent and update its guarded current pointer\n'
+    + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
     + '  preflight --input activation-context.json [--json]  read-only activation validation\n'
     + '  text-slop [file] [--json]                   advisory AI-cliche scan of copy (default .omd/copy-deck.md)\n'
     + '  visual-richness [file] [--register R] [--json]  advisory carrier read of composition (default .omd/composition.md)\n'
@@ -2593,6 +2612,7 @@ async function main(): Promise<never> {
     return cmdEvidence(sub, parseArgs(args.slice(2)));
   }
   if (cmd === 'intent') return cmdIntent(sub, parseArgs(args.slice(2)));
+  if (cmd === 'domain') return cmdDomain(sub, parseArgs(args.slice(2)));
   if (cmd === 'stack') return cmdStack(parseArgs(args.slice(1)));
   if (cmd === 'text-slop') return cmdTextSlop(parseArgs(args.slice(1)));
   if (cmd === 'visual-richness') return cmdVisualRichness(parseArgs(args.slice(1)));

--- a/core/domain/domain-brief.ts
+++ b/core/domain/domain-brief.ts
@@ -1,0 +1,156 @@
+// Domain-understanding contract — the first loop step, run before framing.
+//
+// A raw request ("make me an ERP", "a landing page for this tool") is not yet designable: the
+// harness does not yet know what the domain IS, what surfaces it canonically needs, what real
+// objects it manipulates, or who it is for. Designing straight from the words produces a generic
+// shape because the request under-specifies the domain. This module defines the artifact the
+// domain-analysis step must produce: a bounded, validated `domain-brief-v1` that names the domain,
+// its canonical surfaces, its core objects, its audience, and — crucially — the reference search
+// queries the scout will run, split by the two reference roles:
+//
+//   role ① component  — detailed section/component/button design to source from good sites.
+//   role ② craft      — motion, scroll animation, and sculptural/visual craft to source from
+//                        top-tier galleries (Awwwards, theFWA, …).
+//
+// The brief is the bridge: domain understanding on one side, concrete reference acquisition on the
+// other. It is data only — it carries no rationale, authorship, or source bytes.
+
+export const DOMAIN_BRIEF_SCHEMA = 'domain-brief-v1' as const;
+
+/** A domain has at least one canonical surface and never an unbounded page count. */
+export const MIN_SURFACES = 1;
+export const MAX_SURFACES = 12;
+/** The real entities the domain manipulates (an ERP's purchase-order, invoice, stock item, …). */
+export const MAX_CORE_OBJECTS = 24;
+/** Per-role reference queries stay a focused acquisition list, never an unbounded crawl. */
+export const MIN_QUERIES_PER_ROLE = 1;
+export const MAX_QUERIES_PER_ROLE = 12;
+
+export type DomainSurface = {
+  /** Canonical surface name for the domain (e.g. "inventory dashboard", "purchase order detail"). */
+  readonly name: string;
+  /** What task the surface serves — one clause, not a paragraph. */
+  readonly purpose: string;
+};
+
+export type DomainReferenceQueries = {
+  /** Role ① — detailed component/section design queries good sites can answer. */
+  readonly component: readonly string[];
+  /** Role ② — motion / scroll-animation / sculptural craft queries for top-tier galleries. */
+  readonly craft: readonly string[];
+};
+
+export type DomainBrief = {
+  readonly schema: typeof DOMAIN_BRIEF_SCHEMA;
+  /** The raw request, normalized and trimmed — what the user actually asked. */
+  readonly request: string;
+  /** The identified domain in a few words ("ERP", "developer-tool marketing landing"). */
+  readonly domain: string;
+  /** One-line plain description of what this domain/product is and does. */
+  readonly summary: string;
+  /** The canonical surfaces (pages / screens / reachable states) this domain needs. */
+  readonly surfaces: readonly DomainSurface[];
+  /** The real objects the domain manipulates — its nouns, not UI widgets. */
+  readonly coreObjects: readonly string[];
+  /** Who the work is for — the audience whose task the design serves. */
+  readonly audience: string;
+  /** Reference acquisition queries for the scout, split by the two reference roles. */
+  readonly referenceQueries: DomainReferenceQueries;
+  /**
+   * True when the brief is backed by external research (a lookup of what the domain is and needs),
+   * false when it is honest inference from prior knowledge alone. Either is lawful; the flag records
+   * which, so a purely-inferred brief for an unfamiliar domain can be treated with due caution.
+   */
+  readonly researched: boolean;
+};
+
+export class DomainBriefError extends Error {
+  override readonly name = 'DomainBriefError';
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`domain brief is invalid: ${reason}`);
+    this.reason = reason;
+  }
+}
+
+const fail = (reason: string): never => { throw new DomainBriefError(reason); };
+
+const asRecord = (v: unknown, reason: string): Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : fail(reason);
+
+const asNonEmptyString = (v: unknown, reason: string): string =>
+  typeof v === 'string' && v.trim() !== '' ? v.trim() : fail(reason);
+
+function exactKeys(record: Record<string, unknown>, expected: readonly string[], reason: string): void {
+  const keys = Object.keys(record).sort();
+  const want = [...expected].sort();
+  if (keys.length !== want.length || keys.some((key, index) => key !== want[index])) fail(reason);
+}
+
+function asStringList(value: unknown, min: number, max: number, label: string): string[] {
+  const list: unknown[] = Array.isArray(value) ? value : fail(`${label} must be an array`);
+  if (list.length < min) fail(`${label} must have at least ${min} entr${min === 1 ? 'y' : 'ies'}`);
+  if (list.length > max) fail(`${label} is bounded to ${max} entries`);
+  const out = list.map((entry, index) => asNonEmptyString(entry, `${label}[${index}] must be a non-empty string`));
+  if (new Set(out.map((s) => s.toLowerCase())).size !== out.length) fail(`${label} must not repeat an entry`);
+  return out;
+}
+
+function validateSurface(value: unknown, index: number): DomainSurface {
+  const record = asRecord(value, `surfaces[${index}] must be an object`);
+  exactKeys(record, ['name', 'purpose'], `surfaces[${index}] has unknown or missing keys`);
+  return {
+    name: asNonEmptyString(record.name, `surfaces[${index}].name must be a non-empty string`),
+    purpose: asNonEmptyString(record.purpose, `surfaces[${index}].purpose must be a non-empty string`),
+  };
+}
+
+function validateReferenceQueries(value: unknown): DomainReferenceQueries {
+  const record = asRecord(value, 'referenceQueries must be an object');
+  exactKeys(record, ['component', 'craft'], 'referenceQueries has unknown or missing keys');
+  return {
+    component: asStringList(record.component, MIN_QUERIES_PER_ROLE, MAX_QUERIES_PER_ROLE, 'referenceQueries.component'),
+    craft: asStringList(record.craft, MIN_QUERIES_PER_ROLE, MAX_QUERIES_PER_ROLE, 'referenceQueries.craft'),
+  };
+}
+
+/**
+ * Validates a domain brief. Throws `DomainBriefError` on any violation. A valid brief names the
+ * domain, a one-line summary, a bounded set of canonical surfaces (each with a purpose), the domain's
+ * core objects, the audience, and per-role reference queries for both the component and craft roles.
+ */
+export function validateDomainBrief(value: unknown): DomainBrief {
+  const record = asRecord(value, 'brief must be an object');
+  exactKeys(
+    record,
+    ['audience', 'coreObjects', 'domain', 'referenceQueries', 'request', 'researched', 'schema', 'summary', 'surfaces'],
+    'brief has unknown or missing keys',
+  );
+  if (record.schema !== DOMAIN_BRIEF_SCHEMA) fail(`schema must be ${DOMAIN_BRIEF_SCHEMA}`);
+  const request = asNonEmptyString(record.request, 'request must be a non-empty string');
+  const domain = asNonEmptyString(record.domain, 'domain must be a non-empty string');
+  const summary = asNonEmptyString(record.summary, 'summary must be a non-empty string');
+
+  const rawSurfaces: unknown[] = Array.isArray(record.surfaces) ? record.surfaces : fail('surfaces must be an array');
+  if (rawSurfaces.length < MIN_SURFACES) fail(`surfaces must name at least ${MIN_SURFACES} canonical surface`);
+  if (rawSurfaces.length > MAX_SURFACES) fail(`surfaces is bounded to ${MAX_SURFACES} entries`);
+  const surfaces = rawSurfaces.map((surface, index) => validateSurface(surface, index));
+  if (new Set(surfaces.map((s) => s.name.toLowerCase())).size !== surfaces.length) fail('surfaces must not repeat a name');
+
+  const coreObjects = asStringList(record.coreObjects, 1, MAX_CORE_OBJECTS, 'coreObjects');
+  const audience = asNonEmptyString(record.audience, 'audience must be a non-empty string');
+  const referenceQueries = validateReferenceQueries(record.referenceQueries);
+  const researched: boolean = typeof record.researched === 'boolean' ? record.researched : fail('researched must be a boolean');
+
+  return {
+    schema: DOMAIN_BRIEF_SCHEMA,
+    request,
+    domain,
+    summary,
+    surfaces,
+    coreObjects,
+    audience,
+    referenceQueries,
+    researched,
+  };
+}

--- a/core/protocol/domain-analysis.md
+++ b/core/protocol/domain-analysis.md
@@ -1,0 +1,49 @@
+# Domain analysis
+
+The first step of a run, before framing. A raw request — "make me an ERP", "a landing page for
+this tool", "a booking app" — under-specifies the work: it names a goal but not the domain the goal
+lives in. Designing straight from the words produces a generic shape, because the harness is filling
+in an unexamined domain with the statistical mean of "a web page". This step examines the domain
+first, so every downstream step (framing, reference acquisition, composition) is grounded in what the
+thing actually is.
+
+## What it produces
+
+A single validated artifact, `.omd/domain-brief.json` (`domain-brief-v1`, `omd domain check`):
+
+- **domain** — the identified domain in a few words (`ERP`, `developer-tool marketing landing`).
+- **summary** — one plain line: what this domain/product is and does.
+- **surfaces** — the canonical pages / screens / reachable states this domain needs, each with the
+  task it serves. An ERP is not one page: it is an inventory dashboard, a purchase-order detail, an
+  approvals queue, a supplier list. A tool landing is a hero, a proof section, a pricing block. Name
+  them from the domain, not from a template.
+- **coreObjects** — the real objects the domain manipulates: its nouns, not UI widgets. An ERP's
+  purchase order, invoice, stock item, supplier. These are what the surfaces are *about*.
+- **audience** — who the work is for, whose task the design serves.
+- **referenceQueries** — the concrete search queries the scout will run, split by the two reference
+  roles (see `protocol/reference-assembly.md`):
+  - **component** — role ①: detailed section / component / button design to source from good
+    products ("dense data table with inline actions", "approval status pill").
+  - **craft** — role ②: motion, scroll animation, and sculptural/visual craft to source from
+    top-tier galleries ("awwwards dashboard scroll reveal", "fwa data-viz motion").
+- **researched** — true when the brief is backed by an external lookup of what the domain is and
+  needs, false when it is honest inference from prior knowledge alone. An unfamiliar domain
+  (a niche vertical, an acronym, a named product) must be researched, not guessed; a familiar one
+  may be inferred, but the flag records which so a guessed brief is treated with due caution.
+
+## How it is done
+
+Gather concurrently, never one lookup at a time (per the run's parallel-gathering rule). For an
+unfamiliar domain or a named product, actually look it up — what it is, what a competent instance of
+it contains, who uses it — before writing the brief. The brief is data only: it carries the domain
+facts and the acquisition queries, never rationale, authorship, or source bytes.
+
+## What it feeds
+
+- **frame** builds on the domain brief instead of on the raw words: the frame's subject, primary
+  task, and costliest error are chosen knowing the domain's surfaces and objects.
+- **the scout** runs `referenceQueries.component` and `referenceQueries.craft` as its two-role
+  acquisition list, so references are gathered for *this* domain's parts and *this* domain's craft,
+  not a generic crawl.
+
+The step never designs, scaffolds, or writes production code. It is understanding, recorded.

--- a/core/protocol/human-design-loop.md
+++ b/core/protocol/human-design-loop.md
@@ -3,7 +3,7 @@
 This is the durable contract for an OMD run. Host prompts may explain it, but may not
 reorder it:
 
-`preflight -> frame -> concept -> research -> writer copy deck -> copy check -> blind copy
+`preflight -> domain analysis -> frame -> concept -> research -> writer copy deck -> copy check -> blind copy
 edit -> preserve copy-eye report -> copy review-check -> writer revision -> copy check -> typesetter proof -> blind type review -> type
 revision/proof pass -> composition contract/check -> structural sketches -> blind selection -> production build ->
 semantic checkpoint -> selected-container type reproof -> visual checkpoint -> squint
@@ -20,6 +20,16 @@ strong products solve that same UX problem — the specific flow, state, or comp
 changes, rather than applying generic UX rules from memory alone.
 
 Every research or data-gathering step — the framer's subject research and cited-evidence gathering, the scout's reference, gallery, and domain research — issues its independent searches, captures, and lookups in parallel, not one at a time. A serial gathering pass is a defect to avoid: gather concurrently, then reconcile.
+
+## Domain analysis
+
+Before framing, the run analyzes the request's domain and records `.omd/domain-brief.json`
+(`domain-brief-v1`, validated by `omd domain check`). A raw request names a goal but under-specifies
+its domain; designing straight from the words yields a generic shape. This step identifies the
+domain, its canonical surfaces, its core objects, and its audience, and emits the scout's two-role
+reference queries (component design and top-tier craft). An unfamiliar domain or named product is
+researched, not guessed. It feeds the frame and the scout; it never designs or writes code. The full
+contract is `protocol/domain-analysis.md`.
 
 ## Stack routing
 
@@ -41,7 +51,7 @@ dependency, dependency-API, or configuration change; retain the full final verif
 
 ## State boundary
 
-Durable, reviewable state lives under `.omd/`: `frame.md`, `scout.md`, `copy-deck.md`,
+Durable, reviewable state lives under `.omd/`: `domain-brief.json`, `frame.md`, `scout.md`, `copy-deck.md`,
 `type-proof.md`, `composition.md`, `decisions.md`, `design.md`, `attribution.md`, `motion-spec.md`, `craft.jsonl`,
 `source-seal.json`, `task-evidence.json`, `task-evidence-runs/*.json`, `final-evidence.json`,
 `final-evidence-runs/<runId>.json`, `config.json`, `probes/*.json`, `refs/*.json`, and explicit

--- a/test/domain-brief.test.ts
+++ b/test/domain-brief.test.ts
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DOMAIN_BRIEF_SCHEMA,
+  DomainBriefError,
+  MAX_SURFACES,
+  MAX_QUERIES_PER_ROLE,
+  validateDomainBrief,
+} from '../core/domain/domain-brief.ts';
+
+function baseBrief() {
+  return {
+    schema: DOMAIN_BRIEF_SCHEMA,
+    request: '사내용 ERP 만들어줘',
+    domain: 'ERP',
+    summary: 'A business resource planner: inventory, purchasing, and accounting in one operational tool.',
+    surfaces: [
+      { name: 'inventory dashboard', purpose: 'see stock levels and low-stock alerts at a glance' },
+      { name: 'purchase order detail', purpose: 'create and track a purchase order through approval' },
+    ],
+    coreObjects: ['stock item', 'purchase order', 'invoice', 'supplier'],
+    audience: 'operations staff who work the tool all day',
+    referenceQueries: {
+      component: ['dense data table with inline actions', 'approval status pill'],
+      craft: ['awwwards dashboard scroll reveal', 'fwa data-viz motion'],
+    },
+    researched: true,
+  };
+}
+
+test('validateDomainBrief accepts a well-formed brief and trims/normalizes', () => {
+  const brief = validateDomainBrief({ ...baseBrief(), domain: '  ERP  ' });
+  assert.equal(brief.schema, 'domain-brief-v1');
+  assert.equal(brief.domain, 'ERP');
+  assert.equal(brief.surfaces.length, 2);
+  assert.equal(brief.referenceQueries.craft.length, 2);
+  assert.equal(brief.researched, true);
+});
+
+test('validateDomainBrief rejects a wrong schema', () => {
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), schema: 'domain-brief-v2' }), DomainBriefError);
+});
+
+test('validateDomainBrief rejects unknown or missing keys', () => {
+  const extra = { ...baseBrief(), extra: 1 };
+  assert.throws(() => validateDomainBrief(extra), /unknown or missing keys/);
+  const { audience: _drop, ...missing } = baseBrief();
+  assert.throws(() => validateDomainBrief(missing), /unknown or missing keys/);
+});
+
+test('validateDomainBrief requires at least one surface, each with name and purpose', () => {
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), surfaces: [] }), /at least/);
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), surfaces: [{ name: 'x' }] }), /unknown or missing keys/);
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), surfaces: [{ name: '', purpose: 'y' }] }), /non-empty string/);
+});
+
+test('validateDomainBrief bounds surface count and rejects duplicate surface names', () => {
+  const many = Array.from({ length: MAX_SURFACES + 1 }, (_u, i) => ({ name: `s${i}`, purpose: 'p' }));
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), surfaces: many }), /bounded to/);
+  const dup = [{ name: 'Home', purpose: 'a' }, { name: 'home', purpose: 'b' }];
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), surfaces: dup }), /repeat a name/);
+});
+
+test('validateDomainBrief requires both reference roles to carry queries', () => {
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), referenceQueries: { component: [], craft: ['x'] } }), /component must have at least/);
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), referenceQueries: { craft: ['x'] } }), /unknown or missing keys/);
+  const tooMany = Array.from({ length: MAX_QUERIES_PER_ROLE + 1 }, (_u, i) => `q${i}`);
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), referenceQueries: { component: tooMany, craft: ['x'] } }), /bounded to/);
+});
+
+test('validateDomainBrief requires researched to be a boolean and coreObjects non-empty', () => {
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), researched: 'yes' }), /researched must be a boolean/);
+  assert.throws(() => validateDomainBrief({ ...baseBrief(), coreObjects: [] }), /at least/);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -640,3 +640,19 @@ test('craft names smooth in-page navigation with a reduced-motion fallback', () 
   assert.match(craft, /scroll-behavior: smooth[\s\S]*scrollIntoView\(\{ behavior: 'smooth'/i);
   assert.match(craft, /Under `prefers-reduced-motion: reduce` it reverts to an instant jump/i);
 });
+test('the loop runs domain analysis before framing and records domain-brief.json', () => {
+  const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
+  assert.match(loop, /preflight -> domain analysis -> frame/);
+  assert.match(loop, /## Domain analysis/);
+  assert.match(loop, /records `\.omd\/domain-brief\.json`[\s\S]*`domain-brief-v1`[\s\S]*`omd domain check`/i);
+  assert.match(loop, /two-role reference queries \(component design and top-tier craft\)/i);
+  assert.match(loop, /Durable, reviewable state lives under `\.omd\/`: `domain-brief\.json`/);
+});
+test('the domain-analysis contract names both reference roles and the feeds', () => {
+  const doc = read('core/protocol/domain-analysis.md').replace(/\s+/g, ' ');
+  assert.match(doc, /\*\*component\*\* — role ①/i);
+  assert.match(doc, /\*\*craft\*\* — role ②/i);
+  assert.match(doc, /top-tier galleries/i);
+  assert.match(doc, /It feeds the frame and the scout|feeds[\s\S]*frame[\s\S]*scout/i);
+  assert.match(doc, /never designs.*writes? (?:production )?code|never designs, scaffolds, or writes production code/i);
+});


### PR DESCRIPTION
## Why
A raw request (`make me an ERP`, `a landing for this tool`) names a **goal** but under-specifies its **domain**. Designing straight from the words yields the generic mean — the harness fills an unexamined domain with the statistical average of "a web page". This adds the missing first step: **understand the domain, then design.**

## What it produces
A validated `.omd/domain-brief.json` (`domain-brief-v1`, `omd domain check`):
- **domain / summary / audience** — what the thing is and who it's for.
- **surfaces** — the canonical pages/screens the domain needs, each with its task (an ERP is an inventory dashboard + PO detail + approvals queue, not one page).
- **coreObjects** — the domain's real nouns (purchase order, invoice, stock item), not UI widgets.
- **referenceQueries** — the scout's acquisition queries, **split by the two reference roles**: `component` (detailed section/button design) and `craft` (motion/scroll/sculptural from Awwwards/theFWA). This is the bridge from domain understanding to reference acquisition.
- **researched** — true when an external lookup backed it (required for an unfamiliar domain), false when honest inference.

## Wiring
- `core/domain/domain-brief.ts` — validator (exact keys, bounded, both roles non-empty, no dupes).
- `omd domain check` — schema lint, exit 1 on invalid.
- `human-design-loop.md` — canonical order becomes `preflight -> domain analysis -> frame`; new **Domain analysis** section; `domain-brief.json` listed durable; full contract in `protocol/domain-analysis.md`.
- Feeds the frame and the scout; never designs or writes code.

## Validation
domain-brief + prompt-contract **52/52** (validator positive/negative: bounds, dup names, both-roles, boolean narrowing; loop order + contract wiring); `omd domain check` ok/fail smoke verified; typecheck + build clean; diff --check clean. First of a series (domain step → fragment-scoped references (2 roles) → craft verification gate). No release.