### PR TITLE
feat: coverage is measured per surface by name, and captures bind to the surface they answer

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -109,12 +109,17 @@ board — that the hero is covered when what exists is a third nav. The name is 
 readers see, so a mislabelled capture hides the board's real shape rather than merely being untidy.
 `REF-NAME-MISMATCH` reports it.
 
-Cover the page, do not restudy one slot. Capturing the same element from three sources answers
-"how do others build this one part" — worth doing once — but five captures that collapse onto two
-slots leave every other section with no evidence, and those sections then get whatever the build
-invents. Work down the surfaces the domain brief declares and capture the part that solves each
-one; a nav studied three times while the hero, the process section, and the proof section have
-nothing is a board that cannot be assembled from.
+Cover the result, not one slot. The domain brief's `surfaces` are the list of things the build has
+to compose, so they are the acquisition list: work down it and capture, for each surface, the part
+that solves that surface, binding the capture to it with
+`omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot`.
+A board is finished when every declared surface has at least one bound capture — not when a
+capture count looks respectable. Capturing the same element from three sources answers "how do
+others build this one part" and is worth doing once, but five captures that collapse onto two
+slots leave every other section with no evidence, and those sections then compose from whatever
+the build invents: a nav studied three times while the hero, the process section, and the proof
+section have nothing is a board that cannot be assembled from. `REF-SURFACE-UNCOVERED` names the
+surfaces that still have none.
 
 For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
 material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -108,6 +108,8 @@ interface Opts {
   costliestError?: string;
   /** UX anchor: surface classification — marketing | product | editorial | mixed. (`omd frame set --surface "..."`) */
   surface?: string;
+  /** The surface a capture is evidence for (`omd ref add … --slot hero`), named from the domain brief. */
+  slot?: string;
   /** Page to compare against the committed tokens (`omd tokens check --page <page>`). */
   page?: string;
   /** Lighthouse report path for `omd award score --lighthouse <report.json>`. */
@@ -810,7 +812,7 @@ async function cmdRefAddBatch(opts: Opts): Promise<never> {
 async function cmdRefAdd(opts: Opts): Promise<never> {
   const target = opts._[0];
   if (!target || !opts.as) {
-    console.error('usage: omd ref add <url|file> --as <component> [--selector "css"] [--image]');
+    console.error('usage: omd ref add <url|file> --as <component> [--slot <surface>] [--selector "css"] [--image]');
     process.exit(1);
   }
   if (opts.image && opts.selector) {
@@ -834,6 +836,7 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
       component: opts.as,
       kind: 'image',
       capturedAt: new Date().toISOString(),
+      ...(opts.slot ? { slot: opts.slot } : {}),
       invariants: null,
       principles: [],
       ...(opts.fromUser ? { origin: 'user' as const } : {}),
@@ -897,6 +900,7 @@ async function cmdRefAdd(opts: Opts): Promise<never> {
     kind: opts.selector ? 'component' : 'page',
     capturedAt: new Date().toISOString(),
     ...(opts.selector ? { selector: opts.selector } : {}),
+    ...(opts.slot ? { slot: opts.slot } : {}),
     invariants,
     principles: [],
     slopCount,
@@ -1721,14 +1725,18 @@ async function cmdRefGranularity(opts: Opts): Promise<never> {
   // The domain brief already declares the surfaces this run must compose; use its count so the
   // audit can say how many of them would be built with no reference at all.
   const briefPath = join(process.cwd(), '.omd', 'domain-brief.json');
-  let surfaces: number | undefined;
+  let surfaces: string[] | undefined;
   if (existsSync(briefPath)) {
     try {
-      const brief = JSON.parse(readFileSync(briefPath, 'utf8')) as { surfaces?: unknown[] };
-      if (Array.isArray(brief.surfaces)) surfaces = brief.surfaces.length;
+      const brief = JSON.parse(readFileSync(briefPath, 'utf8')) as { surfaces?: { name?: unknown }[] };
+      if (Array.isArray(brief.surfaces)) {
+        surfaces = brief.surfaces
+          .map((surface) => (typeof surface?.name === 'string' ? surface.name : ''))
+          .filter((name): name is string => name !== '');
+      }
     } catch { surfaces = undefined; }
   }
-  const findings = auditBoardGranularity(loadRefs(process.cwd()), surfaces === undefined ? {} : { surfaces });
+  const findings = auditBoardGranularity(loadRefs(process.cwd()), surfaces === undefined || surfaces.length === 0 ? {} : { surfaces });
   if (opts.json) process.stdout.write(JSON.stringify({ ok: findings.length === 0, findings }));
   else if (findings.length === 0) console.log('ok — the board holds component-scoped parts to compose from');
   else for (const finding of findings) console.error(`[error] ${finding.id}: ${finding.message}\n  ${finding.refs.join('\n  ')}`);
@@ -2754,7 +2762,7 @@ function usage(): never {
     + '  ref candidates [manifest]                   print chat-ready Korean-first candidate Markdown\n'
     + '  ref select <candidate-id> [--json]          bind a closed candidate selection to its evidence\n'
     + '  ref audit [--json]                          warn when references were captured sequentially (use ref add-batch)\n'
-    + '  ref granularity [--json]                    fail when the board holds no component-scoped parts\n'
+    + '  ref granularity [--json]                    fail when the board does not cover the surfaces to compose\n'
     + '\n'
     + '  design                                       discover evidence and create/refresh .omd/design.md\n'
     + '  design --check                              validate design.md section coverage\n'

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -50,8 +50,12 @@ page average with no component anatomy, so section-granular composition has noth
 Two captures of the same source at the same selector are one piece of evidence under two names and
 make the board read larger than it is. Granularity alone is not coverage. Five captures that collapse onto two slots — three navs and two
 install blocks — are two parts studied repeatedly while every other section carries no evidence, and
-those sections then get whatever the build invents. The board is worked down the surfaces the domain
-brief declares, one part per section it intends to compose. `omd ref granularity` audits both and
+those sections then compose from whatever the build invents. Coverage is measured per surface, by
+name: the domain brief's `surfaces` are the list of things the build must compose, so they are the
+acquisition list, and each capture is bound to the surface it answers
+(`omd ref add … --slot <surface>`). A board is finished when every declared surface has at least one
+bound capture — a capture count says nothing about whether the hero has evidence or the nav was
+studied five times, and it is the uncovered sections that need naming. `omd ref granularity` audits both and
 reports `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`,
 `REF-SURFACE-UNCOVERED`, and `REF-NAME-MISMATCH`. A capture is named for what it holds: a reference
 called `*-hero-*` captured at `header` tells every downstream reader that the hero is covered when

--- a/core/ref/board-granularity.ts
+++ b/core/ref/board-granularity.ts
@@ -101,7 +101,7 @@ export function isWholePageCapture(ref: Pick<Reference, 'selector'> & { blueprin
  */
 export function auditBoardGranularity(
   refs: readonly Reference[],
-  opts: { readonly surfaces?: number } = {},
+  opts: { readonly surfaces?: readonly string[] } = {},
 ): GranularityFinding[] {
   const findings: GranularityFinding[] = [];
   const measurable = refs.filter((ref) => ref.kind !== 'image');
@@ -175,12 +175,23 @@ export function auditBoardGranularity(
       });
     }
 
-    if (opts.surfaces !== undefined && bySelector.size < opts.surfaces) {
+  }
+
+  // Coverage is per surface, by name. A count comparison cannot tell a board that studied the nav
+  // five times from one that covered five sections, and it is the uncovered sections — the ones the
+  // build then invents from nothing — that the run needs named.
+  if (opts.surfaces !== undefined && opts.surfaces.length > 0) {
+    const covered = new Set(
+      parts.map((ref) => (ref.slot ?? '').trim().toLowerCase()).filter((slot) => slot !== ''),
+    );
+    const uncovered = opts.surfaces.filter((surface) => !covered.has(surface.trim().toLowerCase()));
+    if (uncovered.length > 0) {
       findings.push({
         id: 'REF-SURFACE-UNCOVERED',
-        message:
-          `the board holds ${bySelector.size} distinct part${bySelector.size === 1 ? '' : 's'} for ${opts.surfaces} surfaces the domain brief declares, so at least ${opts.surfaces - bySelector.size} surface${opts.surfaces - bySelector.size === 1 ? '' : 's'} will be composed with no reference at all. Section-granular composition needs a part per section it intends to compose; the sections with nothing fall back to whatever the build invents.`,
-        refs: [...bySelector.keys()].map((selector) => `part: ${selector}`),
+        message: covered.size === 0
+          ? `no capture is bound to a surface, so none of the ${opts.surfaces.length} surfaces the domain brief declares has evidence: ${opts.surfaces.join(', ')}. Bind each capture to the surface it answers with \`omd ref add … --slot <surface>\`; an unbound board can be counted but not checked, and every section then composes from whatever the build invents.`
+          : `${uncovered.length} of ${opts.surfaces.length} declared surfaces have no capture bound to them: ${uncovered.join(', ')}. Those sections compose from nothing. Capture the part that answers each with \`omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot\`.`,
+        refs: uncovered.map((surface) => `surface: ${surface}`),
       });
     }
   }

--- a/core/types.ts
+++ b/core/types.ts
@@ -525,6 +525,12 @@ export interface Reference {
   /** The CSS selector the measurements were taken from. Absent for `page` and `image`. */
   selector?: string;
   /**
+   * The slot this capture is evidence FOR, named from the surfaces the domain brief declares.
+   * Without it a board can be counted but not checked: five captures against five surfaces says
+   * nothing about whether the hero has evidence or the nav was studied five times.
+   */
+  slot?: string;
+  /**
    * Null for an image, and the type says so on purpose. Pixels cannot be measured this way:
    * there is no spacing ladder to read out of a JPEG. An image reference carries reasoning
    * and nothing else, which also means `ref distance` cannot check it for cloning.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -118,12 +118,17 @@ instructions: |
   readers see, so a mislabelled capture hides the board's real shape rather than merely being untidy.
   `REF-NAME-MISMATCH` reports it.
 
-  Cover the page, do not restudy one slot. Capturing the same element from three sources answers
-  "how do others build this one part" — worth doing once — but five captures that collapse onto two
-  slots leave every other section with no evidence, and those sections then get whatever the build
-  invents. Work down the surfaces the domain brief declares and capture the part that solves each
-  one; a nav studied three times while the hero, the process section, and the proof section have
-  nothing is a board that cannot be assembled from.
+  Cover the result, not one slot. The domain brief's `surfaces` are the list of things the build has
+  to compose, so they are the acquisition list: work down it and capture, for each surface, the part
+  that solves that surface, binding the capture to it with
+  `omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot`.
+  A board is finished when every declared surface has at least one bound capture — not when a
+  capture count looks respectable. Capturing the same element from three sources answers "how do
+  others build this one part" and is worth doing once, but five captures that collapse onto two
+  slots leave every other section with no evidence, and those sections then compose from whatever
+  the build invents: a nav studied three times while the hero, the process section, and the proof
+  section have nothing is a board that cannot be assembled from. `REF-SURFACE-UNCOVERED` names the
+  surfaces that still have none.
 
   For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
   material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"

--- a/test/board-granularity.test.ts
+++ b/test/board-granularity.test.ts
@@ -95,10 +95,13 @@ test('the real board is caught: five component captures collapsing onto two slot
     ref('https://bun.sh', 'cli-install-codeblock', 'pre'),
     ref('https://vite.dev', 'hero-install-tabs', '.language-bash'),
   ];
-  const findings = auditBoardGranularity(board, { surfaces: 5 });
+  const surfaces = ['hero', 'process-loop', 'skills-table', 'install', 'proof'];
+  const findings = auditBoardGranularity(board, { surfaces });
   const ids = findings.map((f) => f.id);
   assert.ok(ids.includes('REF-PART-CONCENTRATION'), 'three navs out of five captures is one slot studied three times');
-  assert.ok(ids.includes('REF-SURFACE-UNCOVERED'), 'three distinct parts cannot compose five surfaces');
+  const uncovered = findings.find((f) => f.id === 'REF-SURFACE-UNCOVERED')!;
+  assert.match(uncovered.message, /no capture is bound to a surface/, 'an unbound board covers nothing');
+  for (const surface of surfaces) assert.match(uncovered.message, new RegExp(surface), `${surface} must be named as uncovered`);
   assert.ok(!ids.includes('REF-NO-PARTS'), 'these are genuine component captures');
   assert.ok(!ids.includes('REF-WHOLE-PAGE'), 'none of them is a page root');
   const conc = findings.find((f) => f.id === 'REF-PART-CONCENTRATION')!;
@@ -106,15 +109,28 @@ test('the real board is caught: five component captures collapsing onto two slot
   assert.equal(conc.refs.length, 3);
 });
 
-test('a board with one part per surface passes the diversity audit', () => {
+test('a board with one bound part per surface passes', () => {
   const board = [
-    ref('https://a.com', 'hero', '.hero'),
-    ref('https://b.com', 'pipeline', '.steps'),
-    ref('https://c.com', 'cards', '.grid'),
-    ref('https://d.com', 'install', 'pre'),
-    ref('https://e.com', 'footer', 'footer'),
+    ref('https://a.com', 'hero-band', '.hero', { slot: 'hero' }),
+    ref('https://b.com', 'pipeline', '.steps', { slot: 'process-loop' }),
+    ref('https://c.com', 'cards', '.grid', { slot: 'skills-table' }),
+    ref('https://d.com', 'install-codeblock', 'pre', { slot: 'install' }),
+    ref('https://e.com', 'site-footer', 'footer', { slot: 'proof' }),
   ];
-  assert.deepEqual(auditBoardGranularity(board, { surfaces: 5 }), []);
+  assert.deepEqual(auditBoardGranularity(board, { surfaces: ['hero', 'process-loop', 'skills-table', 'install', 'proof'] }), []);
+});
+
+test('coverage names exactly the surfaces with no bound capture', () => {
+  const board = [
+    ref('https://a.com', 'hero-band', '.hero', { slot: 'hero' }),
+    ref('https://b.com', 'install-codeblock', 'pre', { slot: 'install' }),
+    ref('https://c.com', 'cards', '.grid', { slot: 'skills-table' }),
+    ref('https://d.com', 'nav-a', 'header', { slot: 'hero' }),
+  ];
+  const finding = auditBoardGranularity(board, { surfaces: ['hero', 'process-loop', 'install', 'skills-table', 'proof'] })
+    .find((f) => f.id === 'REF-SURFACE-UNCOVERED')!;
+  assert.match(finding.message, /2 of 5 declared surfaces have no capture bound to them: process-loop, proof/);
+  assert.deepEqual([...finding.refs], ['surface: process-loop', 'surface: proof']);
 });
 
 test('concentration needs a real board; two captures of one part are not yet a pattern', () => {
@@ -131,7 +147,7 @@ test('surface coverage is only reported when the brief declared surfaces', () =>
     ref('https://d.com', 'install', 'pre'),
   ];
   assert.ok(!auditBoardGranularity(board).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
-  assert.ok(auditBoardGranularity(board, { surfaces: 6 }).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
+  assert.ok(auditBoardGranularity(board, { surfaces: ['hero', 'install'] }).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
 });
 
 test('a reference whose name claims a slot its capture contradicts is named', () => {

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -783,6 +783,8 @@ test('the scout and the reference protocol require component-scoped capture', ()
   assert.match(ra, /a capture scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document/);
   assert.match(ra, /Granularity alone is not coverage/);
   assert.match(ra, /three navs and two install blocks — are two parts studied repeatedly/);
+  assert.match(ra, /Coverage is measured per surface, by name/);
+  assert.match(ra, /A board is finished when every declared surface has at least one bound capture/);
   assert.match(ra, /`REF-SURFACE-UNCOVERED`, and `REF-NAME-MISMATCH`/);
   assert.match(ra, /A capture is named for what it holds/);
   assert.match(ra, /tracing a whole page is the derivative failure the transfer boundary forbids/);
@@ -791,7 +793,9 @@ test('the scout and the reference protocol require component-scoped capture', ()
   assert.match(scout, /Capture parts, not pages/);
   assert.match(scout, /Two captures of the same source at the same selector are one piece of evidence wearing two names/);
   assert.match(scout, /Run `omd ref granularity` before handing the board on/);
-  assert.match(scout, /Cover the page, do not restudy one slot/);
+  assert.match(scout, /Cover the result, not one slot/);
+  assert.match(scout, /`omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot`/);
+  assert.match(scout, /`REF-SURFACE-UNCOVERED` names the surfaces that still have none/);
   assert.match(scout, /Name a capture for what it holds/);
   assert.match(scout, /`REF-NAME-MISMATCH` reports it/);
   assert.match(scout, /a nav studied three times while the hero, the process section, and the proof section have nothing/);


### PR DESCRIPTION
## The requirement
The board must cover **everything the result is made of**. The previous check compared a distinct-part **count** against a surface count — which cannot tell a board that studied the nav five times from one that covered five sections. And it is the **uncovered sections**, the ones the build then invents from nothing, that the run needs named.

## What ships
- **`Reference.slot`** — the surface a capture is evidence *for*, named from the domain brief's `surfaces`. Recorded by **`omd ref add … --slot <surface>`**. (`--surface` was already taken by the frame's `marketing`/`product` classification; `slot` is the vocabulary `reference-usage` already uses for exactly this.)
- **`REF-SURFACE-UNCOVERED`** now takes the declared surface **names** and reports precisely which have no bound capture — with a distinct message for the case that matters most in practice: when **no capture is bound at all**, none of the declared surfaces has evidence and every one is listed.
- `omd ref granularity` reads the names from `.omd/domain-brief.json` automatically, and stays silent when no brief declares surfaces.
- `scout.agent.yaml` + `reference-assembly.md`: the brief's `surfaces` **are the acquisition list**. Work down it, capture the part that solves each, bind it. **A board is finished when every declared surface has at least one bound capture** — not when a capture count looks respectable.

## Validation
**109/109** across board-granularity, prompt-contract, reference, ref-granularity. Includes a board with one bound part per surface that passes clean; a partially bound board where the finding names exactly `process-loop, proof`; and the live unbound board where it lists all five declared surfaces. typecheck + build clean. No release.