### PR TITLE
fix: Claude marketplace agents also inherit the selected model

### DIFF
--- a/adapters/claude.ts
+++ b/adapters/claude.ts
@@ -166,6 +166,8 @@ function emitAgentFilePlugin(agent: AbstractAgent): string {
     '---',
     `name: ${stripOmdPrefix(agent.name)}`,
     `description: ${yamlScalar(pluginizeRefs(agent.description))}`,
+    'model: inherit',
+    `effort: ${agent.reasoning}`,
   ];
   if (agent.deny?.length) frontmatter.push(`disallowedTools: ${agent.deny.join(', ')}`);
   frontmatter.push('---', '');

--- a/agents/composer.md
+++ b/agents/composer.md
@@ -1,6 +1,8 @@
 ---
 name: composer
 description: "Converts sanitized evidence into a durable, fresh page-composition contract before sketches."
+model: inherit
+effort: high
 ---
 
 Own only `.omd/composition.md`. Read `protocol/human-design-loop.md`,

--- a/agents/eye.md
+++ b/agents/eye.md
@@ -1,6 +1,8 @@
 ---
 name: eye
 description: "Blindly critiques anonymous renders or selects a structural sketch; never edits."
+model: inherit
+effort: high
 disallowedTools: Write, Edit, apply_patch
 ---
 

--- a/agents/framer.md
+++ b/agents/framer.md
@@ -1,6 +1,8 @@
 ---
 name: framer
 description: "Interrogates a design brief and records an evidence-backed framing before drawing."
+model: inherit
+effort: high
 disallowedTools: apply_patch
 ---
 

--- a/agents/glance.md
+++ b/agents/glance.md
@@ -1,6 +1,8 @@
 ---
 name: glance
 description: "Reads only squint renders and reports their immediate visual hierarchy."
+model: inherit
+effort: medium
 disallowedTools: Write, Edit, apply_patch
 ---
 

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -1,6 +1,8 @@
 ---
 name: hand
 description: "Builds one selected structure and reflects on two real-content renders while building."
+model: inherit
+effort: medium
 ---
 
 Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, the exact `theory/ux.md`, plus the relevant theory,

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -1,6 +1,8 @@
 ---
 name: scout
 description: "Builds a coverage-complete measured LEGO reference assembly without copying pixels."
+model: inherit
+effort: high
 disallowedTools: Write, Edit, apply_patch
 ---
 

--- a/agents/sketch.md
+++ b/agents/sketch.md
@@ -1,6 +1,8 @@
 ---
 name: sketch
 description: "Produces one isolated, low-fidelity structural candidate from real copy."
+model: inherit
+effort: medium
 ---
 
 Read `protocol/human-design-loop.md` under `omd pack dir` and obey its isolation boundary.

--- a/agents/typesetter.md
+++ b/agents/typesetter.md
@@ -1,6 +1,8 @@
 ---
 name: typesetter
 description: "Proves target-language typography with real copy before page structure begins."
+model: inherit
+effort: high
 ---
 
 Own typography proof, not page design. Read `protocol/human-design-loop.md`, the exact

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -1,6 +1,8 @@
 ---
 name: writer
 description: "Writes and repairs the evidence-traceable copy deck before interface structure begins."
+model: inherit
+effort: high
 ---
 
 You own copy, not layout. Read the user brief, the scout's cited voice/audience evidence,

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -108,6 +108,19 @@ test('emitClaudePlugin strips the omd- prefix from agent filename and frontmatte
   assert.ok(!md.includes('omd-framer'), `filename prefix leaked into body: ${md}`);
 });
 
+test('Claude marketplace agents inherit the session model and vary only role effort', () => {
+  const high = textFile(emitClaudePlugin({ agents: [PLUGIN_AGENT] }), 'agents/framer.md');
+  assert.match(high, /^model: inherit$/m);
+  assert.match(high, /^effort: high$/m);
+  assert.ok(!/^model: (?:opus|sonnet|haiku)$/m.test(high));
+
+  const hand = textFile(emitClaudePlugin({
+    agents: [{ ...PLUGIN_AGENT, name: 'omd-hand', reasoning: 'medium' }],
+  }), 'agents/hand.md');
+  assert.match(hand, /^model: inherit$/m);
+  assert.match(hand, /^effort: medium$/m);
+});
+
 test('emitClaudePlugin rewrites subagent/skill cross-references to the oh-my-design: plugin form', () => {
   const md = textFile(emitClaudePlugin({ agents: [PLUGIN_AGENT] }), 'agents/framer.md');
   assert.ok(md.includes('oh-my-design:eye'), `expected oh-my-design:eye in body: ${md}`);


### PR DESCRIPTION
## Follow-up to #149
Post-install inspection found Claude has **two emission paths**:

1. direct host (fixed in #149),
2. marketplace plugin, via a separate `emitAgentFilePlugin`.

The installed marketplace `agents/eye.md` still omitted both `model: inherit` and `effort`. The direct-host test passed while the path users actually install remained under-specified.

## Fix
Marketplace agents now emit the same invariant:

```yaml
# eye
model: inherit
effort: high

# hand
model: inherit
effort: medium
```

No Claude agent pins Opus, Sonnet, or Haiku. A dedicated marketplace-flavor contract prevents direct-host coverage from masking this path again.

## Validation
Adapter + regression **34/34**; typecheck/build clean; generated plugin metadata inspected. No release.