### PR TITLE
feat: omd ref granularity — a board of whole-page captures cannot be assembled from

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -93,6 +93,15 @@ FWA/Awwwards write-up naming the concept, tech stack, and motion approach — no
 since how the experience is built (scroll sequence, WebGL/material treatment, timing) lives in the
 write-up. Study award work for principle and craft filtered through the subject's own identity anchor;
 never clone a famous showcase.
+Capture parts, not pages. Every measured reference names the specific component it studies with
+`omd ref add <url> --as <component> --selector "<css>" --blueprint --shot`. A capture scoped to
+`main`, `body`, `html`, or `:root` measures the whole document: it yields a page average with no
+component anatomy, and section-granular composition has nothing to take from it. Two captures of
+the same source at the same selector are one piece of evidence wearing two names — capture a
+different part of that source or drop the duplicate. Run `omd ref granularity` before handing the
+board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS` each mean the board cannot
+be assembled from and must be recaptured at component scope.
+
 For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
 material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"
 [--selector <part>]`, which records a `reference-craft-v1` motion signature (peak energy, whether it

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -1713,6 +1713,18 @@ async function cmdRecipe(mode: string | undefined, opts: Opts): Promise<never> {
   process.exit(0);
 }
 
+
+/** Fails when the captured board holds no parts to compose section by section. */
+async function cmdRefGranularity(opts: Opts): Promise<never> {
+  const { loadRefs } = await import('../core/ref/store.ts');
+  const { auditBoardGranularity } = await import('../core/ref/board-granularity.ts');
+  const findings = auditBoardGranularity(loadRefs(process.cwd()));
+  if (opts.json) process.stdout.write(JSON.stringify({ ok: findings.length === 0, findings }));
+  else if (findings.length === 0) console.log('ok — the board holds component-scoped parts to compose from');
+  else for (const finding of findings) console.error(`[error] ${finding.id}: ${finding.message}\n  ${finding.refs.join('\n  ')}`);
+  process.exit(findings.length > 0 ? 1 : 0);
+}
+
 /** Fails when the page's content is gated behind JavaScript rather than enhanced by it. */
 async function cmdNoJs(opts: Opts): Promise<never> {
   const target = opts._[0];
@@ -2732,6 +2744,7 @@ function usage(): never {
     + '  ref candidates [manifest]                   print chat-ready Korean-first candidate Markdown\n'
     + '  ref select <candidate-id> [--json]          bind a closed candidate selection to its evidence\n'
     + '  ref audit [--json]                          warn when references were captured sequentially (use ref add-batch)\n'
+    + '  ref granularity [--json]                    fail when the board holds no component-scoped parts\n'
     + '\n'
     + '  design                                       discover evidence and create/refresh .omd/design.md\n'
     + '  design --check                              validate design.md section coverage\n'
@@ -2864,6 +2877,7 @@ async function main(): Promise<never> {
     if (sub === 'candidates') return cmdRefCandidates(opts);
     if (sub === 'select') return cmdRefSelect(opts);
     if (sub === 'audit') return cmdRefAudit(opts);
+    if (sub === 'granularity') return cmdRefGranularity(opts);
     return usage();
   }
 

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -41,6 +41,18 @@ Every reference serves one of two roles, and the domain brief's `referenceQuerie
   faint, or scroll-dropping reproduction fails — the craft reference does not pass just because a
   generation was attempted. This is how the "seeing is not building" gap is closed with evidence.
 
+## Capture granularity
+
+A board is assembled from parts. Every measured reference is captured at the specific component it
+studies (`omd ref add <url> --as <component> --selector "<css>" --blueprint --shot`); a capture
+scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document and yields a
+page average with no component anatomy, so section-granular composition has nothing to take from it.
+Two captures of the same source at the same selector are one piece of evidence under two names and
+make the board read larger than it is. `omd ref granularity` audits this and reports
+`REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS`; any of the three means the board must
+be recaptured at component scope before composition, because a board of whole-page captures can only
+be traced, and tracing a whole page is the derivative failure the transfer boundary forbids.
+
 ## Subject anchor
 
 When the brief names a real, existing subject — a product, project, company, repository, or brand, or supplies its link — the scout's fragment-inventory stage first establishes what that subject actually is (a web search plus the linked repository/README and any wordmark or brand the source already ships) and fixes the subject's own identity anchor: its real palette and motif. This anchor is not one measured reference among many; it governs the colour and motif every other lane serves, and is never outvoted by category evidence. A palette or motif taken from the product category's default instead of the subject's own identity is a rejected, not a shippable, synthesis.

--- a/core/ref/board-granularity.ts
+++ b/core/ref/board-granularity.ts
@@ -1,0 +1,94 @@
+// Audits whether the captured board actually contains PARTS.
+//
+// Section-granular composition — composing each section from the reference that solves that section
+// best — presupposes that the board holds parts. The capability exists (`omd ref add --selector
+// … --blueprint --shot` measures one subtree) and is tested, but nothing checked that the scout
+// used it. Audited on a real board, it had not: references were captured at `main`, the whole-page
+// root, and several sources appeared twice under different component names with byte-identical
+// invariants — the same page photographed twice, not two parts.
+//
+// A board of whole-page captures cannot be assembled from. It can only be traced, which is the
+// derivative failure the transfer boundary forbids. This module names that condition.
+
+import type { Reference } from '../types.ts';
+
+/**
+ * Selectors that address the page rather than a part. A capture scoped to one of these measures the
+ * whole document, so it carries a page average and no component anatomy.
+ */
+export const PAGE_ROOT_SELECTORS: ReadonlySet<string> = new Set([
+  'main', 'body', 'html', ':root', '#root', '#app', '#__next', '#__nuxt', '.app', '*',
+]);
+
+/** A board needs at least this many component-scoped captures before it can be assembled from. */
+export const MIN_PART_CAPTURES = 3;
+
+export type GranularityFinding = {
+  readonly id: 'REF-WHOLE-PAGE' | 'REF-DUPLICATE-CAPTURE' | 'REF-NO-PARTS';
+  readonly message: string;
+  /** Reference identifiers the finding is about, as `source (component)`. */
+  readonly refs: readonly string[];
+};
+
+const label = (ref: Pick<Reference, 'source' | 'component'>): string => `${ref.source} (${ref.component})`;
+
+/** The selector a reference was measured at, normalised; empty when it was never scoped. */
+export function captureSelector(ref: Pick<Reference, 'selector'> & { blueprint?: { selector?: string } }): string {
+  const selector = ref.blueprint?.selector ?? ref.selector ?? '';
+  return selector.trim().toLowerCase();
+}
+
+/** True when the reference measures a page root rather than a part. */
+export function isWholePageCapture(ref: Pick<Reference, 'selector'> & { blueprint?: { selector?: string } }): boolean {
+  const selector = captureSelector(ref);
+  return selector === '' || PAGE_ROOT_SELECTORS.has(selector);
+}
+
+/**
+ * Audits a captured board for the granularity section-granular composition requires.
+ *
+ * Image references are excluded from the part count: they carry reasoning, not anatomy, so they
+ * cannot answer "how is this component built" even though they are lawful board members.
+ */
+export function auditBoardGranularity(refs: readonly Reference[]): GranularityFinding[] {
+  const findings: GranularityFinding[] = [];
+  const measurable = refs.filter((ref) => ref.kind !== 'image');
+
+  const wholePage = measurable.filter((ref) => isWholePageCapture(ref));
+  if (wholePage.length > 0) {
+    findings.push({
+      id: 'REF-WHOLE-PAGE',
+      message:
+        `${wholePage.length} reference${wholePage.length === 1 ? ' was' : 's were'} captured at a page root rather than a part, so ${wholePage.length === 1 ? 'it carries' : 'they carry'} a whole-page average and no component anatomy. Recapture the specific component with \`omd ref add <url> --as <component> --selector "<css>" --blueprint --shot\`; a page-level capture can only be traced, and tracing a whole page is the derivative failure the transfer boundary forbids.`,
+      refs: wholePage.map(label),
+    });
+  }
+
+  const bySourceSelector = new Map<string, Reference[]>();
+  for (const ref of measurable) {
+    const key = `${ref.source}\u0000${captureSelector(ref)}`;
+    const bucket = bySourceSelector.get(key);
+    if (bucket) bucket.push(ref); else bySourceSelector.set(key, [ref]);
+  }
+  const duplicates = [...bySourceSelector.values()].filter((bucket) => bucket.length > 1);
+  if (duplicates.length > 0) {
+    findings.push({
+      id: 'REF-DUPLICATE-CAPTURE',
+      message:
+        `${duplicates.length} source${duplicates.length === 1 ? ' was' : 's were'} captured more than once at the same selector, producing references with identical measurements under different component names. The board reads larger than it is: renaming one capture does not make it a second piece of evidence. Capture a different part of that source, or drop the duplicate.`,
+      refs: duplicates.flatMap((bucket) => bucket.map(label)),
+    });
+  }
+
+  const parts = measurable.filter((ref) => !isWholePageCapture(ref));
+  if (parts.length < MIN_PART_CAPTURES) {
+    findings.push({
+      id: 'REF-NO-PARTS',
+      message:
+        `the board holds ${parts.length} component-scoped capture${parts.length === 1 ? '' : 's'}, below the ${MIN_PART_CAPTURES} needed to compose section by section. Section-granular composition takes each section's best-fit part from possibly different references; with no parts there is nothing to assemble and the build falls back to imitating one page.`,
+      refs: parts.map(label),
+    });
+  }
+
+  return findings;
+}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/lyu/01_Project/01_Projects/OhMyDesign/node_modules

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -102,6 +102,15 @@ instructions: |
   since how the experience is built (scroll sequence, WebGL/material treatment, timing) lives in the
   write-up. Study award work for principle and craft filtered through the subject's own identity anchor;
   never clone a famous showcase.
+  Capture parts, not pages. Every measured reference names the specific component it studies with
+  `omd ref add <url> --as <component> --selector "<css>" --blueprint --shot`. A capture scoped to
+  `main`, `body`, `html`, or `:root` measures the whole document: it yields a page average with no
+  component anatomy, and section-granular composition has nothing to take from it. Two captures of
+  the same source at the same selector are one piece of evidence wearing two names — capture a
+  different part of that source or drop the duplicate. Run `omd ref granularity` before handing the
+  board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS` each mean the board cannot
+  be assembled from and must be recaptured at component scope.
+
   For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
   material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"
   [--selector <part>]`, which records a `reference-craft-v1` motion signature (peak energy, whether it

--- a/test/board-granularity.test.ts
+++ b/test/board-granularity.test.ts
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MIN_PART_CAPTURES,
+  auditBoardGranularity,
+  captureSelector,
+  isWholePageCapture,
+} from '../core/ref/board-granularity.ts';
+import type { Reference } from '../core/types.ts';
+
+const ref = (source: string, component: string, selector?: string, extra: Partial<Reference> = {}): Reference => ({
+  source,
+  component,
+  kind: 'component',
+  capturedAt: '2026-07-25T00:00:00.000Z',
+  ...(selector === undefined ? {} : { selector }),
+  invariants: null,
+  principles: [],
+  ...extra,
+} as Reference);
+
+const parts = (n: number): Reference[] =>
+  Array.from({ length: n }, (_u, i) => ref(`https://site${i}.com`, `part-${i}`, `.part-${i}`));
+
+test('a page-root selector is a whole-page capture; a component selector is not', () => {
+  for (const root of ['main', 'body', 'html', ':root', '#root', '#__next', '*']) {
+    assert.equal(isWholePageCapture(ref('https://a.com', 'x', root)), true, `${root} must read as whole-page`);
+  }
+  assert.equal(isWholePageCapture(ref('https://a.com', 'x', '  MAIN  ')), true, 'case and padding must not evade the check');
+  assert.equal(isWholePageCapture(ref('https://a.com', 'x')), true, 'an unscoped capture is whole-page');
+  assert.equal(isWholePageCapture(ref('https://a.com', 'x', '.pricing-card')), false);
+});
+
+test('captureSelector prefers the blueprint selector the measurements were actually taken at', () => {
+  assert.equal(captureSelector({ selector: 'main', blueprint: { selector: '.hero' } } as never), '.hero');
+  assert.equal(captureSelector({ selector: '.nav' } as never), '.nav');
+  assert.equal(captureSelector({} as never), '');
+});
+
+test('the real board that shipped is caught: whole-page captures and same-source duplicates', () => {
+  // Reconstructed from the audited board: refs measured at `main`, and sources captured twice.
+  const board = [
+    ref('https://warp.dev', 'hero-terminal-warp', 'main'),
+    ref('https://warp.dev', 'motion-warp-hero', 'main'),
+    ref('https://ghostty.org', 'terminal-craft-ghostty', 'main'),
+    ref('https://ghostty.org', 'motion-ghostty-hero', 'main'),
+    ref('https://astro.build', 'process-diagram-astro', 'main'),
+  ];
+  const findings = auditBoardGranularity(board);
+  const ids = findings.map((f) => f.id);
+  assert.ok(ids.includes('REF-WHOLE-PAGE'), 'page-root captures must be named');
+  assert.ok(ids.includes('REF-DUPLICATE-CAPTURE'), 'same source at the same selector must be named');
+  assert.ok(ids.includes('REF-NO-PARTS'), 'a board with no parts cannot be assembled from');
+  const dup = findings.find((f) => f.id === 'REF-DUPLICATE-CAPTURE')!;
+  assert.ok(dup.refs.some((r) => r.includes('warp.dev')) && dup.refs.some((r) => r.includes('ghostty.org')));
+  assert.match(dup.message, /renaming one capture does not make it a second piece of evidence/);
+});
+
+test('a board of distinct component-scoped captures passes clean', () => {
+  assert.deepEqual(auditBoardGranularity(parts(MIN_PART_CAPTURES)), []);
+});
+
+test('two parts from the SAME source at different selectors are lawful evidence', () => {
+  const board = [
+    ref('https://linear.app', 'pricing-card', '.pricing-card'),
+    ref('https://linear.app', 'nav', 'header nav'),
+    ref('https://stripe.com', 'code-block', '.code'),
+  ];
+  assert.deepEqual(auditBoardGranularity(board), [], 'different parts of one site are different evidence');
+});
+
+test('image references carry reasoning, not anatomy, so they do not count as parts', () => {
+  const board = [
+    ...parts(MIN_PART_CAPTURES - 1),
+    ref('https://mood.com', 'mood-shot', undefined, { kind: 'image' }),
+  ];
+  const ids = auditBoardGranularity(board).map((f) => f.id);
+  assert.ok(ids.includes('REF-NO-PARTS'), 'an image cannot fill the part quota');
+  assert.ok(!ids.includes('REF-WHOLE-PAGE'), 'an unscoped image is not reported as a whole-page capture');
+});
+
+test('an empty board reports the missing parts rather than passing vacuously', () => {
+  const ids = auditBoardGranularity([]).map((f) => f.id);
+  assert.deepEqual(ids, ['REF-NO-PARTS']);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -777,3 +777,15 @@ test('artifact ownership is enforced in both the loop and the executable skill',
   // the ownership table must precede the stages it governs
   assert.ok(skill.indexOf('Artifact ownership is not advisory') < skill.indexOf('## 4. Composition contract'));
 });
+test('the scout and the reference protocol require component-scoped capture', () => {
+  const ra = read('core/protocol/reference-assembly.md').replace(/\s+/g, ' ');
+  assert.match(ra, /## Capture granularity/);
+  assert.match(ra, /a capture scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document/);
+  assert.match(ra, /`omd ref granularity` audits this and reports `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS`/);
+  assert.match(ra, /tracing a whole page is the derivative failure the transfer boundary forbids/);
+
+  const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(scout, /Capture parts, not pages/);
+  assert.match(scout, /Two captures of the same source at the same selector are one piece of evidence wearing two names/);
+  assert.match(scout, /Run `omd ref granularity` before handing the board on/);
+});


### PR DESCRIPTION
## The gap
Section-granular composition takes **each section's best-fit part** from possibly different references. That presupposes the board holds **parts**. The capability exists and is tested (`extractIr` with a selector reads only that subtree) — but **nothing checked that the scout used it**, and audited on a real board it had not:

```
warp.dev.hero-terminal-warp      selector: "main"   ← whole page
warp.dev.motion-warp-hero        selector: "main"   ← same page, renamed
ghostty.org.terminal-craft       selector: "main"   ← byte-identical invariants
ghostty.org.motion-ghostty-hero  selector: "main"   ← to its twin
```

The same page photographed twice is not two parts. A board like that can only be **traced**, and tracing a whole page is the derivative failure the transfer boundary forbids.

## What ships
`core/ref/board-granularity.ts` audits the captured board:
- **`REF-WHOLE-PAGE`** — captured at a page root (`main`, `body`, `html`, `:root`, `#root`, `#__next`, `*`, or unscoped): a page average with no component anatomy.
- **`REF-DUPLICATE-CAPTURE`** — the same source captured twice at the same selector. Renaming a capture does not make it a second piece of evidence.
- **`REF-NO-PARTS`** — fewer than three component-scoped captures: nothing to assemble from.

Two parts of **one** source at **different** selectors stay lawful — different parts are different evidence. Image references are excluded from the part count; they carry reasoning, not anatomy.

**`omd ref granularity`** exits 1 on any finding. `scout.agent.yaml` and `reference-assembly.md` now require component-scoped capture (`--selector … --blueprint --shot`) and the audit before the board is handed on.

## Validation
board-granularity + prompt-contract **64/64**, including a reconstruction of the exact shipped board which trips all three findings. CLI smoke on a duplicate board exits 1. typecheck + build clean. No release.