### PR TITLE
feat: reference role ② (craft) is measured and its reproduction is gated (the how-gap)

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -23,6 +23,7 @@ import { checkTaskEvidence, publishTaskEvidence } from '../core/evidence/task.ts
 import { computeStack } from '../core/stack/index.ts';
 import { scanTextSlop } from '../core/slop/text-slop.ts';
 import { validateDomainBrief } from '../core/domain/domain-brief.ts';
+import { validateReferenceCraft, verifyCraftReproduction } from '../core/ref/reference-craft.ts';
 import { evaluateLighthouse, type LighthouseBudget } from '../core/perf/lighthouse.ts';
 import { evaluateVisualRichness } from '../core/composition-contract/visual-richness.ts';
 import type { VisualRichnessRegister } from '../core/composition-contract/visual-richness.ts';
@@ -1581,6 +1582,25 @@ function cmdDomain(mode: string | undefined, opts: Opts): never {
   process.exit(0);
 }
 
+/** Verifies a generated part actually reproduced the craft of the reference it claims (the how-gap gate). */
+function cmdCraftFidelity(mode: string | undefined, opts: Opts): never {
+  if (mode !== 'check' || !opts.input) throw new Error('usage: omd craft-fidelity check --input <pair.json>  ({ reference, generated } reference-craft-v1 records) [--json]');
+  const payload = inputJson(opts.input, 'omd craft-fidelity check');
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) throw new Error('omd craft-fidelity check input must be an object with `reference` and `generated`');
+  const { reference, generated } = payload as Record<string, unknown>;
+  try {
+    const result = verifyCraftReproduction(validateReferenceCraft(reference), validateReferenceCraft(generated));
+    if (opts.json) process.stdout.write(JSON.stringify(result));
+    else console.log(`ok — reproduction reproduced the reference craft (energy ratio ${result.energyRatio})`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (opts.json) process.stdout.write(JSON.stringify({ ok: false, error: message }));
+    else console.error(`[error] ${message}`);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
 /** Final byte-freshness evidence only; this does not judge semantic copy/source fidelity. */
 function cmdSource(mode: string | undefined, opts: Opts): never {
   const sourceRoot = resolve(opts._[0] ?? process.cwd());
@@ -2496,6 +2516,7 @@ function usage(): never {
     + '  art-direction check --input decision-check.json [--json]  persist the canonical selected direction before composition\n'
     + '  intent append --input trusted-intent.json [--json]  append trusted intent and update its guarded current pointer\n'
     + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
+    + '  craft-fidelity check --input pair.json [--json]  verify a generated part reproduced the reference craft\n'
     + '  preflight --input activation-context.json [--json]  read-only activation validation\n'
     + '  text-slop [file] [--json]                   advisory AI-cliche scan of copy (default .omd/copy-deck.md)\n'
     + '  visual-richness [file] [--register R] [--json]  advisory carrier read of composition (default .omd/composition.md)\n'
@@ -2613,6 +2634,7 @@ async function main(): Promise<never> {
   }
   if (cmd === 'intent') return cmdIntent(sub, parseArgs(args.slice(2)));
   if (cmd === 'domain') return cmdDomain(sub, parseArgs(args.slice(2)));
+  if (cmd === 'craft-fidelity') return cmdCraftFidelity(sub, parseArgs(args.slice(2)));
   if (cmd === 'stack') return cmdStack(parseArgs(args.slice(1)));
   if (cmd === 'text-slop') return cmdTextSlop(parseArgs(args.slice(1)));
   if (cmd === 'visual-richness') return cmdVisualRichness(parseArgs(args.slice(1)));

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -23,6 +23,24 @@ new agent, service, provider, or runtime.
 | production usage ledger | `omd-hand` | Passing v2 selection, current motion-resolution projection, decision-bound composer and hand receipts, actual production source/render/probe evidence, and attribution | Durable `.omd/reference-usage-v2.json` with exactly one `used`, `rejected`, or `anti-reference` row for every selected slot | `recordReferenceUsage(root, { rows }, writer)` then `validateReferenceUsage(root)` | Missing, unselected, duplicate, or unsupported rows, stale selection/motion/receipt bindings, or absent production evidence stop finalization. Do not replace real evidence with a claimed influence. |
 | final provenance report | `finalizer` | A passing v2 usage ledger, current v2 selection, decision-bound handoffs, and `.omd/attribution.md` | Durable `.omd/reference-report.md` and the exact deterministic bilingual Markdown pasted into the final chat | `generateReferenceReport(root)` validates usage and atomically persists the returned Markdown | Any validation failure stops the final report. Do not hand-write, paraphrase, or claim a replacement report; repair the owning earlier stage and regenerate. |
 
+## Reference roles
+
+Every reference serves one of two roles, and the domain brief's `referenceQueries` seed both:
+
+- **① component design** — a detailed section, component, or button whose *structure* is the value.
+  It is captured as a scoped measured record (`omd ref add … --selector … --blueprint --shot`): the
+  captured part's own values, never a whole-page average. This is a static structure a build can copy.
+- **② craft** — the motion, scroll animation, and sculptural moment that top-tier galleries
+  (Awwwards, theFWA) are known for. This role cannot be copied by looking: seeing the effect does not
+  give the build the skill to make it, so a reproduction tends to degrade into a static ghost. It is
+  therefore MEASURED, not asserted, as a `reference-craft-v1` motion signature — peak pixel-energy
+  (`core/motion/energy.ts`), whether it is scroll-linked, and whether it keeps a reduced-motion
+  baseline — and its reproduction is GATED by `verifyCraftReproduction` (`omd craft-fidelity check`):
+  the built part must actually move (energy above the floor and within the reference's fidelity
+  ratio), preserve a scroll-linked reference's scroll response, and be reduced-motion safe. A static,
+  faint, or scroll-dropping reproduction fails — the craft reference does not pass just because a
+  generation was attempted. This is how the "seeing is not building" gap is closed with evidence.
+
 ## Subject anchor
 
 When the brief names a real, existing subject — a product, project, company, repository, or brand, or supplies its link — the scout's fragment-inventory stage first establishes what that subject actually is (a web search plus the linked repository/README and any wordmark or brand the source already ships) and fixes the subject's own identity anchor: its real palette and motif. This anchor is not one measured reference among many; it governs the colour and motif every other lane serves, and is never outvoted by category evidence. A palette or motif taken from the product category's default instead of the subject's own identity is a rejected, not a shippable, synthesis.

--- a/core/ref/reference-craft.ts
+++ b/core/ref/reference-craft.ts
@@ -1,0 +1,157 @@
+// Reference role ② — craft — measured and verifiable.
+//
+// A reference serves two roles (see `protocol/reference-assembly.md`): role ① is detailed component
+// design (structure, captured by a scoped blueprint); role ② is CRAFT — the motion, scroll animation,
+// and sculptural moment that top-tier work is actually known for. Role ① is a static structure you can
+// copy. Role ② cannot be copied by looking: seeing an award site's scroll-scrubbed shader does not give
+// the generator the skill to build it, so a reproduction tends to degrade into a static ghost of the
+// original. This module closes that how-gap by MEASURING craft instead of asserting it.
+//
+// A `reference-craft-v1` record is the measured motion signature of one scoped reference part:
+// its peak pixel-energy (from `computeEnergy` over real screenshots), whether it is scroll-linked,
+// and whether it keeps a reduced-motion baseline. `verifyCraftReproduction` then gates a generated
+// part against the reference it claims to reproduce: the reproduction must actually move
+// (energy above an absolute floor AND within a fidelity ratio of the reference), must preserve a
+// scroll-linked reference's scroll response, and must itself be reduced-motion safe. A degraded,
+// static, or scroll-dropping reproduction fails — the reference does not pass just because a
+// generation was attempted.
+
+export const REFERENCE_CRAFT_SCHEMA = 'reference-craft-v1' as const;
+
+/** A reproduction must move: its peak energy must clear this absolute floor (fraction of pixels). */
+export const CRAFT_ENERGY_FLOOR = 0.01;
+/** And it must reach at least this fraction of the reference's measured energy — not a faint ghost. */
+export const CRAFT_ENERGY_RATIO = 0.6;
+
+export type CraftMotion = {
+  /** Peak per-interval pixel-change energy of the scoped part, 0..1 (see `core/motion/energy.ts`). */
+  readonly peakEnergy: number;
+  /** True when the part's rendered state responds to scroll position (a reveal, parallax, scrub). */
+  readonly scrollLinked: boolean;
+  /** True when the part keeps a complete, functional baseline under `prefers-reduced-motion: reduce`. */
+  readonly reducedMotionSafe: boolean;
+};
+
+export type ReferenceCraft = {
+  readonly schema: typeof REFERENCE_CRAFT_SCHEMA;
+  /** Sanitized reference id / source — no rationale, authorship, or raw bytes. */
+  readonly source: string;
+  /** Slug the reference is filed under. */
+  readonly as: string;
+  /** The CSS selector that scoped this capture — proof it measures ONE part, not a whole page. */
+  readonly selector: string;
+  readonly viewport: { readonly width: number; readonly height: number };
+  readonly motion: CraftMotion;
+  /** The named technique the craft uses, e.g. "scroll-scrubbed shader gradient". */
+  readonly technique: string;
+};
+
+export class ReferenceCraftError extends Error {
+  override readonly name = 'ReferenceCraftError';
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`reference craft is invalid: ${reason}`);
+    this.reason = reason;
+  }
+}
+
+export class CraftFidelityError extends Error {
+  override readonly name = 'CraftFidelityError';
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`craft reproduction failed: ${reason}`);
+    this.reason = reason;
+  }
+}
+
+const fail = (reason: string): never => { throw new ReferenceCraftError(reason); };
+
+const asRecord = (v: unknown, reason: string): Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : fail(reason);
+const asNonEmptyString = (v: unknown, reason: string): string =>
+  typeof v === 'string' && v.trim() !== '' ? v.trim() : fail(reason);
+const asBool = (v: unknown, reason: string): boolean =>
+  typeof v === 'boolean' ? v : fail(reason);
+
+function exactKeys(record: Record<string, unknown>, expected: readonly string[], reason: string): void {
+  const keys = Object.keys(record).sort();
+  const want = [...expected].sort();
+  if (keys.length !== want.length || keys.some((key, index) => key !== want[index])) fail(reason);
+}
+
+function validateMotion(value: unknown): CraftMotion {
+  const record = asRecord(value, 'motion must be an object');
+  exactKeys(record, ['peakEnergy', 'reducedMotionSafe', 'scrollLinked'], 'motion has unknown or missing keys');
+  const peakEnergy = record.peakEnergy;
+  if (typeof peakEnergy !== 'number' || !Number.isFinite(peakEnergy) || peakEnergy < 0 || peakEnergy > 1) {
+    return fail('motion.peakEnergy must be a number within [0, 1]');
+  }
+  return {
+    peakEnergy,
+    scrollLinked: asBool(record.scrollLinked, 'motion.scrollLinked must be a boolean'),
+    reducedMotionSafe: asBool(record.reducedMotionSafe, 'motion.reducedMotionSafe must be a boolean'),
+  };
+}
+
+function validateViewport(value: unknown): { width: number; height: number } {
+  const record = asRecord(value, 'viewport must be an object');
+  exactKeys(record, ['height', 'width'], 'viewport has unknown or missing keys');
+  const width = record.width;
+  const height = record.height;
+  if (typeof width !== 'number' || !Number.isInteger(width) || width <= 0) fail('viewport.width must be a positive integer');
+  if (typeof height !== 'number' || !Number.isInteger(height) || height <= 0) fail('viewport.height must be a positive integer');
+  return { width: width as number, height: height as number };
+}
+
+/** Validates a `reference-craft-v1` record. Throws `ReferenceCraftError` on any violation. */
+export function validateReferenceCraft(value: unknown): ReferenceCraft {
+  const record = asRecord(value, 'record must be an object');
+  exactKeys(record, ['as', 'motion', 'schema', 'selector', 'source', 'technique', 'viewport'], 'record has unknown or missing keys');
+  if (record.schema !== REFERENCE_CRAFT_SCHEMA) fail(`schema must be ${REFERENCE_CRAFT_SCHEMA}`);
+  return {
+    schema: REFERENCE_CRAFT_SCHEMA,
+    source: asNonEmptyString(record.source, 'source must be a non-empty string'),
+    as: asNonEmptyString(record.as, 'as must be a non-empty string'),
+    selector: asNonEmptyString(record.selector, 'selector must be a non-empty string'),
+    viewport: validateViewport(record.viewport),
+    motion: validateMotion(record.motion),
+    technique: asNonEmptyString(record.technique, 'technique must be a non-empty string'),
+  };
+}
+
+export type CraftFidelityResult = {
+  readonly ok: true;
+  /** Reproduction energy as a fraction of the reference's energy. */
+  readonly energyRatio: number;
+};
+
+/**
+ * Gates a generated part against the reference craft it claims to reproduce. Both are validated
+ * `reference-craft-v1` records. Throws `CraftFidelityError` when the reproduction is a degraded ghost
+ * (energy below the absolute floor or below the fidelity ratio of the reference), drops a scroll-linked
+ * reference's scroll response, or is not itself reduced-motion safe. Returns the measured energy ratio
+ * on success. Seeing the reference is not reproducing it; only a measured match passes.
+ */
+export function verifyCraftReproduction(reference: ReferenceCraft, generated: ReferenceCraft): CraftFidelityResult {
+  const ref = validateReferenceCraft(reference);
+  const gen = validateReferenceCraft(generated);
+
+  if (gen.motion.peakEnergy < CRAFT_ENERGY_FLOOR) {
+    throw new CraftFidelityError(
+      `reproduction is static: peak energy ${gen.motion.peakEnergy} is below the ${CRAFT_ENERGY_FLOOR} floor — the craft was not built, only approximated`,
+    );
+  }
+  const energyRatio = ref.motion.peakEnergy > 0 ? gen.motion.peakEnergy / ref.motion.peakEnergy : 1;
+  if (energyRatio < CRAFT_ENERGY_RATIO) {
+    throw new CraftFidelityError(
+      `reproduction is a faint ghost: ${gen.motion.peakEnergy} is ${energyRatio.toFixed(2)}× the reference's ${ref.motion.peakEnergy}, below the ${CRAFT_ENERGY_RATIO} fidelity ratio`,
+    );
+  }
+  if (ref.motion.scrollLinked && !gen.motion.scrollLinked) {
+    throw new CraftFidelityError('reproduction dropped the reference\'s scroll-linked response');
+  }
+  if (!gen.motion.reducedMotionSafe) {
+    throw new CraftFidelityError('reproduction has no reduced-motion baseline — motion craft may never gate content');
+  }
+  return { ok: true, energyRatio: Math.round(energyRatio * 10000) / 10000 };
+}

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -656,3 +656,12 @@ test('the domain-analysis contract names both reference roles and the feeds', ()
   assert.match(doc, /It feeds the frame and the scout|feeds[\s\S]*frame[\s\S]*scout/i);
   assert.match(doc, /never designs.*writes? (?:production )?code|never designs, scaffolds, or writes production code/i);
 });
+test('reference-assembly names the two roles and gates role-② craft by measured reproduction', () => {
+  const ra = read('core/protocol/reference-assembly.md').replace(/\s+/g, ' ');
+  assert.match(ra, /## Reference roles/);
+  assert.match(ra, /\*\*① component design\*\*/);
+  assert.match(ra, /\*\*② craft\*\*/);
+  assert.match(ra, /`reference-craft-v1` motion signature/);
+  assert.match(ra, /GATED by `verifyCraftReproduction` \(`omd craft-fidelity check`\)/);
+  assert.match(ra, /static, faint, or scroll-dropping reproduction fails/i);
+});

--- a/test/reference-craft.test.ts
+++ b/test/reference-craft.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  REFERENCE_CRAFT_SCHEMA,
+  ReferenceCraftError,
+  CraftFidelityError,
+  CRAFT_ENERGY_FLOOR,
+  validateReferenceCraft,
+  verifyCraftReproduction,
+} from '../core/ref/reference-craft.ts';
+
+function craft(overrides = {}) {
+  return {
+    schema: REFERENCE_CRAFT_SCHEMA,
+    source: 'awwwards.com/sites/example',
+    as: 'hero-scroll',
+    selector: '.hero',
+    viewport: { width: 1440, height: 900 },
+    motion: { peakEnergy: 0.4, scrollLinked: true, reducedMotionSafe: true },
+    technique: 'scroll-scrubbed shader gradient',
+    ...overrides,
+  };
+}
+
+test('validateReferenceCraft accepts a well-formed craft signature and trims', () => {
+  const c = validateReferenceCraft(craft({ source: '  awwwards.com/x  ' }));
+  assert.equal(c.schema, 'reference-craft-v1');
+  assert.equal(c.source, 'awwwards.com/x');
+  assert.equal(c.selector, '.hero');
+  assert.equal(c.motion.scrollLinked, true);
+});
+
+test('validateReferenceCraft rejects schema, key, energy-range, and viewport violations', () => {
+  assert.throws(() => validateReferenceCraft(craft({ schema: 'reference-craft-v2' })), ReferenceCraftError);
+  assert.throws(() => validateReferenceCraft({ ...craft(), extra: 1 }), /unknown or missing keys/);
+  assert.throws(() => validateReferenceCraft(craft({ motion: { peakEnergy: 1.4, scrollLinked: true, reducedMotionSafe: true } })), /within \[0, 1\]/);
+  assert.throws(() => validateReferenceCraft(craft({ selector: '' })), /non-empty string/);
+  assert.throws(() => validateReferenceCraft(craft({ viewport: { width: 0, height: 900 } })), /viewport.width must be a positive integer/);
+});
+
+test('verifyCraftReproduction passes when the reproduction moves comparably and keeps scroll + reduced-motion', () => {
+  const result = verifyCraftReproduction(craft(), craft({ motion: { peakEnergy: 0.38, scrollLinked: true, reducedMotionSafe: true } }));
+  assert.equal(result.ok, true);
+  assert.ok(result.energyRatio >= 0.6 && result.energyRatio <= 1);
+});
+
+test('verifyCraftReproduction rejects a static reproduction (energy below the floor)', () => {
+  const gen = craft({ motion: { peakEnergy: CRAFT_ENERGY_FLOOR / 2, scrollLinked: true, reducedMotionSafe: true } });
+  assert.throws(() => verifyCraftReproduction(craft(), gen), (e) => e instanceof CraftFidelityError && /static/.test(e.message));
+});
+
+test('verifyCraftReproduction rejects a faint ghost (below the fidelity ratio of the reference)', () => {
+  // reference 0.4, reproduction 0.1 -> ratio 0.25 < 0.6
+  const gen = craft({ motion: { peakEnergy: 0.1, scrollLinked: true, reducedMotionSafe: true } });
+  assert.throws(() => verifyCraftReproduction(craft(), gen), (e) => e instanceof CraftFidelityError && /faint ghost/.test(e.message));
+});
+
+test('verifyCraftReproduction rejects dropping a scroll-linked response or the reduced-motion baseline', () => {
+  const noScroll = craft({ motion: { peakEnergy: 0.4, scrollLinked: false, reducedMotionSafe: true } });
+  assert.throws(() => verifyCraftReproduction(craft(), noScroll), /dropped the reference's scroll-linked/);
+  const noReduce = craft({ motion: { peakEnergy: 0.4, scrollLinked: true, reducedMotionSafe: false } });
+  assert.throws(() => verifyCraftReproduction(craft(), noReduce), /no reduced-motion baseline/);
+});
+
+test('verifyCraftReproduction does not require scroll when the reference is not scroll-linked', () => {
+  const ref = craft({ motion: { peakEnergy: 0.3, scrollLinked: false, reducedMotionSafe: true } });
+  const gen = craft({ motion: { peakEnergy: 0.3, scrollLinked: false, reducedMotionSafe: true } });
+  assert.equal(verifyCraftReproduction(ref, gen).ok, true);
+});


### PR DESCRIPTION
## The gap
A reference serves **two roles**. Role ① (component design) is a static structure a build can copy — already captured as a scoped blueprint/shot. Role ② (**craft**: the motion, scroll animation, sculptural moment top-tier galleries are known for) **cannot be copied by looking** — seeing an award site's scroll-scrubbed shader does not give the generator the skill to build it, so a reproduction degrades into a static ghost. Seeing the target does not confer the ability to hit it. This closes that **how-gap by measuring craft, not asserting it.**

## What ships
- **`core/ref/reference-craft.ts`** — `reference-craft-v1`: a scoped part's **measured motion signature** (peak pixel-energy from `core/motion/energy.ts`, scroll-linked, reduced-motion-safe) + named technique + the selector proving it is one part, not a whole page.
- **`verifyCraftReproduction`** gates a generated part against the reference it claims: the build must **actually move** (energy above an absolute floor AND within the reference's **fidelity ratio** — not a faint ghost), **preserve** a scroll-linked reference's scroll response, and be **reduced-motion safe**.
- **`omd craft-fidelity check --input pair.json`** runs the gate (exit 1 on failure).
- **`reference-assembly.md`** names the two roles and binds role-② to this measured gate: a static, faint, or scroll-dropping reproduction **fails** — the craft reference does not pass just because a generation was attempted.

## Validation
reference-craft + prompt-contract + domain-brief **60/60** (validator positive/negative incl. energy range + viewport; fidelity pass, static-floor, faint-ghost, scroll-drop, reduced-motion, non-scroll reference; protocol wiring); `omd craft-fidelity` smoke rejects a ghost (exit 1); typecheck + build clean; diff --check clean. Second of the series (domain #131 → craft gate → fragment/role capture). No release.