### PR TITLE
feat: omd craft-usage — machine gate for captured scroll craft declined to a static build

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -107,6 +107,8 @@ interface Opts {
   costliestError?: string;
   /** UX anchor: surface classification — marketing | product | editorial | mixed. (`omd frame set --surface "..."`) */
   surface?: string;
+  /** Reference directory for `omd craft-usage` (default `<cwd>/.omd/refs`). */
+  refs?: string;
   /** Task coverage matrix rows for product or mixed surfaces. (`omd frame set --task-matrix "T1 …"`) */
   taskMatrix?: string;
   /** Render desktop+mobile fixed and full-page proofs in one browser (`omd render <page> --proofs -o <prefix>`). */
@@ -1622,6 +1624,47 @@ async function cmdCraftCapture(opts: Opts): Promise<never> {
   process.exit(0);
 }
 
+/**
+ * Gates the "captured role-② craft declined to stillness" under-reach: reads the captured reference
+ * signatures, measures the built page in a real browser, and fails when a persuasion surface that
+ * captured scroll-linked craft ships static.
+ */
+async function cmdCraftUsage(opts: Opts): Promise<never> {
+  const target = opts._[0];
+  if (!target) throw new Error('usage: omd craft-usage <page> [--surface marketing|product|…] [--refs <dir>] [--selector <css>] [--viewport WxH] [--json]');
+  const { readCapturedCraftSignals, hasCapturedScrollCraft, checkCraftUsage, EXEMPT_SURFACES } = await import('../core/ref/craft-usage.ts');
+  const { parseViewport } = await import('../core/render/index.ts');
+  const { captureReferenceCraft } = await import('../core/ref/reference-craft-capture.ts');
+  const refsDir = opts.refs ?? join(process.cwd(), '.omd', 'refs');
+  const signals = readCapturedCraftSignals(refsDir);
+  const capturedScrollCraft = hasCapturedScrollCraft(signals);
+  const built = await captureReferenceCraft(target, {
+    source: target,
+    as: 'built',
+    technique: 'as shipped',
+    selector: opts.selector ?? null,
+    viewport: parseViewport(opts.viewport ?? '1440x900'),
+  });
+  const surface = opts.surface ?? 'marketing';
+  const finding = checkCraftUsage({ surface, capturedScrollCraft, builtScrollLinked: built.motion.scrollLinked });
+  const payload = {
+    surface,
+    refs: signals.length,
+    capturedScrollCraft,
+    built: { peakEnergy: built.motion.peakEnergy, scrollLinked: built.motion.scrollLinked },
+    findings: finding ? [finding] : [],
+  };
+  if (opts.json) process.stdout.write(JSON.stringify(payload));
+  else if (finding) console.error(`[error] ${finding.id} (surface=${surface}, refs=${signals.length}, built peakEnergy=${built.motion.peakEnergy}, scrollLinked=${built.motion.scrollLinked}): ${finding.message}`);
+  else {
+    const reason = EXEMPT_SURFACES.has(surface)
+      ? 'surface is exempt — its correct risk is functional'
+      : capturedScrollCraft ? 'captured scroll craft is reproduced in the build' : 'no captured scroll craft to reproduce';
+    console.log(`ok — ${reason} (surface=${surface}, refs=${signals.length})`);
+  }
+  process.exit(finding ? 1 : 0);
+}
+
 /** Final byte-freshness evidence only; this does not judge semantic copy/source fidelity. */
 function cmdSource(mode: string | undefined, opts: Opts): never {
   const sourceRoot = resolve(opts._[0] ?? process.cwd());
@@ -2539,6 +2582,7 @@ function usage(): never {
     + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
     + '  craft-fidelity check --input pair.json [--json]  verify a generated part reproduced the reference craft\n'
     + '  craft-capture <url> --as <slug> --technique "<t>" [--selector <css>] [--viewport WxH] [--json]  measure a reference-craft-v1 from a real browser\n'
+    + '  craft-usage <page> [--surface S] [--refs dir] [--json]  fail when captured scroll craft was declined to a static build\n'
     + '  preflight --input activation-context.json [--json]  read-only activation validation\n'
     + '  text-slop [file] [--json]                   advisory AI-cliche scan of copy (default .omd/copy-deck.md)\n'
     + '  visual-richness [file] [--register R] [--json]  advisory carrier read of composition (default .omd/composition.md)\n'
@@ -2658,6 +2702,7 @@ async function main(): Promise<never> {
   if (cmd === 'domain') return cmdDomain(sub, parseArgs(args.slice(2)));
   if (cmd === 'craft-fidelity') return cmdCraftFidelity(sub, parseArgs(args.slice(2)));
   if (cmd === 'craft-capture') return cmdCraftCapture(parseArgs(args.slice(1)));
+  if (cmd === 'craft-usage') return cmdCraftUsage(parseArgs(args.slice(1)));
   if (cmd === 'stack') return cmdStack(parseArgs(args.slice(1)));
   if (cmd === 'text-slop') return cmdTextSlop(parseArgs(args.slice(1)));
   if (cmd === 'visual-richness') return cmdVisualRichness(parseArgs(args.slice(1)));

--- a/core/ref/craft-usage.ts
+++ b/core/ref/craft-usage.ts
@@ -1,0 +1,95 @@
+// Machine gate for the "captured role-② craft declined to stillness" under-reach.
+//
+// The human-design-loop GREEN target says: when the scout captured role-② craft references with real
+// measured scroll motion for a persuasion surface, the build must reproduce at least one scroll-linked
+// reveal — declining every one to ship a static page is under-reach (RED). This module makes that
+// checkable rather than eye-advisory. It reads the captured reference signatures (`.omd/refs/*.json`),
+// asks whether any prove scroll-linked craft is this domain's norm, and — paired with a measured
+// `reference-craft-v1` of the BUILT page (`captureReferenceCraft`) — flags a persuasion surface that
+// captured scroll craft yet shipped static.
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** A ref counts as scroll-craft evidence when its animated share alone clears this, even absent choreography. */
+export const CRAFT_ANIMATED_SHARE_FLOOR = 0.08;
+
+/** Surfaces whose correct risk is functional; captured scroll craft is not required of them. */
+export const EXEMPT_SURFACES: ReadonlySet<string> = new Set(['product', 'quiet']);
+
+export type CraftRefSignal = {
+  readonly source: string;
+  /** Any captured scroll-choreography step actually fired on scroll entry. */
+  readonly scrollFired: boolean;
+  /** Fraction of the captured subtree that is animated (0..1). */
+  readonly animatedShare: number;
+  /** Peak measured motion energy of the capture (0..1). */
+  readonly peakEnergy: number;
+};
+
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+
+/** Extracts the scroll-craft signal from one parsed reference record (tolerant of missing fields). */
+export function refCraftSignal(ref: unknown, source: string): CraftRefSignal {
+  const record = ref && typeof ref === 'object' ? (ref as Record<string, unknown>) : {};
+  const invariants = record.invariants && typeof record.invariants === 'object' ? (record.invariants as Record<string, unknown>) : {};
+  const choreo = Array.isArray(invariants.scrollChoreography) ? (invariants.scrollChoreography as Array<Record<string, unknown>>) : [];
+  const scrollFired = choreo.some((step) => num(step.fired) > 0);
+  const animatedShare = num(invariants.animatedShare);
+  const energy = record.energyCurve && typeof record.energyCurve === 'object' ? (record.energyCurve as Record<string, unknown>) : {};
+  const peakEnergy = num(energy.peakEnergy);
+  return { source, scrollFired, animatedShare, peakEnergy };
+}
+
+/** Reads every `.omd/refs/*.json` and returns each reference's scroll-craft signal. */
+export function readCapturedCraftSignals(refsDir: string): CraftRefSignal[] {
+  if (!existsSync(refsDir)) return [];
+  const signals: CraftRefSignal[] = [];
+  for (const name of readdirSync(refsDir)) {
+    if (!name.endsWith('.json')) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(join(refsDir, name), 'utf8'));
+    } catch {
+      continue;
+    }
+    const source = parsed && typeof parsed === 'object' && typeof (parsed as Record<string, unknown>).source === 'string'
+      ? ((parsed as Record<string, unknown>).source as string)
+      : name;
+    signals.push(refCraftSignal(parsed, source));
+  }
+  return signals;
+}
+
+/**
+ * True when the captured references prove scroll-linked craft is this domain's register norm:
+ * any reference fired scroll choreography, or clears the animated-share floor.
+ */
+export function hasCapturedScrollCraft(signals: readonly CraftRefSignal[]): boolean {
+  return signals.some((s) => s.scrollFired || s.animatedShare >= CRAFT_ANIMATED_SHARE_FLOOR);
+}
+
+export type CraftUsageFinding = {
+  readonly id: 'CRAFT-DECLINED-TO-STILL';
+  readonly message: string;
+};
+
+/**
+ * Flags `CRAFT-DECLINED-TO-STILL` when a persuasion surface captured scroll-linked craft evidence but
+ * the built page ships static. Returns null (ok) on an exempt (`product`/`quiet`) surface, when no
+ * scroll craft was captured, or when the built page is itself scroll-linked.
+ */
+export function checkCraftUsage(opts: {
+  readonly surface: string;
+  readonly capturedScrollCraft: boolean;
+  readonly builtScrollLinked: boolean;
+}): CraftUsageFinding | null {
+  if (EXEMPT_SURFACES.has(opts.surface)) return null;
+  if (!opts.capturedScrollCraft) return null;
+  if (opts.builtScrollLinked) return null;
+  return {
+    id: 'CRAFT-DECLINED-TO-STILL',
+    message:
+      'captured role-② references fire scroll-linked craft for this domain, but the built page ships static — the scroll craft was declined to stillness (under-reach, RED). Reproduce at least one scroll-linked reveal from the captured evidence and verify it with `omd craft-fidelity`, or record an explicit brief-driven reason for stillness.',
+  };
+}

--- a/test/craft-usage.test.ts
+++ b/test/craft-usage.test.ts
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import {
+  CRAFT_ANIMATED_SHARE_FLOOR,
+  checkCraftUsage,
+  hasCapturedScrollCraft,
+  readCapturedCraftSignals,
+  refCraftSignal,
+} from '../core/ref/craft-usage.ts';
+
+const dir = (name: string): string => fileURLToPath(new URL(`fixtures/${name}`, import.meta.url));
+
+test('refCraftSignal reads fired choreography, animated share, and peak energy', () => {
+  const s = refCraftSignal(
+    { invariants: { animatedShare: 0.2, scrollChoreography: [{ step: 1, fired: 1, entered: 4 }] }, energyCurve: { peakEnergy: 0.3 } },
+    'x',
+  );
+  assert.equal(s.scrollFired, true);
+  assert.equal(s.animatedShare, 0.2);
+  assert.equal(s.peakEnergy, 0.3);
+});
+
+test('refCraftSignal tolerates missing or malformed fields', () => {
+  const s = refCraftSignal({}, 'y');
+  assert.equal(s.scrollFired, false);
+  assert.equal(s.animatedShare, 0);
+  assert.equal(s.peakEnergy, 0);
+  const t = refCraftSignal({ invariants: { scrollChoreography: 'nope', animatedShare: 'x' } }, 'z');
+  assert.equal(t.scrollFired, false);
+  assert.equal(t.animatedShare, 0);
+});
+
+test('readCapturedCraftSignals + hasCapturedScrollCraft detect a scroll-craft reference set', () => {
+  const signals = readCapturedCraftSignals(dir('craft-usage-refs'));
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0]!.scrollFired, true);
+  assert.equal(hasCapturedScrollCraft(signals), true);
+});
+
+test('a reference set with no fired choreography and no animated share is not scroll craft', () => {
+  const signals = readCapturedCraftSignals(dir('craft-usage-refs-static'));
+  assert.equal(signals.length, 1);
+  assert.equal(hasCapturedScrollCraft(signals), false);
+});
+
+test('animated share alone above the floor counts as captured scroll craft', () => {
+  const only = [{ source: 'a', scrollFired: false, animatedShare: CRAFT_ANIMATED_SHARE_FLOOR, peakEnergy: 0 }];
+  assert.equal(hasCapturedScrollCraft(only), true);
+  const below = [{ source: 'a', scrollFired: false, animatedShare: CRAFT_ANIMATED_SHARE_FLOOR - 0.01, peakEnergy: 0 }];
+  assert.equal(hasCapturedScrollCraft(below), false);
+});
+
+test('readCapturedCraftSignals returns nothing for an absent refs directory', () => {
+  assert.deepEqual(readCapturedCraftSignals(dir('no-such-refs-dir')), []);
+});
+
+test('checkCraftUsage flags a persuasion surface that captured scroll craft but shipped static', () => {
+  const finding = checkCraftUsage({ surface: 'marketing', capturedScrollCraft: true, builtScrollLinked: false });
+  assert.equal(finding?.id, 'CRAFT-DECLINED-TO-STILL');
+  assert.match(finding!.message, /declined to stillness/);
+});
+
+test('checkCraftUsage passes when the build reproduced scroll-linked craft', () => {
+  assert.equal(checkCraftUsage({ surface: 'marketing', capturedScrollCraft: true, builtScrollLinked: true }), null);
+});
+
+test('checkCraftUsage passes when no scroll craft was captured, and exempts product/quiet', () => {
+  assert.equal(checkCraftUsage({ surface: 'marketing', capturedScrollCraft: false, builtScrollLinked: false }), null);
+  assert.equal(checkCraftUsage({ surface: 'product', capturedScrollCraft: true, builtScrollLinked: false }), null);
+  assert.equal(checkCraftUsage({ surface: 'quiet', capturedScrollCraft: true, builtScrollLinked: false }), null);
+});

--- a/test/fixtures/craft-usage-refs-static/static-ref.json
+++ b/test/fixtures/craft-usage-refs-static/static-ref.json
@@ -1,0 +1,11 @@
+{
+  "source": "https://example.com",
+  "component": "plain-doc",
+  "invariants": {
+    "animatedShare": 0.0,
+    "scrollChoreography": [
+      { "step": 1, "fired": 0, "entered": 6 }
+    ]
+  },
+  "energyCurve": { "peakEnergy": 0 }
+}

--- a/test/fixtures/craft-usage-refs/scroll-ref.json
+++ b/test/fixtures/craft-usage-refs/scroll-ref.json
@@ -1,0 +1,12 @@
+{
+  "source": "https://warp.dev",
+  "component": "motion-hero",
+  "invariants": {
+    "animatedShare": 0.1449,
+    "scrollChoreography": [
+      { "step": 1, "fired": 1, "entered": 10 },
+      { "step": 2, "fired": 1, "entered": 9 }
+    ]
+  },
+  "energyCurve": { "peakEnergy": 0.0125 }
+}


### PR DESCRIPTION
## Why
#136 made *"captured role-② craft must be honored"* a GREEN-target rule, but it was **eye-advisory**. This makes it a **measured gate** — and it fires on the real regenerated example.

## Evidence from the actual run
- `omd ref distance` on the built example: **max 0.16**, most 0.02–0.10 (high closeness is the intended outcome) — the build is far from every captured reference.
- Built page measured with `craft-capture`: **peakEnergy 0, scrollLinked false** — fully static.
- Captured refs fire real scroll choreography (raycast 31, bun 31, zed 20, warp 4; animatedShare 0.14–0.27).
- Built vs ref invariants: typeScale `[12,16]` vs warp `[12,14,15,16,24,28,32,60]`; `animatedProperties [opacity]` vs `[transform, boxShadow, aspectRatio, outlineColor]`; `elevationLevels 0` vs 4/8/26.

## What ships
- **`core/ref/craft-usage.ts`** — reads `.omd/refs/*.json` signatures and asks whether any prove scroll-linked craft is this domain's norm (a fired `scrollChoreography` step, or `animatedShare` at/above the floor). Paired with a real-browser `reference-craft-v1` of the **built** page (`captureReferenceCraft`, #133), `checkCraftUsage` flags **`CRAFT-DECLINED-TO-STILL`** when a persuasion surface captured scroll craft yet ships static. `product`/`quiet` exempt; a build that reproduced scroll-linked craft, or a ref set with no scroll craft, passes.
- **`omd craft-usage <page> [--surface S] [--refs dir]`** — exits 1 on the finding.

## Validation
craft-usage unit suite **9/9**. **Proof on the real example:** `--surface marketing` → `CRAFT-DECLINED-TO-STILL (refs=14, built peakEnergy=0, scrollLinked=false)`, exit 1; `--surface product` → ok, exempt. typecheck + build clean; diff --check clean. No release.