### PR TITLE
feat: catch a board that studies one slot repeatedly instead of covering the page

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -99,8 +99,16 @@ Capture parts, not pages. Every measured reference names the specific component 
 component anatomy, and section-granular composition has nothing to take from it. Two captures of
 the same source at the same selector are one piece of evidence wearing two names — capture a
 different part of that source or drop the duplicate. Run `omd ref granularity` before handing the
-board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS` each mean the board cannot
-be assembled from and must be recaptured at component scope.
+board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`, and
+`REF-SURFACE-UNCOVERED` each mean the board cannot be assembled from and must be recaptured at
+component scope, across the surfaces that still have nothing.
+
+Cover the page, do not restudy one slot. Capturing the same element from three sources answers
+"how do others build this one part" — worth doing once — but five captures that collapse onto two
+slots leave every other section with no evidence, and those sections then get whatever the build
+invents. Work down the surfaces the domain brief declares and capture the part that solves each
+one; a nav studied three times while the hero, the process section, and the proof section have
+nothing is a board that cannot be assembled from.
 
 For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
 material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -1718,7 +1718,17 @@ async function cmdRecipe(mode: string | undefined, opts: Opts): Promise<never> {
 async function cmdRefGranularity(opts: Opts): Promise<never> {
   const { loadRefs } = await import('../core/ref/store.ts');
   const { auditBoardGranularity } = await import('../core/ref/board-granularity.ts');
-  const findings = auditBoardGranularity(loadRefs(process.cwd()));
+  // The domain brief already declares the surfaces this run must compose; use its count so the
+  // audit can say how many of them would be built with no reference at all.
+  const briefPath = join(process.cwd(), '.omd', 'domain-brief.json');
+  let surfaces: number | undefined;
+  if (existsSync(briefPath)) {
+    try {
+      const brief = JSON.parse(readFileSync(briefPath, 'utf8')) as { surfaces?: unknown[] };
+      if (Array.isArray(brief.surfaces)) surfaces = brief.surfaces.length;
+    } catch { surfaces = undefined; }
+  }
+  const findings = auditBoardGranularity(loadRefs(process.cwd()), surfaces === undefined ? {} : { surfaces });
   if (opts.json) process.stdout.write(JSON.stringify({ ok: findings.length === 0, findings }));
   else if (findings.length === 0) console.log('ok — the board holds component-scoped parts to compose from');
   else for (const finding of findings) console.error(`[error] ${finding.id}: ${finding.message}\n  ${finding.refs.join('\n  ')}`);

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -48,9 +48,13 @@ studies (`omd ref add <url> --as <component> --selector "<css>" --blueprint --sh
 scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document and yields a
 page average with no component anatomy, so section-granular composition has nothing to take from it.
 Two captures of the same source at the same selector are one piece of evidence under two names and
-make the board read larger than it is. `omd ref granularity` audits this and reports
-`REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS`; any of the three means the board must
-be recaptured at component scope before composition, because a board of whole-page captures can only
+make the board read larger than it is. Granularity alone is not coverage. Five captures that collapse onto two slots — three navs and two
+install blocks — are two parts studied repeatedly while every other section carries no evidence, and
+those sections then get whatever the build invents. The board is worked down the surfaces the domain
+brief declares, one part per section it intends to compose. `omd ref granularity` audits both and
+reports `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`, and
+`REF-SURFACE-UNCOVERED`; any of them means the board must be recaptured at component scope across the
+surfaces that still have nothing, because a board of whole-page captures can only
 be traced, and tracing a whole page is the derivative failure the transfer boundary forbids.
 
 ## Subject anchor

--- a/core/ref/board-granularity.ts
+++ b/core/ref/board-granularity.ts
@@ -23,8 +23,16 @@ export const PAGE_ROOT_SELECTORS: ReadonlySet<string> = new Set([
 /** A board needs at least this many component-scoped captures before it can be assembled from. */
 export const MIN_PART_CAPTURES = 3;
 
+/**
+ * Captures of the SAME part from several sources are one slot studied repeatedly, not several parts.
+ * When one part accounts for at least this share of a board of at least `CONCENTRATION_MIN_CAPTURES`
+ * captures, the board is concentrated: it can compose that one slot well and has nothing for the rest.
+ */
+export const CONCENTRATION_SHARE = 0.5;
+export const CONCENTRATION_MIN_CAPTURES = 4;
+
 export type GranularityFinding = {
-  readonly id: 'REF-WHOLE-PAGE' | 'REF-DUPLICATE-CAPTURE' | 'REF-NO-PARTS';
+  readonly id: 'REF-WHOLE-PAGE' | 'REF-DUPLICATE-CAPTURE' | 'REF-NO-PARTS' | 'REF-PART-CONCENTRATION' | 'REF-SURFACE-UNCOVERED';
   readonly message: string;
   /** Reference identifiers the finding is about, as `source (component)`. */
   readonly refs: readonly string[];
@@ -50,7 +58,10 @@ export function isWholePageCapture(ref: Pick<Reference, 'selector'> & { blueprin
  * Image references are excluded from the part count: they carry reasoning, not anatomy, so they
  * cannot answer "how is this component built" even though they are lawful board members.
  */
-export function auditBoardGranularity(refs: readonly Reference[]): GranularityFinding[] {
+export function auditBoardGranularity(
+  refs: readonly Reference[],
+  opts: { readonly surfaces?: number } = {},
+): GranularityFinding[] {
   const findings: GranularityFinding[] = [];
   const measurable = refs.filter((ref) => ref.kind !== 'image');
 
@@ -88,6 +99,34 @@ export function auditBoardGranularity(refs: readonly Reference[]): GranularityFi
         `the board holds ${parts.length} component-scoped capture${parts.length === 1 ? '' : 's'}, below the ${MIN_PART_CAPTURES} needed to compose section by section. Section-granular composition takes each section's best-fit part from possibly different references; with no parts there is nothing to assemble and the build falls back to imitating one page.`,
       refs: parts.map(label),
     });
+  }
+
+  // Part diversity: three navs from three sites are one slot studied three times, not three parts.
+  if (parts.length >= CONCENTRATION_MIN_CAPTURES) {
+    const bySelector = new Map<string, Reference[]>();
+    for (const ref of parts) {
+      const key = captureSelector(ref);
+      const bucket = bySelector.get(key);
+      if (bucket) bucket.push(ref); else bySelector.set(key, [ref]);
+    }
+    const [topSelector, topRefs] = [...bySelector.entries()].sort((a, b) => b[1].length - a[1].length)[0]!;
+    if (topRefs.length / parts.length >= CONCENTRATION_SHARE) {
+      findings.push({
+        id: 'REF-PART-CONCENTRATION',
+        message:
+          `${topRefs.length} of ${parts.length} component captures measure the same part (\`${topSelector}\`), so the board studies one slot repeatedly instead of covering the page. Capturing the same element from several sources answers "how do others build this one part" — useful once — but it leaves every other section with no evidence to compose from. Capture the sections that still have none.`,
+        refs: topRefs.map(label),
+      });
+    }
+
+    if (opts.surfaces !== undefined && bySelector.size < opts.surfaces) {
+      findings.push({
+        id: 'REF-SURFACE-UNCOVERED',
+        message:
+          `the board holds ${bySelector.size} distinct part${bySelector.size === 1 ? '' : 's'} for ${opts.surfaces} surfaces the domain brief declares, so at least ${opts.surfaces - bySelector.size} surface${opts.surfaces - bySelector.size === 1 ? '' : 's'} will be composed with no reference at all. Section-granular composition needs a part per section it intends to compose; the sections with nothing fall back to whatever the build invents.`,
+        refs: [...bySelector.keys()].map((selector) => `part: ${selector}`),
+      });
+    }
   }
 
   return findings;

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/lyu/01_Project/01_Projects/OhMyDesign/node_modules

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -108,8 +108,16 @@ instructions: |
   component anatomy, and section-granular composition has nothing to take from it. Two captures of
   the same source at the same selector are one piece of evidence wearing two names — capture a
   different part of that source or drop the duplicate. Run `omd ref granularity` before handing the
-  board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS` each mean the board cannot
-  be assembled from and must be recaptured at component scope.
+  board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`, and
+  `REF-SURFACE-UNCOVERED` each mean the board cannot be assembled from and must be recaptured at
+  component scope, across the surfaces that still have nothing.
+
+  Cover the page, do not restudy one slot. Capturing the same element from three sources answers
+  "how do others build this one part" — worth doing once — but five captures that collapse onto two
+  slots leave every other section with no evidence, and those sections then get whatever the build
+  invents. Work down the surfaces the domain brief declares and capture the part that solves each
+  one; a nav studied three times while the hero, the process section, and the proof section have
+  nothing is a board that cannot be assembled from.
 
   For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
   material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"

--- a/test/board-granularity.test.ts
+++ b/test/board-granularity.test.ts
@@ -83,3 +83,52 @@ test('an empty board reports the missing parts rather than passing vacuously', (
   const ids = auditBoardGranularity([]).map((f) => f.id);
   assert.deepEqual(ids, ['REF-NO-PARTS']);
 });
+
+test('the real board is caught: five component captures collapsing onto two slots', () => {
+  // Reconstructed from the shipped board: three navs and two install code blocks, with every other
+  // section of the page carrying no reference at all.
+  const board = [
+    ref('https://bun.sh', 'cli-header-nav', 'header'),
+    ref('https://vite.dev', 'vite-header-nav', 'header'),
+    ref('https://www.warp.dev', 'warp-agentic-hero-craft', 'header'),
+    ref('https://bun.sh', 'cli-install-codeblock', 'pre'),
+    ref('https://vite.dev', 'hero-install-tabs', '.language-bash'),
+  ];
+  const findings = auditBoardGranularity(board, { surfaces: 5 });
+  const ids = findings.map((f) => f.id);
+  assert.ok(ids.includes('REF-PART-CONCENTRATION'), 'three navs out of five captures is one slot studied three times');
+  assert.ok(ids.includes('REF-SURFACE-UNCOVERED'), 'three distinct parts cannot compose five surfaces');
+  assert.ok(!ids.includes('REF-NO-PARTS'), 'these are genuine component captures');
+  assert.ok(!ids.includes('REF-WHOLE-PAGE'), 'none of them is a page root');
+  const conc = findings.find((f) => f.id === 'REF-PART-CONCENTRATION')!;
+  assert.match(conc.message, /3 of 5 component captures measure the same part \(`header`\)/);
+  assert.equal(conc.refs.length, 3);
+});
+
+test('a board with one part per surface passes the diversity audit', () => {
+  const board = [
+    ref('https://a.com', 'hero', '.hero'),
+    ref('https://b.com', 'pipeline', '.steps'),
+    ref('https://c.com', 'cards', '.grid'),
+    ref('https://d.com', 'install', 'pre'),
+    ref('https://e.com', 'footer', 'footer'),
+  ];
+  assert.deepEqual(auditBoardGranularity(board, { surfaces: 5 }), []);
+});
+
+test('concentration needs a real board; two captures of one part are not yet a pattern', () => {
+  const small = [ref('https://a.com', 'nav-a', 'header'), ref('https://b.com', 'nav-b', 'header'), ref('https://c.com', 'x', '.x')];
+  const ids = auditBoardGranularity(small).map((f) => f.id);
+  assert.ok(!ids.includes('REF-PART-CONCENTRATION'), 'below the capture minimum the share is noise');
+});
+
+test('surface coverage is only reported when the brief declared surfaces', () => {
+  const board = [
+    ref('https://a.com', 'hero', '.hero'),
+    ref('https://b.com', 'pipeline', '.steps'),
+    ref('https://c.com', 'cards', '.grid'),
+    ref('https://d.com', 'install', 'pre'),
+  ];
+  assert.ok(!auditBoardGranularity(board).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
+  assert.ok(auditBoardGranularity(board, { surfaces: 6 }).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -781,11 +781,15 @@ test('the scout and the reference protocol require component-scoped capture', ()
   const ra = read('core/protocol/reference-assembly.md').replace(/\s+/g, ' ');
   assert.match(ra, /## Capture granularity/);
   assert.match(ra, /a capture scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document/);
-  assert.match(ra, /`omd ref granularity` audits this and reports `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, and `REF-NO-PARTS`/);
+  assert.match(ra, /Granularity alone is not coverage/);
+  assert.match(ra, /three navs and two install blocks — are two parts studied repeatedly/);
+  assert.match(ra, /`REF-PART-CONCENTRATION`, and `REF-SURFACE-UNCOVERED`/);
   assert.match(ra, /tracing a whole page is the derivative failure the transfer boundary forbids/);
 
   const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
   assert.match(scout, /Capture parts, not pages/);
   assert.match(scout, /Two captures of the same source at the same selector are one piece of evidence wearing two names/);
   assert.match(scout, /Run `omd ref granularity` before handing the board on/);
+  assert.match(scout, /Cover the page, do not restudy one slot/);
+  assert.match(scout, /a nav studied three times while the hero, the process section, and the proof section have nothing/);
 });


### PR DESCRIPTION
## What the live board actually shows
#145 catches whole-page captures and same-source duplicates — and on the live board it correctly names **six page-root references**. But the five that *were* captured properly at component scope collapse onto **two slots**:

```
bun.sh     header          ← nav
vite.dev   header          ← nav
warp.dev   header          ← nav
bun.sh     pre             ← install code block
vite.dev   .language-bash  ← install code block
```

Hero, process, skills, proof, footer — **no reference at all**. Those sections then get whatever the build invents, which is the failure the entire reference stage exists to prevent.

## The distinction
Capturing one element from several sources answers *"how do others build this one part"* — worth doing **once**. It is not coverage.

- **`REF-PART-CONCENTRATION`** — one part accounts for ≥50% of a board of ≥4 component captures. Names the repeated selector and the references sharing it. Below four captures the share is noise and nothing is reported.
- **`REF-SURFACE-UNCOVERED`** — distinct part count below the surface count **the domain brief already declares**, so the audit says exactly how many surfaces would be composed with no reference.

`omd ref granularity` reads the surface count from `.omd/domain-brief.json` automatically. `scout.agent.yaml` and `reference-assembly.md` now require working down the declared surfaces rather than restudying one slot.

## Verified on the real board
```
REF-WHOLE-PAGE          6 references captured at a page root
REF-PART-CONCENTRATION  3 of 5 component captures measure the same part (header)
REF-SURFACE-UNCOVERED   3 distinct parts for 5 surfaces → ≥2 composed with no reference
```

Suites green, including a reconstruction of that board which trips both new findings while correctly staying silent on `REF-NO-PARTS` and `REF-WHOLE-PAGE`. typecheck + build clean. No release.