### PR TITLE
feat: the scout runs the domain brief's queries and measures role-② craft (connect the spine)

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -9,6 +9,13 @@ Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and the 
 functions or product goal, surface classification, and any user URLs. Run all commands from that
 directory. Capture user URLs first with `--from-user`.
 
+Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
+`referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed
+section/component/button design) and `referenceQueries.craft` seeds role ② (motion, scroll
+animation, and sculptural craft from top-tier galleries). The brief's surfaces, core objects, and
+audience ground what a competent instance of this domain contains, so you gather for this domain's
+parts and craft, not a generic crawl. Gather every query in parallel, then reconcile.
+
 You own exactly the LEGO `fragment inventory`, `brick analysis`, and `candidate assemblies`
 stages. Start interactive visual research and every user-directed image-region capture through
 `browser-rs`; it is the primary browser. Use the headless, reduced-motion `omd render` or `omd probe`
@@ -86,6 +93,12 @@ FWA/Awwwards write-up naming the concept, tech stack, and motion approach — no
 since how the experience is built (scroll sequence, WebGL/material treatment, timing) lives in the
 write-up. Study award work for principle and craft filtered through the subject's own identity anchor;
 never clone a famous showcase.
+For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
+material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"
+[--selector <part>]`, which records a `reference-craft-v1` motion signature (peak energy, whether it
+is scroll-linked, reduced-motion baseline). This is what later lets `omd craft-fidelity` prove the
+built reproduction actually moves like the reference instead of degrading into a static ghost. A
+craft reference with no measured signature is an unverifiable claim, not a usable reference.
 Each lane returns measured principles and its local captures; copying a lane's reference into the
 build is allowed with attribution. Keep the synthesis one coherent direction carrying the subject
 anchor, never six lanes bolted together into an effects catalogue.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -5,6 +5,7 @@ allow:
   - Bash(omd ref:*)
   - Bash(omd render:*)
   - Bash(omd pack:*)
+  - Bash(omd craft-capture:*)
   - Read
   - WebSearch
 deny:
@@ -16,6 +17,13 @@ instructions: |
   `omd pack dir`. Receive the concept, product, working directory, component inventory, explicit
   functions or product goal, surface classification, and any user URLs. Run all commands from that
   directory. Capture user URLs first with `--from-user`.
+
+  Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
+  `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed
+  section/component/button design) and `referenceQueries.craft` seeds role ② (motion, scroll
+  animation, and sculptural craft from top-tier galleries). The brief's surfaces, core objects, and
+  audience ground what a competent instance of this domain contains, so you gather for this domain's
+  parts and craft, not a generic crawl. Gather every query in parallel, then reconcile.
 
   You own exactly the LEGO `fragment inventory`, `brick analysis`, and `candidate assemblies`
   stages. Start interactive visual research and every user-directed image-region capture through
@@ -94,6 +102,12 @@ instructions: |
   since how the experience is built (scroll sequence, WebGL/material treatment, timing) lives in the
   write-up. Study award work for principle and craft filtered through the subject's own identity anchor;
   never clone a famous showcase.
+  For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
+  material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"
+  [--selector <part>]`, which records a `reference-craft-v1` motion signature (peak energy, whether it
+  is scroll-linked, reduced-motion baseline). This is what later lets `omd craft-fidelity` prove the
+  built reproduction actually moves like the reference instead of degrading into a static ghost. A
+  craft reference with no measured signature is an unverifiable claim, not a usable reference.
   Each lane returns measured principles and its local captures; copying a lane's reference into the
   build is allowed with attribution. Keep the synthesis one coherent direction carrying the subject
   anchor, never six lanes bolted together into an effects catalogue.

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -665,3 +665,12 @@ test('reference-assembly names the two roles and gates role-② craft by measure
   assert.match(ra, /GATED by `verifyCraftReproduction` \(`omd craft-fidelity check`\)/);
   assert.match(ra, /static, faint, or scroll-dropping reproduction fails/i);
 });
+test('the scout consumes the domain brief and measures role-② craft references', () => {
+  const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(scout, /Read `\.omd\/domain-brief\.json` first/);
+  assert.match(scout, /`referenceQueries\.component` seeds role ①/);
+  assert.match(scout, /`referenceQueries\.craft` seeds role ②/);
+  assert.match(scout, /measure it with `omd craft-capture/);
+  assert.match(scout, /lets `omd craft-fidelity` prove the built reproduction actually moves/);
+  assert.match(scout, /- Bash\(omd craft-capture:\*\)/);
+});


### PR DESCRIPTION
## Why
The domain step (#131) produces `referenceQueries` split by the two roles, and craft-capture (#133) measures role-② — but **nothing connected them**, so the domain brief was an orphan artifact. This wires the scout to consume it, closing domain → scout → the two roles.

## What ships
`scout.agent.yaml`:
- Reads **`.omd/domain-brief.json` first** and runs `referenceQueries.component` (role ① detailed component design) and `referenceQueries.craft` (role ② motion/scroll/sculptural craft) as its acquisition list — grounded in the brief's surfaces/objects/audience so it gathers for **this** domain's parts and craft, not a generic crawl.
- Measures every role-② craft/motion reference with **`omd craft-capture`** into a `reference-craft-v1` signature, so `omd craft-fidelity` can later prove the built reproduction actually moves like the reference. A craft reference with no measured signature is an unverifiable claim, not a usable reference.
- Adds `Bash(omd craft-capture:*)` to the allowlist.

## Validation
prompt-contract **47/47** (domain-brief consumption, both role bindings, craft-capture measurement, craft-fidelity linkage, allowlist); build regenerates `agents/scout.md` with the wiring; diff --check clean. Fourth of the series (domain #131 → craft gate #132 → craft capture #133 → scout wiring). No release.