### PR TITLE
feat: name the motion implementation stack and add the award-bar eval

### DIFF
--- a/core/theory/motion.md
+++ b/core/theory/motion.md
@@ -261,6 +261,37 @@ and parallax — are in `core/motion/recipes/`. The easing token vocabulary (--e
 Recipes reference the theory here; the hand wires the recipe parameters from the board's
 motion studies.
 
+## The implementation stack
+
+Recipes are installed with `omd recipe add`, not reimplemented; what follows is what they install on.
+
+**CSS first, always.** `animation-timeline: view()`/`scroll()` is the default for scroll-linked motion
+and the only path that satisfies the scroll-scene contract without scripting: the compositor advances
+it as the reader scrolls, so it is scroll-position-scrubbed by construction and it survives with
+JavaScript disabled. `transform` and `opacity` are the only properties to animate — they reach the
+composite step without touching layout — and a CSS `transition` is interruptible where a `keyframes`
+animation is not, which is why state changes belong in transitions.
+
+**GSAP where CSS cannot reach.** GSAP became free for every use in 2024 under Webflow's stewardship,
+including ScrollTrigger, Flip, MotionPath, Observer, and SplitText, so the licence question that used
+to push work toward weaker tools is gone. Reach for it when the scene needs timeline orchestration,
+pinning, scrubbed sequences across several elements, or FLIP-style layout transitions — things a CSS
+timeline cannot express. `ScrollTrigger` with `scrub: true` is scroll-position-scrubbed in exactly the
+sense the evidence contract requires; a time-driven `ScrollTrigger` callback is not, and does not
+qualify. Smooth-scroll libraries (Lenis and its peers) are a separate, optional layer: they change the
+feel of scrolling itself and must not be the thing that makes content reachable.
+
+**The frequency rule cuts the other way.** A high-frequency, keyboard-initiated interaction —
+a command palette, a context menu, a tab switch — is *better without* an entrance animation. Seen
+hundreds of times a day, the animation stops being delight and becomes latency the user has to sit
+through. Raycast ships no entrance animation and it feels correct. Ambition belongs to the moments a
+reader meets once or twice: the load scene, the scroll narrative, the signature.
+
+**Main-thread independence decides the library.** A `requestAnimationFrame`-driven animation (the
+default in most React motion libraries) drops frames whenever the main thread is busy — exactly when a
+page is hydrating or fetching. CSS animations and the Web Animations API keep running regardless.
+Where an animation must stay smooth during load, it belongs in CSS or WAAPI, not in a rAF loop.
+
 ## Sources
 
 - Nielsen, "Response Times: The 3 Important Limits" (1993) — 0.1s / 1s / 10s thresholds

--- a/evals/award-bar/graders/award-score.md
+++ b/evals/award-bar/graders/award-score.md
@@ -1,0 +1,19 @@
+# Grader: Developer-Rubric Score Clears the Honourable-Mention Floor
+
+Score the finished page against the published Awwwards Developer Award weights and check the result.
+
+## Pass criteria
+
+- `omd award score <page> --json` runs and reports `coverage` of at least 0.8 — most of the rubric's weight had evidence, so the score is not a sliver of the page.
+- `verdict` is `honourable-mention` or `developer-award`.
+- `floorFailures` is empty. This is the conjunctive part: an axis below its floor cannot be averaged away by the others, so a page with clean markup and no motion does not pass here.
+
+## Fail criteria
+
+- `verdict` is `below-hm`.
+- `floorFailures` names any axis — most often `animation`, which is what a statically-shipped landing scores.
+- `coverage` below 0.8: too much of the rubric went unmeasured for the number to mean anything. Collect the missing evidence rather than reporting the partial score as a result.
+
+## Severity
+
+FAIL — the rubric is the industry's own bar. A run that cannot clear the Honourable-Mention floor on the measurable axes has not produced award-tier work, whatever the internal checks say.

--- a/evals/award-bar/graders/content-survives-no-js.md
+++ b/evals/award-bar/graders/content-survives-no-js.md
@@ -1,0 +1,16 @@
+# Grader: Motion Enhances Content, Never Gates It
+
+Check that the page's content is readable with JavaScript disabled.
+
+## Pass criteria
+
+- `omd no-js <page>` exits 0: no `NOJS-CONTENT-LOSS`.
+- Blocks that are below the fold and simply not yet scrolled to do not count — the check measures content that stays invisible *while in the viewport*.
+
+## Fail criteria
+
+- `NOJS-CONTENT-LOSS` fires: text is lost, or sizable blocks stay invisible once the reader reaches them. This is the signature of a reveal whose default state is `opacity: 0` with an IntersectionObserver as its only advance.
+
+## Severity
+
+FAIL — "content accessible with no JS" is a published developer-award accessibility criterion. A reveal that gates content fails it outright.

--- a/evals/award-bar/graders/installed-not-reimplemented.md
+++ b/evals/award-bar/graders/installed-not-reimplemented.md
@@ -1,0 +1,18 @@
+# Grader: Techniques Were Installed, Not Reimplemented
+
+Check that motion and composition techniques arrived as real source rather than as a from-prose approximation.
+
+## Pass criteria
+
+- `.omd/decisions.md` records at least one `omd recipe add` install for the motion or composition technique the page ships.
+- The installed files are present in the project and referenced by the build.
+- `omd craft-capture <page> --selector <the installed part>` measures the installed part as `scrollLinked: true`, or with `peakEnergy` above the floor for a load scene.
+
+## Fail criteria
+
+- The page's motion was hand-written from a recipe document with no install recorded — the reimplementation path that reliably degrades to a static approximation.
+- An install is recorded but the measured part shows neither scroll-linkage nor load energy: the source landed and was never wired.
+
+## Severity
+
+FAIL — installing is the step that removes the reimplementation gap. A recorded install with no measured motion is a claim without evidence.

--- a/evals/award-bar/graders/tokens-committed.md
+++ b/evals/award-bar/graders/tokens-committed.md
@@ -1,0 +1,17 @@
+# Grader: The Design System's Ladders Were Committed and Used
+
+Check that the run decided its scales before composing, and that the build landed on them.
+
+## Pass criteria
+
+- `.omd/tokens.json` exists and `omd tokens check` passes: at least four type rungs, each step at least 1.15× its neighbour, a display moment of at least 2.5× on this persuasion register, at least four spacing rungs, and a named `accent` colour role.
+- `omd tokens check --page <page>` reports no `TOKEN-DRIFT`: every rendered type size and spacing step sits on a committed rung.
+
+## Fail criteria
+
+- No `.omd/tokens.json`, or it fails validation — the run composed without deciding its system.
+- `TOKEN-DRIFT` fires: components invented neighbouring values instead of landing on the ladder. A two-rung type scale such as `[12, 16]` is the collapsed case this grader exists to catch.
+
+## Severity
+
+FAIL — an uncommitted system cannot accumulate. Every off-ladder value is a component that decided for itself.

--- a/evals/award-bar/prompt.md
+++ b/evals/award-bar/prompt.md
@@ -1,0 +1,5 @@
+Design and build the marketing landing page for a small independent typeface foundry called "활자소" (Hwaljaso — "type workshop"). It sells three retail Korean typefaces and takes custom lettering commissions. The audience is Korean designers and brand studios who already care about type. Use oh-my-design:ultradesign.
+
+The page ships in Korean, at `--stack vanilla` or a framework of the run's choosing, and must be reachable at a local URL for review.
+
+This eval measures the run against the published Awwwards Developer Award rubric rather than an internal target. Every criterion below is scored from evidence the run itself produces.

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -737,3 +737,27 @@ test('the loop commits the design system ladders before composition', () => {
   assert.match(loop, /collapsed to a two-rung type scale of \[12, 16\]/);
   assert.match(loop, /`TOKEN-DRIFT` for any rendered value that is not on a committed rung/);
 });
+test('motion theory names the implementation stack and the frequency counter-rule', () => {
+  const motion = read('core/theory/motion.md').replace(/\s+/g, ' ');
+  assert.match(motion, /## The implementation stack/);
+  assert.match(motion, /`animation-timeline: view\(\)`\/`scroll\(\)` is the default/);
+  assert.match(motion, /GSAP became free for every use in 2024 under Webflow's stewardship/);
+  assert.match(motion, /`ScrollTrigger` with `scrub: true` is scroll-position-scrubbed/);
+  assert.match(motion, /a time-driven `ScrollTrigger` callback is not, and does not qualify/);
+  assert.match(motion, /high-frequency, keyboard-initiated interaction[\s\S]*better without\* an entrance animation/);
+  assert.match(motion, /CSS animations and the Web Animations API keep running regardless/);
+});
+
+test('the award-bar eval scores against the rubric, tokens, installs, and no-JS survival', () => {
+  const prompt = read('evals/award-bar/prompt.md').replace(/\s+/g, ' ');
+  assert.match(prompt, /published Awwwards Developer Award rubric rather than an internal target/);
+  const score = read('evals/award-bar/graders/award-score.md').replace(/\s+/g, ' ');
+  assert.match(score, /`coverage` of at least 0\.8/);
+  assert.match(score, /`floorFailures` is empty/);
+  const tokens = read('evals/award-bar/graders/tokens-committed.md').replace(/\s+/g, ' ');
+  assert.match(tokens, /A two-rung type scale such as `\[12, 16\]` is the collapsed case/);
+  const install = read('evals/award-bar/graders/installed-not-reimplemented.md').replace(/\s+/g, ' ');
+  assert.match(install, /records at least one `omd recipe add` install/);
+  const nojs = read('evals/award-bar/graders/content-survives-no-js.md').replace(/\s+/g, ' ');
+  assert.match(nojs, /content accessible with no JS/);
+});


### PR DESCRIPTION
## Motion stack (`theory/motion.md`)
- **CSS first.** `animation-timeline: view()/scroll()` is the default — the only path that is scroll-position-scrubbed *by construction* and survives with JavaScript disabled. `transform`/`opacity` only. A CSS **transition is interruptible** where a `keyframes` animation is not, so state changes belong in transitions.
- **GSAP where CSS cannot reach** — timeline orchestration, pinning, multi-element scrubbed sequences, FLIP — now that it is **free for every use** under Webflow. Precise note: `ScrollTrigger` `scrub: true` **qualifies** under the evidence contract; a time-driven callback **does not**. Smooth-scroll libraries are an optional *feel* layer that must never be what makes content reachable.
- **The counter-rule the harness was missing.** The loop pushes motion ambition; practitioners are equally clear that a **high-frequency, keyboard-initiated** interaction is *better without* an entrance animation — at hundreds of uses a day it becomes latency, not delight. Ambition belongs to the once-or-twice moments.
- **Main-thread independence decides the library.** rAF-driven animation drops frames exactly when the page is hydrating; CSS and WAAPI keep running.

## `evals/award-bar`
Measures the whole chain against the **industry's** bar:
1. **award-score** — developer-rubric verdict ≥ Honourable Mention, **coverage ≥ 0.8**, **no floor failures**.
2. **tokens-committed** — ladders committed and no `TOKEN-DRIFT`; the `[12, 16]` collapse is the named case.
3. **installed-not-reimplemented** — a recorded `omd recipe add` **and** measured motion on the installed part.
4. **content-survives-no-js** — `omd no-js` clean.

## Validation
prompt-contract + motion suites green; build + typecheck clean. No release.