### PR TITLE
feat: measure reference role-② craft from a real browser (omd craft-capture)

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -63,6 +63,7 @@ interface Opts {
   to?: string;
   because?: string;
   as?: string;
+  technique?: string;
   add?: string;
   noLog?: boolean;
   /** Skip the energy (motion) capture on `omd ref add` — one fewer browser launch for non-motion refs. */
@@ -1601,6 +1602,26 @@ function cmdCraftFidelity(mode: string | undefined, opts: Opts): never {
   process.exit(0);
 }
 
+/** Measures a `reference-craft-v1` from a real browser (role ② craft acquisition). */
+async function cmdCraftCapture(opts: Opts): Promise<never> {
+  const target = opts._[0];
+  if (!target || !opts.as || !opts.technique) {
+    throw new Error('usage: omd craft-capture <url|file> --as <slug> --technique "<name>" [--selector <css>] [--viewport WxH] [--json]');
+  }
+  const { parseViewport } = await import('../core/render/index.ts');
+  const { captureReferenceCraft } = await import('../core/ref/reference-craft-capture.ts');
+  const craft = await captureReferenceCraft(target, {
+    source: target,
+    as: opts.as,
+    technique: opts.technique,
+    selector: opts.selector ?? null,
+    viewport: parseViewport(opts.viewport ?? '1440x900'),
+  });
+  if (opts.json) process.stdout.write(JSON.stringify(craft));
+  else console.log(`${craft.as}: peakEnergy ${craft.motion.peakEnergy}, scrollLinked ${craft.motion.scrollLinked}, reducedMotionSafe ${craft.motion.reducedMotionSafe} (${craft.technique})`);
+  process.exit(0);
+}
+
 /** Final byte-freshness evidence only; this does not judge semantic copy/source fidelity. */
 function cmdSource(mode: string | undefined, opts: Opts): never {
   const sourceRoot = resolve(opts._[0] ?? process.cwd());
@@ -2517,6 +2538,7 @@ function usage(): never {
     + '  intent append --input trusted-intent.json [--json]  append trusted intent and update its guarded current pointer\n'
     + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
     + '  craft-fidelity check --input pair.json [--json]  verify a generated part reproduced the reference craft\n'
+    + '  craft-capture <url> --as <slug> --technique "<t>" [--selector <css>] [--viewport WxH] [--json]  measure a reference-craft-v1 from a real browser\n'
     + '  preflight --input activation-context.json [--json]  read-only activation validation\n'
     + '  text-slop [file] [--json]                   advisory AI-cliche scan of copy (default .omd/copy-deck.md)\n'
     + '  visual-richness [file] [--register R] [--json]  advisory carrier read of composition (default .omd/composition.md)\n'
@@ -2635,6 +2657,7 @@ async function main(): Promise<never> {
   if (cmd === 'intent') return cmdIntent(sub, parseArgs(args.slice(2)));
   if (cmd === 'domain') return cmdDomain(sub, parseArgs(args.slice(2)));
   if (cmd === 'craft-fidelity') return cmdCraftFidelity(sub, parseArgs(args.slice(2)));
+  if (cmd === 'craft-capture') return cmdCraftCapture(parseArgs(args.slice(1)));
   if (cmd === 'stack') return cmdStack(parseArgs(args.slice(1)));
   if (cmd === 'text-slop') return cmdTextSlop(parseArgs(args.slice(1)));
   if (cmd === 'visual-richness') return cmdVisualRichness(parseArgs(args.slice(1)));

--- a/core/ref/reference-craft-capture.ts
+++ b/core/ref/reference-craft-capture.ts
@@ -1,0 +1,155 @@
+// Produces a `reference-craft-v1` record from real-browser OBSERVATION, so a craft signature is
+// measured, never hand-asserted. It mirrors the scroll-scene capture's proven primitives
+// (`computeEnergy` over viewport screenshots, `waitForDocumentFonts`, a fresh reduced-motion page)
+// but measures the two things role ② craft is about:
+//
+//   1. does the part MOVE — peak pixel-energy over time at load, and over time right after the part
+//      is scrolled into view (a reveal-on-entry animation still resolving);
+//   2. is it SCROLL-LINKED — either the part (or a descendant) drives a CSS scroll timeline
+//      (`animation-timeline: scroll()/view()`), or scrolling it into view produced reveal energy.
+//
+// It also records whether the part keeps a baseline under reduced motion (content present). The
+// result is a validated `reference-craft-v1`; `verifyCraftReproduction` then gates a build against it.
+
+import { pathToFileURL } from 'node:url';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { computeEnergy } from '../motion/energy.ts';
+import { waitForDocumentFonts } from '../render/index.ts';
+import {
+  CRAFT_ENERGY_FLOOR,
+  REFERENCE_CRAFT_SCHEMA,
+  validateReferenceCraft,
+  type ReferenceCraft,
+} from './reference-craft.ts';
+
+const DEFAULT_SETTLE_INTERVAL_MS = 240;
+
+export type ReferenceCraftCaptureOptions = {
+  /** Sanitized reference id / source recorded on the result. */
+  readonly source: string;
+  /** Slug the reference is filed under. */
+  readonly as: string;
+  /** The named technique observed (the scout names what it is capturing). */
+  readonly technique: string;
+  readonly viewport: { readonly width: number; readonly height: number };
+  /** CSS selector scoping the captured part; when absent the whole document is measured. */
+  readonly selector?: string | null;
+  readonly settleIntervalMs?: number;
+};
+
+function toUrl(target: string): string {
+  if (/^https?:\/\//.test(target)) return target;
+  const path = resolve(target);
+  if (!existsSync(path)) throw new Error(`no such page: ${target}`);
+  return pathToFileURL(path).href;
+}
+
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Two animation frames so a scroll or reveal settles before a capture. */
+async function settleFrames(page: import('playwright').Page): Promise<void> {
+  await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))));
+}
+
+/** True when the scoped subtree (or the document) drives a CSS scroll/view timeline. */
+async function usesScrollTimeline(page: import('playwright').Page, selector: string | null): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const root: ParentNode = sel ? (document.querySelector(sel) ?? document) : document;
+    const scope = sel && document.querySelector(sel) ? [document.querySelector(sel)!, ...Array.from(root.querySelectorAll('*'))] : Array.from(document.querySelectorAll('*'));
+    for (const el of scope) {
+      const timeline = getComputedStyle(el as Element).getPropertyValue('animation-timeline').trim();
+      if (timeline && timeline !== 'auto' && timeline !== 'none') return true;
+    }
+    return false;
+  }, selector);
+}
+
+async function scrollIntoView(page: import('playwright').Page, selector: string | null): Promise<void> {
+  await page.evaluate((sel) => {
+    const el = sel ? document.querySelector(sel) : null;
+    if (el) el.scrollIntoView({ block: 'center', behavior: 'instant' as ScrollBehavior });
+    else {
+      const max = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      window.scrollTo({ top: Math.round(max * 0.5), left: 0, behavior: 'instant' as ScrollBehavior });
+    }
+  }, selector);
+}
+
+async function partHasContent(page: import('playwright').Page, selector: string | null): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const el = (sel ? document.querySelector(sel) : document.body) as HTMLElement | null;
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const hasBox = rect.width > 1 && rect.height > 1;
+    const hasText = (el.textContent ?? '').trim().length > 0;
+    const hasMedia = el.querySelector('img, svg, canvas, video, picture') !== null;
+    return hasBox && (hasText || hasMedia);
+  }, selector);
+}
+
+/**
+ * Observes a real browser and returns a validated `reference-craft-v1` for one scoped part.
+ * Measures peak motion energy at load and on scroll-into-view, classifies scroll-linkage from a CSS
+ * scroll timeline or observed reveal energy, and records whether the part keeps a reduced-motion
+ * baseline. Throws on a malformed viewport/selector or an absent target.
+ */
+export async function captureReferenceCraft(target: string, opts: ReferenceCraftCaptureOptions): Promise<ReferenceCraft> {
+  const interval = Math.max(1, Math.floor(opts.settleIntervalMs ?? DEFAULT_SETTLE_INTERVAL_MS));
+  const viewport = { width: opts.viewport.width, height: opts.viewport.height };
+  const selector = opts.selector ?? null;
+  const url = toUrl(target);
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({ viewport });
+    await page.goto(url, { waitUntil: 'networkidle' });
+    await waitForDocumentFonts(page);
+
+    // 1. Load-window motion: does the part animate at rest, at the top of the page, over time?
+    await page.evaluate(() => window.scrollTo({ top: 0, left: 0, behavior: 'instant' as ScrollBehavior }));
+    await settleFrames(page);
+    const loadA = await page.screenshot({ fullPage: false });
+    await wait(interval);
+    const loadB = await page.screenshot({ fullPage: false });
+    const loadEnergy = computeEnergy([loadA, loadB]).peakEnergy;
+
+    // 2. Reveal-on-entry motion: scroll the part into view, then measure time-energy as it resolves.
+    await scrollIntoView(page, selector);
+    const revealA = await page.screenshot({ fullPage: false });
+    await wait(interval);
+    const revealB = await page.screenshot({ fullPage: false });
+    const revealEnergy = computeEnergy([revealA, revealB]).peakEnergy;
+
+    const scrollTimeline = await usesScrollTimeline(page, selector);
+    const scrollLinked = scrollTimeline || revealEnergy >= CRAFT_ENERGY_FLOOR;
+    const peakEnergy = Math.min(1, Math.max(loadEnergy, revealEnergy));
+
+    // 3. Reduced-motion baseline: a fresh reduced-motion page must still present the part's content.
+    const reducedPage = await browser.newPage({ viewport });
+    let reducedMotionSafe: boolean;
+    try {
+      await reducedPage.emulateMedia({ reducedMotion: 'reduce' });
+      await reducedPage.goto(url, { waitUntil: 'networkidle' });
+      await waitForDocumentFonts(reducedPage);
+      await scrollIntoView(reducedPage, selector);
+      await settleFrames(reducedPage);
+      reducedMotionSafe = await partHasContent(reducedPage, selector);
+    } finally {
+      await reducedPage.close();
+    }
+
+    return validateReferenceCraft({
+      schema: REFERENCE_CRAFT_SCHEMA,
+      source: opts.source,
+      as: opts.as,
+      selector: selector ?? ':root',
+      viewport,
+      motion: { peakEnergy, scrollLinked, reducedMotionSafe },
+      technique: opts.technique,
+    });
+  } finally {
+    await browser.close();
+  }
+}

--- a/test/fixtures/craft-reveal.html
+++ b/test/fixtures/craft-reveal.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<style>
+  body { margin: 0; background: #0b0b0d; color: #eee; font-family: sans-serif; }
+  #hero { height: 100vh; display: flex; align-items: center; justify-content: center; font-size: 40px; }
+  .spacer { height: 60vh; }
+  #part {
+    margin: 0 40px; padding: 80px 40px; background: #1a1a22; border-radius: 16px;
+    font-size: 34px; line-height: 1.3;
+    opacity: 0; transform: translateY(60px);
+    transition: opacity 700ms ease, transform 700ms ease;
+  }
+  #part.in { opacity: 1; transform: none; }
+  @media (prefers-reduced-motion: reduce) {
+    #part { opacity: 1 !important; transform: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+  <div id="hero">top of the page</div>
+  <div class="spacer"></div>
+  <section id="part">A scroll-revealed section that fades and slides into place when it enters the viewport.</section>
+  <div class="spacer"></div>
+  <script>
+    const io = new IntersectionObserver((entries) => {
+      for (const e of entries) if (e.isIntersecting) e.target.classList.add('in');
+    }, { threshold: 0.2 });
+    io.observe(document.getElementById('part'));
+  </script>
+</body>
+</html>

--- a/test/fixtures/craft-static.html
+++ b/test/fixtures/craft-static.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<style>
+  body { margin: 0; background: #0b0b0d; color: #eee; font-family: sans-serif; }
+  #hero { height: 100vh; display: flex; align-items: center; justify-content: center; font-size: 40px; }
+  .spacer { height: 60vh; }
+  #part {
+    margin: 0 40px; padding: 80px 40px; background: #1a1a22; border-radius: 16px;
+    font-size: 34px; line-height: 1.3;
+  }
+</style>
+</head>
+<body>
+  <div id="hero">top of the page</div>
+  <div class="spacer"></div>
+  <section id="part">A plain static section with no motion of any kind — it does not animate on load or on scroll.</section>
+  <div class="spacer"></div>
+</body>
+</html>

--- a/test/reference-craft-capture.test.ts
+++ b/test/reference-craft-capture.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { captureReferenceCraft } from '../core/ref/reference-craft-capture.ts';
+
+const fixture = (name: string): string => fileURLToPath(new URL(`fixtures/${name}`, import.meta.url));
+const viewport = { width: 800, height: 600 };
+
+test('captureReferenceCraft measures reveal motion and scroll-linkage on a real reveal fixture', async () => {
+  const craft = await captureReferenceCraft(fixture('craft-reveal.html'), {
+    source: 'fixture', as: 'reveal-part', technique: 'scroll reveal', viewport, selector: '#part',
+  });
+  assert.equal(craft.schema, 'reference-craft-v1');
+  assert.equal(craft.selector, '#part');
+  assert.ok(craft.motion.peakEnergy > 0.01, `expected observed motion, got ${craft.motion.peakEnergy}`);
+  assert.equal(craft.motion.scrollLinked, true);
+  assert.equal(craft.motion.reducedMotionSafe, true);
+});
+
+test('captureReferenceCraft records a static part as not moving and not scroll-linked', async () => {
+  const craft = await captureReferenceCraft(fixture('craft-static.html'), {
+    source: 'fixture', as: 'static-part', technique: 'none', viewport, selector: '#part',
+  });
+  assert.ok(craft.motion.peakEnergy < 0.01, `expected static, got ${craft.motion.peakEnergy}`);
+  assert.equal(craft.motion.scrollLinked, false);
+  assert.equal(craft.motion.reducedMotionSafe, true);
+});


### PR DESCRIPTION
## Why
PR #132 defined the craft signature (`reference-craft-v1`) and the reproduction gate, but **nothing produced a signature from observation** — records were hand-written. This adds the capturer, so role-② craft is **measured, not asserted** — the "fetching method" for craft references.

## What ships
- **`core/ref/reference-craft-capture.ts`** — `captureReferenceCraft` observes a real browser (mirroring the scroll-scene primitives: `computeEnergy` over screenshots, `waitForDocumentFonts`, a fresh reduced-motion page) and measures:
  1. **does the scoped part MOVE** — peak pixel-energy over time at load, and over time right after it is scrolled into view (a reveal still resolving);
  2. **is it SCROLL-LINKED** — it drives a CSS scroll/view timeline (`animation-timeline`), or scrolling it into view produced reveal energy;
  3. **reduced-motion baseline** — content present under `prefers-reduced-motion: reduce`.
  Returns a validated `reference-craft-v1` that `omd craft-fidelity` gates a build against.
- **`omd craft-capture <url> --as <slug> --technique "<t>" [--selector css] [--viewport WxH]`** wires it for the scout/loop.

## Validation
reference-craft-capture browser suite **2/2** on real fixtures: a scroll-reveal fixture reads `peakEnergy>0.01` + `scrollLinked true` + `reducedMotionSafe true`; a static fixture reads `peakEnergy<0.01` + `scrollLinked false`. CLI smoke: reveal fixture → `peakEnergy 0.4389, scrollLinked true`. typecheck + build clean; diff --check clean. Third of the series (domain #131 → craft gate #132 → this capture). No release.