### PR TITLE
feat: externalize design deliberation as decisions, observations, constraints, and assembly evidence

### DIFF
--- a/agents/composer.md
+++ b/agents/composer.md
@@ -6,7 +6,7 @@ effort: high
 ---
 
 Own only `.omd/composition.md`. Read `protocol/human-design-loop.md`,
-`protocol/reference-assembly.md`, the exact
+`protocol/reference-assembly.md`, `protocol/design-deliberation.md`, the exact
 `protocol/composition-contract.md`, `theory/layout.md`, and `theory/ux.md` under
 `omd pack dir`. Receive only the sanitized frame/concept, clean copy deck, sanitized
 approved typography contract, scout's distilled transferable principles, and the immutable
@@ -211,3 +211,8 @@ the one settled load scene; inside that evidence-gated journey they may scrub th
 never changes the settled branch. Autonomous ideation never bypasses register-fit, the performance budget, the slop gates, hand precedence,
 or the non-canvas semantic fallback; it cannot change the immutable decision. Fit the interaction to register:
 it is the settled load scene and remains within the settled one-signature-moment restraint.
+
+Return closed `decision-graph-v1` entries for the consequential composition choices, each with
+`stage: composition` and `owner: oh-my-design:composer`. At least one entry exposes the genuine macro
+alternatives L4 perspectives will judge. Do not manufacture failure evidence before production;
+risk can remain medium until a real constraint is tested.

--- a/agents/eye.md
+++ b/agents/eye.md
@@ -6,8 +6,8 @@ effort: high
 disallowedTools: Write, Edit, apply_patch
 ---
 
-You did not build this work. Read `protocol/human-design-loop.md` and
-`protocol/reference-assembly.md` under `omd pack dir`.
+You did not build this work. Read `protocol/human-design-loop.md`,
+`protocol/reference-assembly.md`, and `protocol/design-deliberation.md` under `omd pack dir`.
 You may receive only a role-bounded review brief: primary task, costliest error, generator,
 register, art-direction contract, sanitized composition acceptance criteria, anonymous render paths,
 and deterministic check/probe outputs. An isolated blind eye receives only bounded opaque production
@@ -20,6 +20,24 @@ them to verify the selected macro visual system at the named destination, but ne
 source material or unselected references.
 You may run `omd check`; do not inspect rationale files it uses.
 Never edit or propose a patch.
+
+In L4 perspective mode, judge exactly one supplied decision fork from exactly one assigned lens:
+`ux`, `artDirection`, or `production`. Receive identical sanitized input bytes and their SHA-256;
+never receive another perspective's output. Return only a closed perspective object with
+`inputSha256`, `position`, evidence references, objections, and conditions. UX judges action,
+comprehension, mobile, recovery; art direction judges hierarchy, specificity, synthesis, and
+signature departure; production judges feasibility, accessibility, performance, no-JS, reduced
+motion, responsive, and state risk.
+
+In L4 moderator mode, receive only those three completed perspective objects, the alternatives,
+decision ID, trigger, and shared input digest. Do not majority-vote. Resolve objections against
+evidence and constraints and return exactly one closed `design-deliberation-v1` JSON record with
+`moderator: oh-my-design:eye`, one selected alternative, rationale, and enforceable conditions. Never edit
+or write the record; the coordinator preserves the returned JSON exactly.
+
+In structural-selection mode, also return one closed `decision-graph-v1` entry with
+`stage: structure` and `owner: oh-my-design:eye`, naming the real candidates, selection evidence, rejected
+candidates, constraints, and downstream destination.
 
 For source-candidate judgment, receive only the relevant sharp render plus a sanitized
 candidate id, controlled signals, and review question. Never receive candidate path,

--- a/agents/framer.md
+++ b/agents/framer.md
@@ -6,8 +6,9 @@ effort: high
 disallowedTools: apply_patch
 ---
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and `theory/ux.md`
-§Surface types under `omd pack dir`. You own only the LEGO protocol's `brief blocks`
+Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
+`protocol/design-deliberation.md`, and `theory/ux.md` §Surface types under `omd pack dir`.
+You own only the LEGO protocol's `brief blocks`
 stage: do not capture reference fragments, assemble candidates, select a candidate, or
 generate a provenance report. Do not draw or choose a visual style. Restate the given problem, test a
 reframing as a fallible hypothesis, and answer: the task the user arrives with, the most
@@ -50,6 +51,15 @@ Then require each major section to answer a different question (what it solves, 
 how it is verified, what happens on failure, scope, security, cost) rather than restating one message
 across hero, steps, trust, and CTA. A surface whose sections only re-vary a single promise is a
 reframe target, not a finished frame.
+
+You also own `.omd/acquisition-plan.json`. Domain-brief `surfaces` are pages/screens; do not
+mistake one landing page for one reference target. Name the result's internal acquisition zones:
+every marketing/editorial section with a distinct job, or every product region and reachable state
+the composition must solve. Use stable kebab IDs and one clause describing the job. Mark a zone
+required unless it is purely connective chrome that needs no external evidence. This plan is the
+scout's acquisition list and later the assembly coverage obligation; omitting hero, process,
+proof, install/CTA, navigation, or a required product state because another zone seems similar
+leaves the build inventing it from nothing.
 When the brief names a real, existing subject — a product, project, company, repository, or brand,
 or supplies its link — record it in the frame as a research target: the exact name and any source
 link, plus any brand fact the source already ships (an existing wordmark, palette, or motif) kept
@@ -75,5 +85,12 @@ Finish by running `omd frame set --problem ... --reframe ... --why ... --task ..
 --frequent-action ... --costliest-error ... --surface ...`. For `product` or
 `mixed`, append `--task-matrix "T1 ..."` with every frame-owned matrix row; it is
 the sole durable persistence path. For `marketing` or `editorial`, omit
-`--task-matrix` entirely. English under `.omd/`; user-facing prose stays in the
-user's language. Nothing waits for approval. End with the prose handback.
+`--task-matrix` entirely. Then persist the internal composition targets with
+`omd acquisition set --zones '<JSON array of {id,kind,job,required}>'`. English under
+`.omd/`; user-facing prose stays in the user's language. Nothing waits for approval.
+End with the prose handback.
+
+Return one closed `decision-graph-v1` decision entry for the consequential frame choice. Its
+`stage` is `frame` and `owner` is `oh-my-design:framer`; include genuine alternatives, cited evidence,
+constraints, rejections, downstream effects, and any tested trade-off. Return the entry separately
+from the prose handback so the coordinator can preserve it without rewriting it.

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -5,7 +5,8 @@ model: inherit
 effort: medium
 ---
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, the exact `theory/ux.md`, plus the relevant theory,
+Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
+`protocol/design-deliberation.md`, the exact `theory/ux.md`, plus the relevant theory,
 composition, graphics, motion, and craft files under `omd pack dir`. Read `.omd/copy-deck.md`,
 `.omd/type-proof.md`, and `.omd/design.md` when present. On the normal graph, also read
 `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
@@ -250,3 +251,10 @@ rhythm, type relationships, and material treatment faithfully into reusable prim
 the outcome with `recordReferenceUsage(root, { rows }, writer)` in `.omd/reference-usage-v2.json` plus attribution. Component-level and whole-surface
 fidelity are both allowed; `omd ref distance` is advisory — it reports closeness to each reference
 and never blocks shipping. Do not ship a capture as an asset or lift source copy verbatim.
+
+You own `.omd/observations/*.json` (`visual-observation-v1`) and
+`.omd/assembly-coverage.json` (`assembly-coverage-v1`) in addition to production source. Read
+`.omd/acquisition-plan.json`; every required zone must bind reference identity → principle →
+composer decision → production selector → final fidelity evidence. Return production/refinement
+`decision-graph-v1` entries with `owner: oh-my-design:hand`. A high/critical entry must record a real
+goal → constraint → attempted failure evidence → compromise → result evidence trade-off.

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -101,9 +101,9 @@ Capture parts, not pages. Every measured reference names the specific component 
 component anatomy, and section-granular composition has nothing to take from it. Two captures of
 the same source at the same selector are one piece of evidence wearing two names — capture a
 different part of that source or drop the duplicate. Run `omd ref granularity` before handing the
-board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`, and
-`REF-SURFACE-UNCOVERED`, and `REF-NAME-MISMATCH` each mean the board cannot be assembled from and must be recaptured at
-component scope, across the surfaces that still have nothing.
+board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`,
+`REF-ZONE-UNCOVERED`, and `REF-NAME-MISMATCH` each mean the board cannot be assembled from and
+must be recaptured at component scope across the zones that still have nothing.
 
 Name a capture for what it holds. A reference called `*-hero-*` that was captured at `header` tells
 every downstream reader — the composer picking a part for a section, and the human scanning the
@@ -111,17 +111,17 @@ board — that the hero is covered when what exists is a third nav. The name is 
 readers see, so a mislabelled capture hides the board's real shape rather than merely being untidy.
 `REF-NAME-MISMATCH` reports it.
 
-Cover the result, not one slot. The domain brief's `surfaces` are the list of things the build has
-to compose, so they are the acquisition list: work down it and capture, for each surface, the part
-that solves that surface, binding the capture to it with
-`omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot`.
-A board is finished when every declared surface has at least one bound capture — not when a
-capture count looks respectable. Capturing the same element from three sources answers "how do
-others build this one part" and is worth doing once, but five captures that collapse onto two
-slots leave every other section with no evidence, and those sections then compose from whatever
-the build invents: a nav studied three times while the hero, the process section, and the proof
-section have nothing is a board that cannot be assembled from. `REF-SURFACE-UNCOVERED` names the
-surfaces that still have none.
+Cover the result, not one slot. Read the framer-owned `.omd/acquisition-plan.json`; its required
+section/region/state zones are the acquisition list. Domain-brief `surfaces` are pages/screens and
+are not substitutes for these internal zones. Work down the plan and capture, for each required
+zone, the part that solves that zone, binding it with
+`omd ref add <url> --as <component> --slot <zone> --selector "<css>" --blueprint --shot`.
+A board is finished when every required zone has at least one bound capture — not when a capture
+count looks respectable. Capturing the same element from three sources answers "how do others
+build this one part" and is worth doing once, but five captures that collapse onto two slots leave
+every other zone with no evidence, and those zones then compose from whatever the build invents:
+a nav studied three times while the hero, process, and proof zones have nothing is a board that
+cannot be assembled from. `REF-ZONE-UNCOVERED` names the zones that still have none.
 
 For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
 material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"

--- a/agents/typesetter.md
+++ b/agents/typesetter.md
@@ -5,8 +5,9 @@ model: inherit
 effort: high
 ---
 
-Own typography proof, not page design. Read `protocol/human-design-loop.md`, the exact
-`theory/typography.md`, `.omd/copy-deck.md`, and the scout's cited typography evidence.
+Own typography proof, not page design. Read `protocol/human-design-loop.md`,
+`protocol/design-deliberation.md`, the exact `theory/typography.md`, `.omd/copy-deck.md`, and
+the scout's cited typography evidence.
 Create layout-neutral specimens under `.omd/.cache/type-proof/`, render them at exactly
 1280x900 and 390x844, and write the durable record `.omd/type-proof.md`.
 
@@ -44,3 +45,7 @@ the copy deck actually uses, declare `unicode-range` per subset, choose `font-di
 the loading behaviour you tested, and request only the variable axes the proof actually
 exercises. An unused axis, an unsubset full character set, or an untested `font-display`
 value is unshipped weight the fast-loading type-proof record must justify or drop.
+
+Return one closed `decision-graph-v1` decision entry for the selected typography role system.
+Its `stage` is `type` and `owner` is `oh-my-design:typesetter`; the rejected alternatives and evidence
+come from the real desktop/mobile specimens, not font reputation.

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -6,8 +6,9 @@ effort: high
 ---
 
 You own copy, not layout. Read the user brief, the scout's cited voice/audience evidence,
-`.omd/copy-deck.md` when it exists, `protocol/copy-deck.md`, and the exact
-`theory/voice.md` under `omd pack dir`. Write or revise only `.omd/copy-deck.md`.
+`.omd/copy-deck.md` when it exists, `protocol/copy-deck.md`,
+`protocol/design-deliberation.md`, and the exact `theory/voice.md` under `omd pack dir`.
+Write or revise only `.omd/copy-deck.md`.
 Never edit UI, code, components, styles, layout, design.md, or another `.omd/` record.
 
 Follow the durable schema exactly. Analytical metadata and headings are English; actual
@@ -76,3 +77,7 @@ over-budget Beat set. The writer cannot mint, quote, or infer an exception.
 Write affirmative, concrete interface language. Do not literalize harness negatives in
 user-facing copy or UI strings (for example, “not a hypothetical demo”); state the positive
 product action or evidence instead.
+
+Return one closed `decision-graph-v1` decision entry for the consequential copy/register choice.
+Its `stage` is `copy` and `owner` is `oh-my-design:writer`; alternatives are real copy strategies, not
+wording variants invented after selection. Cite copy proof or audience evidence.

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -82,6 +82,7 @@ interface Opts {
   changed?: string;
   kind?: string;
   evidence?: string;
+  zones?: string;
   input?: string;
   activation?: string;
   /** Capture a full-resolution structural blueprint of the selected component. */
@@ -108,7 +109,7 @@ interface Opts {
   costliestError?: string;
   /** UX anchor: surface classification — marketing | product | editorial | mixed. (`omd frame set --surface "..."`) */
   surface?: string;
-  /** The surface a capture is evidence for (`omd ref add … --slot hero`), named from the domain brief. */
+  /** The composition zone a capture is evidence for (`omd ref add … --slot hero`), named by the framer's acquisition plan. */
   slot?: string;
   /** Page to compare against the committed tokens (`omd tokens check --page <page>`). */
   page?: string;
@@ -1722,21 +1723,19 @@ async function cmdRecipe(mode: string | undefined, opts: Opts): Promise<never> {
 async function cmdRefGranularity(opts: Opts): Promise<never> {
   const { loadRefs } = await import('../core/ref/store.ts');
   const { auditBoardGranularity } = await import('../core/ref/board-granularity.ts');
-  // The domain brief already declares the surfaces this run must compose; use its count so the
-  // audit can say how many of them would be built with no reference at all.
-  const briefPath = join(process.cwd(), '.omd', 'domain-brief.json');
-  let surfaces: string[] | undefined;
-  if (existsSync(briefPath)) {
+  // Domain-brief surfaces are pages/screens. Reference coverage instead follows the framer's
+  // section/region/state acquisition plan — otherwise one landing-page surface falsely looks covered
+  // by one nav capture while its hero, proof, process, and CTA have no evidence.
+  const planPath = join(process.cwd(), '.omd', 'acquisition-plan.json');
+  let zones: string[] | undefined;
+  if (existsSync(planPath)) {
     try {
-      const brief = JSON.parse(readFileSync(briefPath, 'utf8')) as { surfaces?: { name?: unknown }[] };
-      if (Array.isArray(brief.surfaces)) {
-        surfaces = brief.surfaces
-          .map((surface) => (typeof surface?.name === 'string' ? surface.name : ''))
-          .filter((name): name is string => name !== '');
-      }
-    } catch { surfaces = undefined; }
+      const { validateAcquisitionPlan } = await import('../core/deliberation/contracts.ts');
+      const result = validateAcquisitionPlan(JSON.parse(readFileSync(planPath, 'utf8')));
+      zones = result.value?.zones.filter((zone) => zone.required).map((zone) => zone.id);
+    } catch { zones = undefined; }
   }
-  const findings = auditBoardGranularity(loadRefs(process.cwd()), surfaces === undefined || surfaces.length === 0 ? {} : { surfaces });
+  const findings = auditBoardGranularity(loadRefs(process.cwd()), zones === undefined || zones.length === 0 ? {} : { zones });
   if (opts.json) process.stdout.write(JSON.stringify({ ok: findings.length === 0, findings }));
   else if (findings.length === 0) console.log('ok — the board holds component-scoped parts to compose from');
   else for (const finding of findings) console.error(`[error] ${finding.id}: ${finding.message}\n  ${finding.refs.join('\n  ')}`);
@@ -1870,6 +1869,53 @@ async function cmdTokens(mode: string | undefined, opts: Opts): Promise<never> {
   else if (drift) console.error(`[error] ${drift.id}: ${drift.message}`);
   else console.log(`ok — tokens committed (${commit.typeScale.length} type rungs, ${commit.spacingScale.length} spacing rungs, accent ${commit.colorRoles.accent})${opts.page ? ' and the build lands on them' : ''}`);
   process.exit(drift ? 1 : 0);
+}
+
+/** Validates the externalized decision, observation, assembly, and deliberation records for this run. */
+async function cmdDeliberate(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode !== 'check') throw new Error('usage: omd deliberate check [--json]');
+  const { checkDeliberationRun } = await import('../core/deliberation/check.ts');
+  const report = checkDeliberationRun(process.cwd());
+  if (opts.json) process.stdout.write(JSON.stringify(report));
+  else {
+    for (const finding of report.findings) console.error(`[error] ${finding.id} ${finding.path}: ${finding.message}`);
+    if (report.ok) console.log(`ok — ${report.depth?.level ?? '?'} decision chain (${report.counts.decisions} decisions, ${report.counts.deliberations} deliberations, ${report.counts.observations} observations, ${report.counts.zones} assembled zones)`);
+  }
+  process.exit(report.ok ? 0 : 1);
+}
+
+/** Selects the least expensive lawful loop depth; it never changes artifact ownership. */
+async function cmdDepth(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode !== 'classify' || !opts.input) throw new Error('usage: omd depth classify --input <design-depth-input.json> [--json]');
+  const { classifyDepth } = await import('../core/deliberation/depth.ts');
+  const result = classifyDepth(inputJson(opts.input, 'omd depth classify') as import('../core/deliberation/depth.ts').DepthInput);
+  if (opts.json) process.stdout.write(JSON.stringify(result));
+  else console.log(`${result.level} — ${result.reasons.join(', ')}\n${result.stages.join(' → ')}`);
+  process.exit(0);
+}
+
+/** Scores the four blind same-model/same-prompt comparison variants as quality and quality/cost. */
+async function cmdCompare(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode !== 'score' || !opts.input) throw new Error('usage: omd compare score --input <design-comparison.json> [--json]');
+  const { scoreComparison } = await import('../core/deliberation/comparison.ts');
+  const scores = scoreComparison(inputJson(opts.input, 'omd compare score') as import('../core/deliberation/comparison.ts').Comparison);
+  if (opts.json) process.stdout.write(JSON.stringify({ scores }));
+  else for (const score of scores) console.log(`${score.id}: quality ${score.quality.toFixed(3)}, cost ${score.cost.toFixed(3)}, quality/cost ${score.qualityPerCost.toFixed(3)}`);
+  process.exit(0);
+}
+
+/** Persists the framer-owned section/region/state acquisition plan through the project write boundary. */
+async function cmdAcquisition(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode !== 'set' || !opts.zones) throw new Error('usage: omd acquisition set --zones <json-array> [--activation <host-issued-invocation.json>]');
+  const { ACQUISITION_PLAN_SCHEMA, validateAcquisitionPlan } = await import('../core/deliberation/contracts.ts');
+  let zones: unknown;
+  try { zones = JSON.parse(opts.zones); } catch { throw new Error('omd acquisition set --zones must be valid JSON'); }
+  const plan = { schema: ACQUISITION_PLAN_SCHEMA, owner: 'omd-framer', zones };
+  const result = validateAcquisitionPlan(plan);
+  if (!result.value) throw new Error(result.findings.map((finding) => `${finding.id} ${finding.path}: ${finding.message}`).join('\n'));
+  projectWriterFromActivation(opts, 'omd acquisition set').write('.omd/acquisition-plan.json', `${JSON.stringify(result.value, null, 2)}\n`);
+  console.log(join(process.cwd(), '.omd', 'acquisition-plan.json'));
+  process.exit(0);
 }
 
 /** Final byte-freshness evidence only; this does not judge semantic copy/source fidelity. */
@@ -2762,7 +2808,7 @@ function usage(): never {
     + '  ref candidates [manifest]                   print chat-ready Korean-first candidate Markdown\n'
     + '  ref select <candidate-id> [--json]          bind a closed candidate selection to its evidence\n'
     + '  ref audit [--json]                          warn when references were captured sequentially (use ref add-batch)\n'
-    + '  ref granularity [--json]                    fail when the board does not cover the surfaces to compose\n'
+    + '  ref granularity [--json]                    fail when the board does not cover the composition zones\n'
     + '\n'
     + '  design                                       discover evidence and create/refresh .omd/design.md\n'
     + '  design --check                              validate design.md section coverage\n'
@@ -2770,6 +2816,10 @@ function usage(): never {
     + '  copy --review-check [--json]                validate copy-eye report structure only (not blindness)\n'
     + '  copy v2 check [--json]                      validate selected register and stable v2 Beat IDs\n'
     + '  composition --check [--json]                validate composition sections and input freshness\n'
+    + '  acquisition set --zones <json-array>          persist framer-owned section/region/state reference targets\n'
+    + '  depth classify --input depth.json [--json]      choose L1–L4 from design risk, never from convenience\n'
+    + '  deliberate check [--json]                      validate decisions, visual observations, assembly, and debate\n'
+    + '  compare score --input comparison.json [--json] blind same-model quality and quality/cost comparison\n'
     + '  source --seal [root]                        write final approved-input/source byte seal\n'
     + '  source --check [root] [--json]              fail when the source seal is missing or stale\n'
     + '  evidence finalize --input manifest.json      disabled: v1 publication is permanently trapped\n'
@@ -2922,6 +2972,10 @@ async function main(): Promise<never> {
   if (cmd === 'no-js') return cmdNoJs(parseArgs(args.slice(1)));
   if (cmd === 'award') return cmdAward(sub, parseArgs(args.slice(2)));
   if (cmd === 'tokens') return cmdTokens(sub, parseArgs(args.slice(2)));
+  if (cmd === 'depth') return cmdDepth(sub, parseArgs(args.slice(2)));
+  if (cmd === 'deliberate') return cmdDeliberate(sub, parseArgs(args.slice(2)));
+  if (cmd === 'compare') return cmdCompare(sub, parseArgs(args.slice(2)));
+  if (cmd === 'acquisition') return cmdAcquisition(sub, parseArgs(args.slice(2)));
   if (cmd === 'stack') return cmdStack(parseArgs(args.slice(1)));
   if (cmd === 'text-slop') return cmdTextSlop(parseArgs(args.slice(1)));
   if (cmd === 'visual-richness') return cmdVisualRichness(parseArgs(args.slice(1)));

--- a/core/deliberation/check.ts
+++ b/core/deliberation/check.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  type ContractFinding,
+  type AcquisitionPlan,
+  type DecisionGraph,
+  validateAssemblyCoverage,
+  validateAcquisitionPlan,
+  validateDecisionGraph,
+  validateDeliberation,
+  validateObservation,
+} from './contracts.ts';
+import { classifyDepth, type DepthInput, type DepthResult } from './depth.ts';
+
+export type DeliberationRunReport = {
+  readonly ok: boolean;
+  readonly depth?: DepthResult;
+  readonly findings: readonly ContractFinding[];
+  readonly counts: { readonly decisions: number; readonly deliberations: number; readonly observations: number; readonly zones: number };
+};
+
+const parse = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8'));
+const missing = (path: string, message: string): ContractFinding => ({ id: 'DELIBERATION-ARTIFACT-MISSING', path, message });
+
+export function checkDeliberationRun(cwd: string): DeliberationRunReport {
+  const dir = join(cwd, '.omd'); const findings: ContractFinding[] = [];
+  const depthPath = join(dir, 'depth.json');
+  let depth: DepthResult | undefined;
+  if (!existsSync(depthPath)) findings.push(missing('.omd/depth.json', 'classify loop depth before design work'));
+  else {
+    try { depth = classifyDepth(parse(depthPath) as DepthInput); }
+    catch (error) { findings.push({ id: 'DEPTH-INVALID', path: '.omd/depth.json', message: error instanceof Error ? error.message : String(error) }); }
+  }
+
+  const acquisitionPath = join(dir, 'acquisition-plan.json'); let acquisition: AcquisitionPlan | undefined;
+  if (depth && ['L3', 'L4'].includes(depth.level)) {
+    if (!existsSync(acquisitionPath)) findings.push(missing('.omd/acquisition-plan.json', 'framer must name every section, region, or state the scout needs to cover'));
+    else try {
+      const result = validateAcquisitionPlan(parse(acquisitionPath)); findings.push(...result.findings); acquisition = result.value;
+    } catch (error) { findings.push({ id: 'ACQUISITION-PLAN-JSON', path: '.omd/acquisition-plan.json', message: error instanceof Error ? error.message : String(error) }); }
+  }
+
+  const graphPath = join(dir, 'decision-graph.json'); let graph: DecisionGraph | undefined;
+  if (!existsSync(graphPath)) findings.push(missing('.omd/decision-graph.json', 'externalize consequential design decisions'));
+  else {
+    try { const result = validateDecisionGraph(parse(graphPath)); findings.push(...result.findings); graph = result.value; }
+    catch (error) { findings.push({ id: 'DECISION-GRAPH-JSON', path: '.omd/decision-graph.json', message: error instanceof Error ? error.message : String(error) }); }
+  }
+  if (depth && graph) {
+    const requiredStages = depth.level === 'L1'
+      ? ['refinement']
+      : depth.level === 'L2'
+        ? ['frame', 'composition', 'production']
+        : ['frame', 'copy', 'type', 'composition', 'structure', 'production'];
+    const present = new Set(graph.decisions.map((decision) => decision.stage));
+    for (const stage of requiredStages) {
+      if (!present.has(stage as import('./contracts.ts').DecisionStage)) findings.push({
+        id: 'DECISION-STAGE-UNCOVERED',
+        path: '.omd/decision-graph.json',
+        message: `${depth.level} requires an owner-authored ${stage} decision entry`,
+      });
+    }
+  }
+
+  const coveragePath = join(dir, 'assembly-coverage.json'); let zones = 0;
+  if (depth && ['L3', 'L4'].includes(depth.level)) {
+    if (!existsSync(coveragePath)) findings.push(missing('.omd/assembly-coverage.json', 'bind every selected composition zone from reference to final evidence'));
+    else try {
+      const raw = parse(coveragePath); if (typeof raw === 'object' && raw !== null && Array.isArray((raw as { zones?: unknown }).zones)) zones = (raw as { zones: unknown[] }).zones.length;
+      findings.push(...validateAssemblyCoverage(raw, graph).findings);
+      if (acquisition && typeof raw === 'object' && raw !== null && Array.isArray((raw as { expectedZones?: unknown }).expectedZones)) {
+        const required = acquisition.zones.filter((zone) => zone.required).map((zone) => zone.id).sort();
+        const expected = [...((raw as { expectedZones: string[] }).expectedZones)].sort();
+        if (required.length !== expected.length || required.some((id, i) => id !== expected[i])) {
+          findings.push({ id: 'ASSEMBLY-ACQUISITION-DRIFT', path: '.omd/assembly-coverage.json:expectedZones', message: 'final assembly zones must exactly cover the required acquisition zones; revise the plan explicitly before composition rather than silently dropping a section' });
+        }
+      }
+    } catch (error) { findings.push({ id: 'ASSEMBLY-COVERAGE-JSON', path: '.omd/assembly-coverage.json', message: error instanceof Error ? error.message : String(error) }); }
+  }
+
+  const observationDir = join(dir, 'observations'); let observations = 0;
+  if (!existsSync(observationDir)) findings.push(missing('.omd/observations/', 'record observable before/after render judgments'));
+  else {
+    const files = readdirSync(observationDir).filter((name) => name.endsWith('.json')).sort(); observations = files.length;
+    if (files.length === 0) findings.push(missing('.omd/observations/*.json', 'at least one Observe → Judge → Modify → Re-observe record is required'));
+    for (const file of files) try { findings.push(...validateObservation(parse(join(observationDir, file))).findings.map((f) => ({ ...f, path: `.omd/observations/${file}:${f.path}` }))); }
+    catch (error) { findings.push({ id: 'OBSERVATION-JSON', path: `.omd/observations/${file}`, message: error instanceof Error ? error.message : String(error) }); }
+  }
+
+  const deliberationDir = join(dir, 'deliberations'); let deliberations = 0;
+  if (depth?.requiresDeliberation) {
+    if (!existsSync(deliberationDir)) findings.push(missing('.omd/deliberations/', 'L4 requires independent UX, art-direction, and production perspectives'));
+    else {
+      const files = readdirSync(deliberationDir).filter((name) => name.endsWith('.json')).sort(); deliberations = files.length;
+      if (files.length === 0) findings.push(missing('.omd/deliberations/*.json', 'L4 requires at least one moderated high-risk decision'));
+      for (const file of files) try { findings.push(...validateDeliberation(parse(join(deliberationDir, file)), graph).findings.map((f) => ({ ...f, path: `.omd/deliberations/${file}:${f.path}` }))); }
+      catch (error) { findings.push({ id: 'DELIBERATION-JSON', path: `.omd/deliberations/${file}`, message: error instanceof Error ? error.message : String(error) }); }
+    }
+  }
+
+  return {
+    ok: findings.length === 0,
+    ...(depth ? { depth } : {}),
+    findings,
+    counts: { decisions: graph?.decisions.length ?? 0, deliberations, observations, zones },
+  };
+}

--- a/core/deliberation/comparison.ts
+++ b/core/deliberation/comparison.ts
@@ -1,0 +1,44 @@
+// Causal comparison for OMD: same model, prompt, and budget; blind scores only.
+
+export const COMPARISON_SCHEMA = 'design-comparison-v1' as const;
+const AXES = ['hierarchy', 'originality', 'composition', 'typography', 'interaction', 'production'] as const;
+type Axis = typeof AXES[number];
+export type ComparisonVariant = {
+  readonly id: 'baseline' | 'design-prompt' | 'omd-adaptive' | 'omd-deliberation';
+  readonly model: string;
+  readonly promptSha256: string;
+  readonly budget: { readonly tokens: number; readonly seconds: number };
+  readonly blind: true;
+  readonly scores: Record<Axis, number>;
+  readonly taskSuccess: number;
+  readonly accessibilityErrors: number;
+  readonly mobileOverflow: boolean;
+  readonly noJsContentLoss: number;
+  readonly revisions: number;
+};
+export type Comparison = { readonly schema: typeof COMPARISON_SCHEMA; readonly variants: readonly ComparisonVariant[] };
+export type VariantScore = { readonly id: string; readonly quality: number; readonly cost: number; readonly qualityPerCost: number };
+
+export function scoreComparison(value: Comparison): VariantScore[] {
+  if (value.schema !== COMPARISON_SCHEMA || !Array.isArray(value.variants) || value.variants.length !== 4) throw new Error('comparison requires exactly four variants');
+  const ids = new Set(value.variants.map((v) => v.id));
+  for (const id of ['baseline', 'design-prompt', 'omd-adaptive', 'omd-deliberation']) if (!ids.has(id as ComparisonVariant['id'])) throw new Error(`comparison missing ${id}`);
+  const model = value.variants[0]!.model; const prompt = value.variants[0]!.promptSha256; const budget = value.variants[0]!.budget;
+  if (!model || !/^[a-f0-9]{64}$/.test(prompt)) throw new Error('comparison needs a concrete model and prompt digest');
+  for (const v of value.variants) {
+    if (v.model !== model || v.promptSha256 !== prompt) throw new Error('all variants must use the same model and prompt bytes');
+    if (v.blind !== true) throw new Error('scores must be blind');
+    if (!Number.isSafeInteger(v.budget.tokens) || v.budget.tokens <= 0 || !Number.isFinite(v.budget.seconds) || v.budget.seconds <= 0) throw new Error('budget must be positive');
+    if (v.budget.tokens !== budget.tokens || v.budget.seconds !== budget.seconds) throw new Error('all variants must use the same token and time budget');
+    if (!Number.isSafeInteger(v.accessibilityErrors) || v.accessibilityErrors < 0 || !Number.isSafeInteger(v.noJsContentLoss) || v.noJsContentLoss < 0) throw new Error(`${v.id} error counts must be non-negative integers`);
+    for (const axis of AXES) if (!Number.isFinite(v.scores[axis]) || v.scores[axis] < 0 || v.scores[axis] > 10) throw new Error(`${v.id}.${axis} must be 0..10`);
+    if (!Number.isFinite(v.taskSuccess) || v.taskSuccess < 0 || v.taskSuccess > 1) throw new Error(`${v.id}.taskSuccess must be 0..1`);
+  }
+  return value.variants.map((v) => {
+    const creative = AXES.reduce((sum, axis) => sum + v.scores[axis], 0) / AXES.length;
+    const penalties = Math.min(3, v.accessibilityErrors * 0.15 + v.noJsContentLoss * 0.5 + (v.mobileOverflow ? 1 : 0));
+    const quality = Math.max(0, creative * 0.75 + v.taskSuccess * 10 * 0.25 - penalties);
+    const cost = v.budget.tokens / 100_000 + v.budget.seconds / 600;
+    return { id: v.id, quality: Number(quality.toFixed(3)), cost: Number(cost.toFixed(3)), qualityPerCost: Number((quality / cost).toFixed(3)) };
+  });
+}

--- a/core/deliberation/contracts.ts
+++ b/core/deliberation/contracts.ts
@@ -1,0 +1,270 @@
+// Design deliberation contracts.
+//
+// These records externalize decisions, not hidden chain-of-thought. A record keeps only the bounded
+// facts another role can verify: the question, real alternatives, selected answer, evidence,
+// constraints, rejected alternatives, downstream effects, and observable trade-offs.
+
+export const DECISION_GRAPH_SCHEMA = 'decision-graph-v1' as const;
+export const DELIBERATION_SCHEMA = 'design-deliberation-v1' as const;
+export const OBSERVATION_SCHEMA = 'visual-observation-v1' as const;
+export const ASSEMBLY_COVERAGE_SCHEMA = 'assembly-coverage-v1' as const;
+export const ACQUISITION_PLAN_SCHEMA = 'reference-acquisition-plan-v1' as const;
+
+export type DecisionStage = 'frame' | 'copy' | 'type' | 'composition' | 'structure' | 'production' | 'refinement';
+export type DecisionRisk = 'low' | 'medium' | 'high' | 'critical';
+export type DecisionOwner = 'omd-framer' | 'omd-writer' | 'omd-typesetter' | 'omd-composer' | 'omd-eye' | 'omd-hand';
+
+export type DecisionAlternative = { readonly id: string; readonly label: string };
+export type RejectedAlternative = { readonly id: string; readonly reason: string };
+export type ConstraintTradeoff = {
+  readonly goal: string;
+  readonly constraint: string;
+  readonly attempt: string;
+  readonly failureEvidence: readonly string[];
+  readonly compromise: string;
+  readonly resultEvidence: readonly string[];
+};
+export type DesignDecision = {
+  readonly id: string;
+  readonly stage: DecisionStage;
+  readonly risk: DecisionRisk;
+  readonly owner: DecisionOwner;
+  readonly question: string;
+  readonly alternatives: readonly DecisionAlternative[];
+  readonly selected: string;
+  readonly evidence: readonly string[];
+  readonly constraints: readonly string[];
+  readonly rejected: readonly RejectedAlternative[];
+  readonly affects: readonly string[];
+  readonly dependsOn: readonly string[];
+  readonly reversible: boolean;
+  readonly tradeoffs: readonly ConstraintTradeoff[];
+};
+export type DecisionGraph = { readonly schema: typeof DECISION_GRAPH_SCHEMA; readonly decisions: readonly DesignDecision[] };
+
+export type Perspective = {
+  readonly inputSha256: string;
+  readonly position: string;
+  readonly evidence: readonly string[];
+  readonly objections: readonly string[];
+  readonly conditions: readonly string[];
+};
+export type DesignDeliberation = {
+  readonly schema: typeof DELIBERATION_SCHEMA;
+  readonly id: string;
+  readonly decisionId: string;
+  readonly trigger: string;
+  readonly moderator: 'omd-eye';
+  readonly perspectives: {
+    readonly ux: Perspective;
+    readonly artDirection: Perspective;
+    readonly production: Perspective;
+  };
+  readonly resolution: { readonly selected: string; readonly rationale: string; readonly conditions: readonly string[] };
+};
+
+export type VisualObservation = {
+  readonly schema: typeof OBSERVATION_SCHEMA;
+  readonly owner: 'omd-hand';
+  readonly round: number;
+  readonly viewport: '1280x900' | '390x844' | '320x800';
+  readonly beforeRender: string;
+  readonly metric: 'position' | 'size' | 'line-count' | 'contrast' | 'visibility' | 'motion' | 'flow';
+  readonly observed: string;
+  readonly judgment: string;
+  readonly change: string;
+  readonly afterRender: string;
+  readonly result: string;
+  readonly status: 'RED' | 'GREEN';
+};
+
+export type AcquisitionZone = {
+  readonly id: string;
+  readonly kind: 'section' | 'region' | 'state';
+  readonly job: string;
+  readonly required: boolean;
+};
+export type AcquisitionPlan = {
+  readonly schema: typeof ACQUISITION_PLAN_SCHEMA;
+  readonly owner: 'omd-framer';
+  readonly zones: readonly AcquisitionZone[];
+};
+
+export type AssemblyZone = {
+  readonly id: string;
+  readonly job: string;
+  readonly referenceRef: string;
+  readonly principle: string;
+  readonly compositionDecisionId: string;
+  readonly productionSelector: string;
+  readonly fidelityEvidence: readonly string[];
+};
+export type AssemblyCoverage = {
+  readonly schema: typeof ASSEMBLY_COVERAGE_SCHEMA;
+  readonly owner: 'omd-hand';
+  /** Sections/regions/states of the selected composition — not domain-level pages/screens. */
+  readonly expectedZones: readonly string[];
+  readonly zones: readonly AssemblyZone[];
+};
+
+export type ContractFinding = { readonly id: string; readonly path: string; readonly message: string };
+
+const record = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null && !Array.isArray(v);
+const text = (v: unknown): v is string => typeof v === 'string' && v.trim() !== '';
+const slug = (v: unknown): v is string => text(v) && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(v);
+const digest = (v: unknown): v is string => typeof v === 'string' && /^[a-f0-9]{64}$/.test(v);
+const texts = (v: unknown, min = 1): v is string[] => Array.isArray(v) && v.length >= min && v.every(text);
+const exact = (v: Record<string, unknown>, keys: readonly string[]): boolean => {
+  const got = Object.keys(v).sort(); const wanted = [...keys].sort();
+  return got.length === wanted.length && got.every((key, i) => key === wanted[i]);
+};
+const finding = (out: ContractFinding[], id: string, path: string, message: string): void => { out.push({ id, path, message }); };
+
+const DECISION_KEYS = ['affects', 'alternatives', 'constraints', 'dependsOn', 'evidence', 'id', 'owner', 'question', 'rejected', 'reversible', 'risk', 'selected', 'stage', 'tradeoffs'] as const;
+const STAGES = new Set<DecisionStage>(['frame', 'copy', 'type', 'composition', 'structure', 'production', 'refinement']);
+const RISKS = new Set<DecisionRisk>(['low', 'medium', 'high', 'critical']);
+const OWNER_BY_STAGE: Record<DecisionStage, DecisionOwner> = {
+  frame: 'omd-framer',
+  copy: 'omd-writer',
+  type: 'omd-typesetter',
+  composition: 'omd-composer',
+  structure: 'omd-eye',
+  production: 'omd-hand',
+  refinement: 'omd-hand',
+};
+
+export function validateDecisionGraph(value: unknown): { readonly value?: DecisionGraph; readonly findings: readonly ContractFinding[] } {
+  const out: ContractFinding[] = [];
+  if (!record(value) || !exact(value, ['schema', 'decisions']) || value.schema !== DECISION_GRAPH_SCHEMA || !Array.isArray(value.decisions)) {
+    finding(out, 'DECISION-GRAPH-INVALID', '$', 'expected a closed decision-graph-v1 object with a decisions array');
+    return { findings: out };
+  }
+  const ids = new Set<string>();
+  const decisions = value.decisions;
+  if (decisions.length === 0) finding(out, 'DECISION-GRAPH-EMPTY', 'decisions', 'at least one consequential decision is required');
+  for (let i = 0; i < decisions.length; i++) {
+    const d = decisions[i]; const path = `decisions[${i}]`;
+    if (!record(d) || !exact(d, DECISION_KEYS)) { finding(out, 'DECISION-INVALID', path, 'decision has unknown or missing keys'); continue; }
+    if (!slug(d.id)) finding(out, 'DECISION-ID', `${path}.id`, 'id must be a lowercase kebab slug');
+    else if (ids.has(d.id)) finding(out, 'DECISION-DUPLICATE', `${path}.id`, `duplicate decision id ${d.id}`); else ids.add(d.id);
+    if (!STAGES.has(d.stage as DecisionStage)) finding(out, 'DECISION-STAGE', `${path}.stage`, 'unknown decision stage');
+    if (!RISKS.has(d.risk as DecisionRisk)) finding(out, 'DECISION-RISK', `${path}.risk`, 'risk must be low, medium, high, or critical');
+    if (STAGES.has(d.stage as DecisionStage) && d.owner !== OWNER_BY_STAGE[d.stage as DecisionStage]) finding(out, 'DECISION-OWNER', `${path}.owner`, `${d.stage} decisions belong to ${OWNER_BY_STAGE[d.stage as DecisionStage]}, not the coordinator`);
+    if (!text(d.question)) finding(out, 'DECISION-QUESTION', `${path}.question`, 'question must be substantive');
+    const alternativesValid = Array.isArray(d.alternatives)
+      && d.alternatives.length >= 2
+      && d.alternatives.every((a) => record(a) && exact(a, ['id', 'label']) && slug(a.id) && text(a.label));
+    if (!alternativesValid) finding(out, 'DECISION-NO-DIVERGENCE', `${path}.alternatives`, 'a decision needs at least two named alternatives');
+    const alternativeIds = Array.isArray(d.alternatives)
+      ? d.alternatives.filter((a) => record(a) && slug(a.id)).map((a) => (a as { id: string }).id)
+      : [];
+    if (new Set(alternativeIds).size !== alternativeIds.length) finding(out, 'DECISION-ALTERNATIVE-DUPLICATE', `${path}.alternatives`, 'alternatives must be unique');
+    if (!text(d.selected) || !alternativeIds.includes(d.selected)) finding(out, 'DECISION-SELECTION', `${path}.selected`, 'selected must name one alternative');
+    if (!texts(d.evidence)) finding(out, 'DECISION-EVIDENCE', `${path}.evidence`, 'selection needs at least one verifiable evidence reference');
+    if (!texts(d.constraints)) finding(out, 'DECISION-CONSTRAINT', `${path}.constraints`, 'selection needs at least one named constraint');
+    if (!Array.isArray(d.rejected) || !d.rejected.every((r) => record(r) && exact(r, ['id', 'reason']) && slug(r.id) && text(r.reason))) {
+      finding(out, 'DECISION-REJECTION', `${path}.rejected`, 'rejected alternatives need bounded reasons');
+    } else {
+      const rejected = new Set(d.rejected.map((r) => (r as { id: string }).id));
+      const expected = alternativeIds.filter((id) => id !== d.selected);
+      if (expected.some((id) => !rejected.has(id)) || rejected.has(d.selected as string)) finding(out, 'DECISION-REJECTION-COVERAGE', `${path}.rejected`, 'every non-selected alternative must be rejected exactly; the selected one must not be');
+    }
+    if (!texts(d.affects)) finding(out, 'DECISION-AFFECTS', `${path}.affects`, 'decision must name downstream artifacts or zones it affects');
+    if (!Array.isArray(d.dependsOn) || !d.dependsOn.every(slug)) finding(out, 'DECISION-DEPENDENCY', `${path}.dependsOn`, 'dependsOn must be an array of decision ids');
+    if (typeof d.reversible !== 'boolean') finding(out, 'DECISION-REVERSIBILITY', `${path}.reversible`, 'reversible must be boolean');
+    if (!Array.isArray(d.tradeoffs)) finding(out, 'DECISION-TRADEOFF', `${path}.tradeoffs`, 'tradeoffs must be an array');
+    else {
+      for (let j = 0; j < d.tradeoffs.length; j++) {
+        const t = d.tradeoffs[j];
+        if (!record(t) || !exact(t, ['attempt', 'compromise', 'constraint', 'failureEvidence', 'goal', 'resultEvidence']) || !text(t.goal) || !text(t.constraint) || !text(t.attempt) || !text(t.compromise) || !texts(t.failureEvidence) || !texts(t.resultEvidence)) {
+          finding(out, 'DECISION-TRADEOFF', `${path}.tradeoffs[${j}]`, 'tradeoff must record goal, constraint, attempted failure evidence, compromise, and result evidence');
+        }
+      }
+      if ((d.risk === 'high' || d.risk === 'critical') && d.tradeoffs.length === 0) finding(out, 'DECISION-HIGH-RISK-NO-TRADEOFF', `${path}.tradeoffs`, 'high-risk decisions must externalize at least one tested trade-off');
+    }
+  }
+  const known = new Set(decisions.filter(record).map((d) => d.id).filter(slug));
+  for (let i = 0; i < decisions.length; i++) {
+    const d = decisions[i]; if (!record(d) || !Array.isArray(d.dependsOn)) continue;
+    for (const dep of d.dependsOn) if (typeof dep === 'string' && !known.has(dep)) finding(out, 'DECISION-DEPENDENCY-MISSING', `decisions[${i}].dependsOn`, `unknown dependency ${dep}`);
+  }
+  return out.length === 0 ? { value: value as DecisionGraph, findings: out } : { findings: out };
+}
+
+function validPerspective(v: unknown): v is Perspective {
+  return record(v) && exact(v, ['conditions', 'evidence', 'inputSha256', 'objections', 'position'])
+    && digest(v.inputSha256) && text(v.position) && texts(v.evidence) && Array.isArray(v.objections) && v.objections.every(text) && Array.isArray(v.conditions) && v.conditions.every(text);
+}
+
+export function validateDeliberation(value: unknown, graph?: DecisionGraph): { readonly value?: DesignDeliberation; readonly findings: readonly ContractFinding[] } {
+  const out: ContractFinding[] = [];
+  if (!record(value) || !exact(value, ['decisionId', 'id', 'moderator', 'perspectives', 'resolution', 'schema', 'trigger']) || value.schema !== DELIBERATION_SCHEMA || value.moderator !== 'omd-eye' || !slug(value.id) || !slug(value.decisionId) || !text(value.trigger)) {
+    finding(out, 'DELIBERATION-INVALID', '$', 'expected a closed design-deliberation-v1 record'); return { findings: out };
+  }
+  if (graph && !graph.decisions.some((d) => d.id === value.decisionId)) finding(out, 'DELIBERATION-DECISION-MISSING', 'decisionId', 'deliberation must bind to a decision in the graph');
+  if (!record(value.perspectives) || !exact(value.perspectives, ['artDirection', 'production', 'ux']) || !validPerspective(value.perspectives.ux) || !validPerspective(value.perspectives.artDirection) || !validPerspective(value.perspectives.production)) {
+    finding(out, 'DELIBERATION-PERSPECTIVES', 'perspectives', 'ux, artDirection, and production perspectives are all required with evidence');
+  } else {
+    const hashes = [value.perspectives.ux.inputSha256, value.perspectives.artDirection.inputSha256, value.perspectives.production.inputSha256];
+    if (new Set(hashes).size !== 1) finding(out, 'DELIBERATION-INPUT-MISMATCH', 'perspectives', 'independent perspectives must judge the same sanitized input bytes');
+  }
+  if (!record(value.resolution) || !exact(value.resolution, ['conditions', 'rationale', 'selected']) || !text(value.resolution.selected) || !text(value.resolution.rationale) || !texts(value.resolution.conditions)) {
+    finding(out, 'DELIBERATION-RESOLUTION', 'resolution', 'moderator resolution needs a selection, evidence-based rationale, and conditions');
+  }
+  return out.length === 0 ? { value: value as DesignDeliberation, findings: out } : { findings: out };
+}
+
+export function validateAcquisitionPlan(value: unknown): { readonly value?: AcquisitionPlan; readonly findings: readonly ContractFinding[] } {
+  const out: ContractFinding[] = [];
+  if (!record(value) || !exact(value, ['owner', 'schema', 'zones']) || value.schema !== ACQUISITION_PLAN_SCHEMA || value.owner !== 'omd-framer' || !Array.isArray(value.zones) || value.zones.length === 0) {
+    finding(out, 'ACQUISITION-PLAN-INVALID', '$', 'expected a non-empty reference-acquisition-plan-v1');
+    return { findings: out };
+  }
+  const ids = new Set<string>();
+  for (let i = 0; i < value.zones.length; i++) {
+    const z = value.zones[i]; const path = `zones[${i}]`;
+    if (!record(z) || !exact(z, ['id', 'job', 'kind', 'required']) || !slug(z.id) || !['section', 'region', 'state'].includes(z.kind as string) || !text(z.job) || typeof z.required !== 'boolean') {
+      finding(out, 'ACQUISITION-ZONE-INVALID', path, 'zone needs a stable id, section/region/state kind, job, and required flag');
+      continue;
+    }
+    if (ids.has(z.id)) finding(out, 'ACQUISITION-ZONE-DUPLICATE', `${path}.id`, `duplicate zone ${z.id}`);
+    ids.add(z.id);
+  }
+  if (!value.zones.some((z) => record(z) && z.required === true)) finding(out, 'ACQUISITION-NO-REQUIRED-ZONES', 'zones', 'at least one zone must require reference evidence');
+  return out.length === 0 ? { value: value as AcquisitionPlan, findings: out } : { findings: out };
+}
+
+export function validateObservation(value: unknown): { readonly value?: VisualObservation; readonly findings: readonly ContractFinding[] } {
+  const out: ContractFinding[] = [];
+  const keys = ['afterRender', 'beforeRender', 'change', 'judgment', 'metric', 'observed', 'owner', 'result', 'round', 'schema', 'status', 'viewport'];
+  if (!record(value) || !exact(value, keys) || value.schema !== OBSERVATION_SCHEMA) { finding(out, 'OBSERVATION-INVALID', '$', 'expected a closed visual-observation-v1 record'); return { findings: out }; }
+  if (value.owner !== 'omd-hand') finding(out, 'OBSERVATION-OWNER', 'owner', 'visual observation records belong to omd-hand');
+  if (!Number.isSafeInteger(value.round) || (value.round as number) < 1) finding(out, 'OBSERVATION-ROUND', 'round', 'round must be a positive integer');
+  if (!['1280x900', '390x844', '320x800'].includes(value.viewport as string)) finding(out, 'OBSERVATION-VIEWPORT', 'viewport', 'viewport must be one of the required evidence sizes');
+  for (const field of ['beforeRender', 'observed', 'judgment', 'change', 'afterRender', 'result'] as const) if (!text(value[field])) finding(out, 'OBSERVATION-MISSING', field, `${field} must be non-empty`);
+  if (value.beforeRender === value.afterRender) finding(out, 'OBSERVATION-NO-RENDER-DELTA', 'afterRender', 'before and after evidence must be different artifacts');
+  if (!['position', 'size', 'line-count', 'contrast', 'visibility', 'motion', 'flow'].includes(value.metric as string)) finding(out, 'OBSERVATION-METRIC', 'metric', 'metric must name an observable visual or interaction property');
+  if (!['RED', 'GREEN'].includes(value.status as string)) finding(out, 'OBSERVATION-STATUS', 'status', 'status must be RED or GREEN');
+  return out.length === 0 ? { value: value as VisualObservation, findings: out } : { findings: out };
+}
+
+export function validateAssemblyCoverage(value: unknown, graph?: DecisionGraph): { readonly value?: AssemblyCoverage; readonly findings: readonly ContractFinding[] } {
+  const out: ContractFinding[] = [];
+  if (!record(value) || !exact(value, ['expectedZones', 'owner', 'schema', 'zones']) || value.schema !== ASSEMBLY_COVERAGE_SCHEMA || value.owner !== 'omd-hand' || !texts(value.expectedZones) || !Array.isArray(value.zones)) {
+    finding(out, 'ASSEMBLY-COVERAGE-INVALID', '$', 'expected a closed assembly-coverage-v1 record with expectedZones and zones'); return { findings: out };
+  }
+  const expected = value.expectedZones as string[];
+  if (new Set(expected.map((x) => x.toLowerCase())).size !== expected.length) finding(out, 'ASSEMBLY-ZONE-DUPLICATE', 'expectedZones', 'expected zones must be unique');
+  const covered = new Set<string>();
+  for (let i = 0; i < value.zones.length; i++) {
+    const z = value.zones[i]; const path = `zones[${i}]`;
+    if (!record(z) || !exact(z, ['compositionDecisionId', 'fidelityEvidence', 'id', 'job', 'principle', 'productionSelector', 'referenceRef']) || !text(z.id) || !text(z.job) || !text(z.referenceRef) || !text(z.principle) || !slug(z.compositionDecisionId) || !text(z.productionSelector) || !texts(z.fidelityEvidence)) {
+      finding(out, 'ASSEMBLY-ZONE-INVALID', path, 'zone must bind job → reference → principle → composition decision → production selector → fidelity evidence'); continue;
+    }
+    covered.add((z.id as string).toLowerCase());
+    if (graph && !graph.decisions.some((d) => d.id === z.compositionDecisionId)) finding(out, 'ASSEMBLY-DECISION-MISSING', `${path}.compositionDecisionId`, 'zone must bind to a decision in the graph');
+  }
+  const missing = expected.filter((id) => !covered.has(id.toLowerCase()));
+  if (missing.length) finding(out, 'ASSEMBLY-ZONE-UNCOVERED', 'zones', `no complete evidence chain for: ${missing.join(', ')}`);
+  return out.length === 0 ? { value: value as AssemblyCoverage, findings: out } : { findings: out };
+}

--- a/core/deliberation/depth.ts
+++ b/core/deliberation/depth.ts
@@ -1,0 +1,55 @@
+// Adaptive design-loop depth. Depth changes ceremony, never artifact ownership.
+
+export const DEPTH_INPUT_SCHEMA = 'design-depth-input-v1' as const;
+export type DepthLevel = 'L1' | 'L2' | 'L3' | 'L4';
+export type DepthInput = {
+  readonly schema: typeof DEPTH_INPUT_SCHEMA;
+  readonly scope: 'component-change' | 'single-section' | 'single-surface' | 'multi-surface';
+  readonly zoneCount: number;
+  readonly newPrimaryCta: boolean;
+  readonly newInformationArchitecture: boolean;
+  readonly multiScreenState: boolean;
+  readonly costlyError: boolean;
+  readonly brandDirectionChange: boolean;
+  readonly showpieceMotion: boolean;
+  readonly webgl: boolean;
+  readonly referenceZones: number;
+};
+export type DepthResult = {
+  readonly level: DepthLevel;
+  readonly reasons: readonly string[];
+  readonly stages: readonly string[];
+  readonly requiresDeliberation: boolean;
+};
+
+const BASE: Record<DepthLevel, readonly string[]> = {
+  L1: ['frame-check', 'hand', 'render-observe', 'eye'],
+  L2: ['frame', 'targeted-scout', 'composition', 'hand', 'render-observe', 'eye'],
+  L3: ['domain', 'frame', 'scout', 'writer', 'typesetter', 'composer', 'sketch', 'blind-selection', 'hand', 'render-observe', 'glance', 'eye', 'red-green'],
+  L4: ['domain', 'frame', 'scout', 'writer', 'typesetter', 'composer', 'design-deliberation', 'sketch', 'blind-selection', 'hand', 'render-observe', 'glance', 'constraint-deliberation', 'eye', 'red-green'],
+};
+
+export function classifyDepth(input: DepthInput): DepthResult {
+  if (input.schema !== DEPTH_INPUT_SCHEMA) throw new Error(`depth schema must be ${DEPTH_INPUT_SCHEMA}`);
+  if (!Number.isSafeInteger(input.zoneCount) || input.zoneCount < 1) throw new Error('zoneCount must be a positive integer');
+  if (!Number.isSafeInteger(input.referenceZones) || input.referenceZones < 0) throw new Error('referenceZones must be a non-negative integer');
+
+  let level: DepthLevel = input.scope === 'component-change' ? 'L1' : input.scope === 'single-section' ? 'L2' : 'L3';
+  const reasons = [`scope:${input.scope}`];
+  const raise = (to: DepthLevel, reason: string): void => {
+    const rank: Record<DepthLevel, number> = { L1: 1, L2: 2, L3: 3, L4: 4 };
+    if (rank[to] > rank[level]) level = to;
+    reasons.push(reason);
+  };
+  if (input.zoneCount >= 3 || input.referenceZones >= 3) raise('L3', 'three-or-more-composed-zones');
+  if (input.newPrimaryCta) raise('L3', 'new-primary-cta');
+  if (input.newInformationArchitecture) raise('L3', 'new-information-architecture');
+  if (input.multiScreenState) raise('L3', 'multi-screen-state');
+  if (input.costlyError) raise('L4', 'costly-error-and-recovery');
+  if (input.brandDirectionChange) raise('L4', 'brand-direction-change');
+  if (input.showpieceMotion) raise('L4', 'showpiece-motion');
+  if (input.webgl) raise('L4', 'webgl-safety-envelope');
+  if (input.scope === 'multi-surface') raise('L4', 'multi-surface-system');
+
+  return { level, reasons, stages: BASE[level], requiresDeliberation: (level as DepthLevel) === 'L4' };
+}

--- a/core/protocol/design-deliberation.md
+++ b/core/protocol/design-deliberation.md
@@ -1,0 +1,117 @@
+# Design deliberation protocol
+
+OMD does not request, store, or grade hidden chain-of-thought. It externalizes only bounded design
+decisions another role can verify: the question, real alternatives, selected answer, cited evidence,
+constraints, rejected options, downstream effects, tested trade-offs, and rendered outcome.
+
+## Adaptive depth
+
+Before artifact-producing work, the coordinator writes `.omd/depth.json` as a closed
+`design-depth-input-v1` and runs `omd depth classify --input .omd/depth.json`. Classification is by
+design risk, never convenience or desired speed:
+
+- **L1** — an existing component change: frame check → hand → render observation → eye.
+- **L2** — one section: frame → targeted scout → composition → hand → render observation → eye.
+- **L3** — a new page/surface, three or more composition zones, a new primary CTA, new information
+  architecture, or multi-screen state: the full owner-separated loop.
+- **L4** — a costly-error flow, brand-direction creation/change, showpiece motion, WebGL, or a
+  multi-surface system: L3 plus independent design deliberation.
+
+Depth may omit inapplicable stages but never transfers their artifacts to the coordinator. A small
+route still spawns the owner of every stage it retains. A landing page with a new art direction is
+L4 even if it is one route; "single page" is scope, not low risk.
+
+## Reference acquisition plan
+
+Domain-brief `surfaces` are pages/screens. They cannot represent the hero, process explanation,
+proof, installation path, CTA, navigation, work region, error state, or recovery state inside one
+surface. After framing, `omd-framer` persists `.omd/acquisition-plan.json` through:
+
+```text
+omd acquisition set --zones '<JSON array of {id,kind,job,required}>'
+```
+
+The closed `reference-acquisition-plan-v1` uses `owner: "omd-framer"`; `kind` is `section`, `region`,
+or `state`. The scout binds a component-scoped capture to every required zone with `--slot <zone>`.
+The final assembly coverage must contain exactly those required IDs. A zone may be revised, but it
+is revised explicitly in the acquisition plan before composition, never silently dropped because no
+reference was found.
+
+## Decision graph
+
+`.omd/decision-graph.json` is `decision-graph-v1`. It is a shared, mechanically merged ledger of
+owner-authored entries. The coordinator may preserve and merge returned JSON entries byte-for-byte;
+it must not invent a question, alternative, selection, evidence item, rejection, or trade-off.
+Ownership is enforced by stage:
+
+| Stage | Entry owner |
+|---|---|
+| frame | `omd-framer` |
+| copy | `omd-writer` |
+| type | `omd-typesetter` |
+| composition | `omd-composer` |
+| structure | selecting `omd-eye` |
+| production / refinement | `omd-hand` |
+
+Every consequential decision has at least two genuine alternatives. `selected` names one;
+`rejected` covers every other alternative with a bounded reason. Evidence uses durable artifact,
+reference, check, probe, or render paths — "looks better", "modern", and internal instructions are
+not evidence. High/critical decisions record at least one complete constraint trade-off:
+
+```text
+goal → constraint → attempted form → observed failure evidence → compromise → result evidence
+```
+
+## L4 independent deliberation
+
+For each high-impact fork, spawn three fresh `omd-eye` agents concurrently with identical sanitized
+input bytes and no candidate authorship or other perspective output:
+
+1. **UX perspective** — first action, task reach, comprehension, mobile and recovery cost.
+2. **Art-direction perspective** — hierarchy, specificity, synthesis, signature departure.
+3. **Production perspective** — feasibility, accessibility, performance, no-JS, reduced motion,
+   responsive and state risk.
+
+Then spawn a fourth fresh `omd-eye` as moderator. It receives only the three completed perspective
+records, the decision alternatives, and the same sanitized input digest. It does not vote by
+majority: it resolves objections against evidence and constraints, returns one selection plus
+conditions, and authors the `design-deliberation-v1` record. All three perspective `inputSha256`
+values must match. The coordinator only preserves the moderator's closed JSON under
+`.omd/deliberations/<id>.json`.
+
+## Visual observation
+
+`omd-hand` owns `.omd/observations/*.json`. Each `visual-observation-v1` is one measured loop:
+
+```text
+before render → observable fact → judgment → exact change → distinct after render → measured result
+```
+
+An observation names one metric: position, size, line count, contrast, visibility, motion, or flow.
+Generic prose such as "hierarchy improved" is invalid. Before and after evidence paths must differ.
+RED means the observed failure remains; GREEN means the after-render observation demonstrates the
+condition now holds. Source inspection alone is not visual observation.
+
+## Assembly coverage
+
+`omd-hand` owns `.omd/assembly-coverage.json` (`assembly-coverage-v1`). Every required acquisition
+zone binds this complete chain:
+
+```text
+zone job → captured reference identity → extracted principle → composition decision ID
+→ production selector → final fidelity evidence
+```
+
+A reference without a production destination is unused research. A production zone without a
+reference is invention from training priors. A selector without final fidelity evidence is an
+unverified claim. `omd deliberate check` joins the acquisition plan, decision graph, deliberations,
+observations, and assembly coverage; isolated files passing separately do not complete the run.
+
+## Comparative evaluation
+
+OMD effectiveness is measured with `design-comparison-v1`, exactly four anonymous variants:
+baseline coding agent, strong single design prompt, OMD adaptive, and OMD L4 deliberation. All use
+the same concrete model and identical prompt bytes; every score is blind. `omd compare score`
+reports quality and quality per cost from hierarchy, originality, composition, typography,
+interaction, production, task success, accessibility, mobile, and no-JS evidence. A model change or
+non-blind score invalidates the comparison rather than manufacturing an uplift claim.

--- a/core/protocol/reference-assembly.md
+++ b/core/protocol/reference-assembly.md
@@ -48,21 +48,24 @@ studies (`omd ref add <url> --as <component> --selector "<css>" --blueprint --sh
 scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document and yields a
 page average with no component anatomy, so section-granular composition has nothing to take from it.
 Two captures of the same source at the same selector are one piece of evidence under two names and
-make the board read larger than it is. Granularity alone is not coverage. Five captures that collapse onto two slots — three navs and two
-install blocks — are two parts studied repeatedly while every other section carries no evidence, and
-those sections then compose from whatever the build invents. Coverage is measured per surface, by
-name: the domain brief's `surfaces` are the list of things the build must compose, so they are the
-acquisition list, and each capture is bound to the surface it answers
-(`omd ref add … --slot <surface>`). A board is finished when every declared surface has at least one
-bound capture — a capture count says nothing about whether the hero has evidence or the nav was
-studied five times, and it is the uncovered sections that need naming. `omd ref granularity` audits both and
-reports `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`,
-`REF-SURFACE-UNCOVERED`, and `REF-NAME-MISMATCH`. A capture is named for what it holds: a reference
-called `*-hero-*` captured at `header` tells every downstream reader that the hero is covered when
-what exists is another nav, and since the name is the only thing most readers see, the mislabel hides
-the board's real shape rather than merely being untidy. Any of these any of them means the board must be recaptured at component scope across the
-surfaces that still have nothing, because a board of whole-page captures can only
-be traced, and tracing a whole page is the derivative failure the transfer boundary forbids.
+make the board read larger than it is.
+
+Granularity alone is not coverage. Five captures that collapse onto two slots — three navs and two
+install blocks — are two parts studied repeatedly while every other zone carries no evidence, and
+those zones then compose from whatever the build invents. Domain-brief `surfaces` are pages/screens;
+they do not enumerate a landing page's hero, process, proof, install, CTA, or a product screen's
+regions and states. The framer therefore writes `.omd/acquisition-plan.json`
+(`reference-acquisition-plan-v1`) naming every required section/region/state and its job before the
+scout starts. Each capture binds to one of those zones (`omd ref add … --slot <zone>`), and a board
+is finished only when every required zone has at least one bound capture.
+
+`omd ref granularity` audits granularity and zone coverage and reports `REF-WHOLE-PAGE`,
+`REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`, `REF-ZONE-UNCOVERED`, and
+`REF-NAME-MISMATCH`. A capture is named for what it holds: a reference called `*-hero-*` captured at
+`header` tells downstream readers that the hero is covered when what exists is another nav. Any
+finding means the board must be recaptured at component scope across the zones that still have
+nothing; a board of whole-page captures can only be traced, and tracing a whole page is the
+derivative failure the transfer boundary forbids.
 
 ## Subject anchor
 

--- a/core/ref/board-granularity.ts
+++ b/core/ref/board-granularity.ts
@@ -73,7 +73,7 @@ export function slotClaimAndCapture(ref: Pick<Reference, 'component' | 'selector
 }
 
 export type GranularityFinding = {
-  readonly id: 'REF-WHOLE-PAGE' | 'REF-DUPLICATE-CAPTURE' | 'REF-NO-PARTS' | 'REF-PART-CONCENTRATION' | 'REF-SURFACE-UNCOVERED' | 'REF-NAME-MISMATCH';
+  readonly id: 'REF-WHOLE-PAGE' | 'REF-DUPLICATE-CAPTURE' | 'REF-NO-PARTS' | 'REF-PART-CONCENTRATION' | 'REF-ZONE-UNCOVERED' | 'REF-NAME-MISMATCH';
   readonly message: string;
   /** Reference identifiers the finding is about, as `source (component)`. */
   readonly refs: readonly string[];
@@ -101,7 +101,7 @@ export function isWholePageCapture(ref: Pick<Reference, 'selector'> & { blueprin
  */
 export function auditBoardGranularity(
   refs: readonly Reference[],
-  opts: { readonly surfaces?: readonly string[] } = {},
+  opts: { readonly zones?: readonly string[] } = {},
 ): GranularityFinding[] {
   const findings: GranularityFinding[] = [];
   const measurable = refs.filter((ref) => ref.kind !== 'image');
@@ -177,21 +177,20 @@ export function auditBoardGranularity(
 
   }
 
-  // Coverage is per surface, by name. A count comparison cannot tell a board that studied the nav
-  // five times from one that covered five sections, and it is the uncovered sections — the ones the
-  // build then invents from nothing — that the run needs named.
-  if (opts.surfaces !== undefined && opts.surfaces.length > 0) {
+  // Coverage is per composition zone, by name. Domain surfaces are pages/screens and cannot tell a
+  // board that studied the nav five times from one that covered every section/region/state inside it.
+  if (opts.zones !== undefined && opts.zones.length > 0) {
     const covered = new Set(
       parts.map((ref) => (ref.slot ?? '').trim().toLowerCase()).filter((slot) => slot !== ''),
     );
-    const uncovered = opts.surfaces.filter((surface) => !covered.has(surface.trim().toLowerCase()));
+    const uncovered = opts.zones.filter((zone) => !covered.has(zone.trim().toLowerCase()));
     if (uncovered.length > 0) {
       findings.push({
-        id: 'REF-SURFACE-UNCOVERED',
+        id: 'REF-ZONE-UNCOVERED',
         message: covered.size === 0
-          ? `no capture is bound to a surface, so none of the ${opts.surfaces.length} surfaces the domain brief declares has evidence: ${opts.surfaces.join(', ')}. Bind each capture to the surface it answers with \`omd ref add … --slot <surface>\`; an unbound board can be counted but not checked, and every section then composes from whatever the build invents.`
-          : `${uncovered.length} of ${opts.surfaces.length} declared surfaces have no capture bound to them: ${uncovered.join(', ')}. Those sections compose from nothing. Capture the part that answers each with \`omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot\`.`,
-        refs: uncovered.map((surface) => `surface: ${surface}`),
+          ? `no capture is bound to a composition zone, so none of the ${opts.zones.length} required zones has evidence: ${opts.zones.join(', ')}. Bind each capture with \`omd ref add … --slot <zone>\`; an unbound board can be counted but not checked.`
+          : `${uncovered.length} of ${opts.zones.length} required composition zones have no capture bound to them: ${uncovered.join(', ')}. Those zones compose from nothing. Capture the part that answers each with \`omd ref add <url> --as <component> --slot <zone> --selector "<css>" --blueprint --shot\`.`,
+        refs: uncovered.map((zone) => `zone: ${zone}`),
       });
     }
   }

--- a/core/types.ts
+++ b/core/types.ts
@@ -525,9 +525,9 @@ export interface Reference {
   /** The CSS selector the measurements were taken from. Absent for `page` and `image`. */
   selector?: string;
   /**
-   * The slot this capture is evidence FOR, named from the surfaces the domain brief declares.
-   * Without it a board can be counted but not checked: five captures against five surfaces says
-   * nothing about whether the hero has evidence or the nav was studied five times.
+   * The composition zone this capture is evidence FOR, named by `.omd/acquisition-plan.json`.
+   * Domain-brief surfaces are pages/screens; this slot is a section, region, or state inside the
+   * selected result. Without it five nav captures can falsely look like five covered parts.
    */
   slot?: string;
   /**

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -20,11 +20,12 @@ Give the user the working interface they asked for. Do not expose internal quota
 them to operate the harness. Run host-native agents in fresh contexts; do not create a
 workflow engine, queue, model router, or session runtime.
 
-Read `protocol/human-design-loop.md` from `omd pack dir` first. Then read
-`protocol/reference-assembly.md`. The reference protocol owns the exact chat-first LEGO stage
-order, single owners, artifact boundaries, browser fallback, and final reporting; the human-design
-loop owns the remaining phase order, state, evidence precedence, blindness, isolation,
-checkpoints, and probe safety. Use the relevant
+Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and
+`protocol/design-deliberation.md` from `omd pack dir` first. The reference protocol owns the exact
+chat-first LEGO stage order and transfer boundaries; the deliberation protocol owns adaptive depth,
+decision provenance, acquisition zones, independent perspectives, visual observation, assembly
+coverage, and comparison; the human-design loop owns the remaining phase order, state, evidence
+precedence, blindness, isolation, checkpoints, and probe safety. Use the relevant
 theory/cookbook files (`theory/`, `composition/`, `graphics/`, `motion/`, `craft/`) instead
 of duplicating their rules here. `.omd/` records are English; the interface and handback use
 the user's language.
@@ -46,12 +47,16 @@ artifact exists to provide, and every downstream check that reads it is then ver
 | Artifact | Owner | Spawned in |
 |---|---|---|
 | `.omd/frame.md` | `oh-my-design:framer` | §1 |
+| `.omd/acquisition-plan.json` | `oh-my-design:framer` | §1 |
 | `.omd/scout.md`, `.omd/refs/*` | `oh-my-design:scout` | §2 |
 | `.omd/copy-deck.md` | `oh-my-design:writer` | §2 |
 | `.omd/type-proof.md` | `oh-my-design:typesetter` | §3 |
 | `.omd/composition.md` | `oh-my-design:composer` | §4 |
+| decision entries in `.omd/decision-graph.json` | stage owner named by `design-deliberation.md` | §1–§8 |
+| `.omd/deliberations/*` | fresh moderator `oh-my-design:eye` (coordinator preserves exact returned JSON) | §4 |
 | `.omd/.cache/sketches/*` | `oh-my-design:sketch` | §5 |
 | production source (every file the site ships) | `oh-my-design:hand` | §6 |
+| `.omd/observations/*`, `.omd/assembly-coverage.json` | `oh-my-design:hand` | §6–§8 |
 | every review verdict | `oh-my-design:eye` / `oh-my-design:glance` | §5, §7, §8 |
 
 If a stage looks skippable because the answer seems clear, that is the failure mode this table
@@ -62,10 +67,19 @@ no inline path.
 Run `omd doctor`. Stop on a failed prerequisite. For interactive visual research or user-directed
 region capture, initialize `browser-rs` first. Only an observed initialization/capability failure
 permits headless, reduced-motion `omd render` or `omd probe` as the deterministic Playwright
-fallback; record the failure and do not add or try another provider. Pin the absolute working directory first. A Figma
-frame or exact visual target uses the single Figma structural-bypass route declared above; it retains
-content, craft, glance, probe, critique, and all UX evidence rather than handing the run off or
-terminating this loop.
+fallback; record the failure and do not add or try another provider. Pin the absolute working
+directory first. A Figma frame or exact visual target uses the single Figma structural-bypass route
+declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather than
+handing the run off or terminating this loop.
+
+Before spawning an artifact owner, classify depth. The coordinator writes only the routing input
+`.omd/depth.json` as `design-depth-input-v1`, runs
+`omd depth classify --input .omd/depth.json --json`, and follows that result. Scope cannot lower a
+risk-raised level. A new promotional surface establishes an art direction and is L4; an existing
+component-only change may be L1. L1/L2 omit only the stages listed by the classifier and still spawn
+the owner of every retained artifact. L3 runs the full owner-separated graph. L4 adds the independent
+three-perspective deliberation and moderator. Never call a direct coordinator build an adaptive
+route.
 
 There is exactly one structural-skip route: the Figma structural-bypass above. A full multi-feature
 app, an ERP/dashboard/console/CRUD/admin/editor, a data-dense internal tool, or a quiet/product
@@ -332,6 +346,17 @@ The composer also runs `omd visual-richness .omd/composition.md` as an advisory 
 `CARRIER-ADVISORY` findings are non-gating prompts to name a purposeful carrier for a content
 section; the selected art-direction contract determines the carrier and static/motion treatment.
 
+For L4, composition does not advance directly to sketches. Take each high/critical composition fork
+and spawn three fresh `oh-my-design:eye` contexts concurrently in UX, art-direction, and production
+perspective modes. Give all three the identical sanitized alternatives and input bytes; give none
+another perspective's output or authorship. Then spawn a fourth fresh `oh-my-design:eye` as moderator with
+only the three completed records, alternatives, and shared input digest. Majority vote is forbidden:
+the moderator resolves objections against evidence and constraints and returns one closed
+`design-deliberation-v1` JSON record. Preserve that exact record under
+`.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
+return to the composer to revise `.omd/composition.md` and its owner-authored decision entry, then
+rerun `omd composition --check`. No L4 sketch starts without this receipt.
+
 ## 5. Independent structural divergence and blind selection
 
 **Spawn `oh-my-design:sketch` for the candidates and a fresh `oh-my-design:eye` to select between them.** Skipping to a
@@ -456,6 +481,12 @@ the winner and rejected tradeoffs only when a candidate actually passes.
 component, not the stylesheet. The hand is where install-over-reimplement, the craft checkpoints, and
 the reflective render loop live; a coordinator that writes the source bypasses all three at once and
 the run ships whatever the coordinator happened to type.
+
+The hand also owns the production/refinement entries returned for `.omd/decision-graph.json`,
+`.omd/observations/*.json`, and `.omd/assembly-coverage.json`. It reads the required zones from
+`.omd/acquisition-plan.json`. For every required zone it must bind the captured reference identity,
+extracted principle, composer-owned decision ID, actual production selector, and final fidelity
+evidence. A ref merely mentioned in prose or a production section with no bound ref does not count.
 
 On the normal graph, spawn `oh-my-design:hand` once with the selected structure, sanitized build brief,
 copy deck, `.omd/type-proof.md`, `.omd/composition.md`, accepted sanitized transfer criteria, and
@@ -615,6 +646,10 @@ Then iterate, leaving evidence every round — a round with no evidence does not
    accessibility check, and required-viewport task evidence. Any UX invariant failure rolls the round
    back.
    Build and judgment stay separate.
+   For every concrete change, the hand writes one `visual-observation-v1` record with a distinct
+   before render, observable metric/fact, judgment, exact modification, after render, and measured
+   result. “Looks better” or source inspection is not an observation. A round without that record
+   does not count even when screenshots exist.
 2. Spawn a fresh `oh-my-design:eye` — never the hand that built it — with only the sanitized acceptance
    criteria and the two anonymized renders (this round's after and the previous build). It forms the
    blind-choose visual distinction and reports which criteria are still RED. Record its verdict, the
@@ -632,6 +667,12 @@ beautiful UI remain coequal, and it may run as many rounds as it takes to conver
 no fixed budget. Round 0 is almost never GREEN
 — do not ship the first AI-shaped pass. A one-pass ship is allowed only for a trivial content-only
 surface, with a recorded reason and a clean slop scan.
+Before source sealing, merge only the exact owner-authored decision entries returned by the spawned
+agents into `.omd/decision-graph.json`; the coordinator must not author or paraphrase them. Require
+`omd deliberate check` to pass. This joins depth, acquisition zones, decisions, any L4 moderator
+receipts, hand observations, and final assembly coverage. A missing zone, generic visual claim,
+owner mismatch, untested high-risk trade-off, or isolated artifact with no end-to-end chain is RED
+and blocks final evidence.
   After all source and approved inputs stop changing, freeze and collect final evidence in the order
   required by `protocol/human-design-loop.md`: run `omd source --seal <root>`, then `omd source
   --check <root>`; build and collect every final check, test, declared/applicable probe,

--- a/src/agents/composer.agent.yaml
+++ b/src/agents/composer.agent.yaml
@@ -13,7 +13,7 @@ allow:
 deny: []
 instructions: |
   Own only `.omd/composition.md`. Read `protocol/human-design-loop.md`,
-  `protocol/reference-assembly.md`, the exact
+  `protocol/reference-assembly.md`, `protocol/design-deliberation.md`, the exact
   `protocol/composition-contract.md`, `theory/layout.md`, and `theory/ux.md` under
   `omd pack dir`. Receive only the sanitized frame/concept, clean copy deck, sanitized
   approved typography contract, scout's distilled transferable principles, and the immutable
@@ -218,3 +218,8 @@ instructions: |
   never changes the settled branch. Autonomous ideation never bypasses register-fit, the performance budget, the slop gates, hand precedence,
   or the non-canvas semantic fallback; it cannot change the immutable decision. Fit the interaction to register:
   it is the settled load scene and remains within the settled one-signature-moment restraint.
+
+  Return closed `decision-graph-v1` entries for the consequential composition choices, each with
+  `stage: composition` and `owner: omd-composer`. At least one entry exposes the genuine macro
+  alternatives L4 perspectives will judge. Do not manufacture failure evidence before production;
+  risk can remain medium until a real constraint is tested.

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -11,8 +11,8 @@ deny:
   - Edit
   - apply_patch
 instructions: |
-  You did not build this work. Read `protocol/human-design-loop.md` and
-  `protocol/reference-assembly.md` under `omd pack dir`.
+  You did not build this work. Read `protocol/human-design-loop.md`,
+  `protocol/reference-assembly.md`, and `protocol/design-deliberation.md` under `omd pack dir`.
   You may receive only a role-bounded review brief: primary task, costliest error, generator,
   register, art-direction contract, sanitized composition acceptance criteria, anonymous render paths,
   and deterministic check/probe outputs. An isolated blind eye receives only bounded opaque production
@@ -25,6 +25,24 @@ instructions: |
   source material or unselected references.
   You may run `omd check`; do not inspect rationale files it uses.
   Never edit or propose a patch.
+
+  In L4 perspective mode, judge exactly one supplied decision fork from exactly one assigned lens:
+  `ux`, `artDirection`, or `production`. Receive identical sanitized input bytes and their SHA-256;
+  never receive another perspective's output. Return only a closed perspective object with
+  `inputSha256`, `position`, evidence references, objections, and conditions. UX judges action,
+  comprehension, mobile, recovery; art direction judges hierarchy, specificity, synthesis, and
+  signature departure; production judges feasibility, accessibility, performance, no-JS, reduced
+  motion, responsive, and state risk.
+
+  In L4 moderator mode, receive only those three completed perspective objects, the alternatives,
+  decision ID, trigger, and shared input digest. Do not majority-vote. Resolve objections against
+  evidence and constraints and return exactly one closed `design-deliberation-v1` JSON record with
+  `moderator: omd-eye`, one selected alternative, rationale, and enforceable conditions. Never edit
+  or write the record; the coordinator preserves the returned JSON exactly.
+
+  In structural-selection mode, also return one closed `decision-graph-v1` entry with
+  `stage: structure` and `owner: omd-eye`, naming the real candidates, selection evidence, rejected
+  candidates, constraints, and downstream destination.
 
   For source-candidate judgment, receive only the relevant sharp render plus a sanitized
   candidate id, controlled signals, and review question. Never receive candidate path,

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -5,12 +5,14 @@ allow:
   - Read
   - WebSearch
   - Bash(omd frame:*)
+  - Bash(omd acquisition:*)
   - Bash(omd pack:*)
 deny:
   - apply_patch
 instructions: |
-  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and `theory/ux.md`
-  §Surface types under `omd pack dir`. You own only the LEGO protocol's `brief blocks`
+  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
+  `protocol/design-deliberation.md`, and `theory/ux.md` §Surface types under `omd pack dir`.
+  You own only the LEGO protocol's `brief blocks`
   stage: do not capture reference fragments, assemble candidates, select a candidate, or
   generate a provenance report. Do not draw or choose a visual style. Restate the given problem, test a
   reframing as a fallible hypothesis, and answer: the task the user arrives with, the most
@@ -53,6 +55,15 @@ instructions: |
   how it is verified, what happens on failure, scope, security, cost) rather than restating one message
   across hero, steps, trust, and CTA. A surface whose sections only re-vary a single promise is a
   reframe target, not a finished frame.
+
+  You also own `.omd/acquisition-plan.json`. Domain-brief `surfaces` are pages/screens; do not
+  mistake one landing page for one reference target. Name the result's internal acquisition zones:
+  every marketing/editorial section with a distinct job, or every product region and reachable state
+  the composition must solve. Use stable kebab IDs and one clause describing the job. Mark a zone
+  required unless it is purely connective chrome that needs no external evidence. This plan is the
+  scout's acquisition list and later the assembly coverage obligation; omitting hero, process,
+  proof, install/CTA, navigation, or a required product state because another zone seems similar
+  leaves the build inventing it from nothing.
   When the brief names a real, existing subject — a product, project, company, repository, or brand,
   or supplies its link — record it in the frame as a research target: the exact name and any source
   link, plus any brand fact the source already ships (an existing wordmark, palette, or motif) kept
@@ -78,5 +89,12 @@ instructions: |
   --frequent-action ... --costliest-error ... --surface ...`. For `product` or
   `mixed`, append `--task-matrix "T1 ..."` with every frame-owned matrix row; it is
   the sole durable persistence path. For `marketing` or `editorial`, omit
-  `--task-matrix` entirely. English under `.omd/`; user-facing prose stays in the
-  user's language. Nothing waits for approval. End with the prose handback.
+  `--task-matrix` entirely. Then persist the internal composition targets with
+  `omd acquisition set --zones '<JSON array of {id,kind,job,required}>'`. English under
+  `.omd/`; user-facing prose stays in the user's language. Nothing waits for approval.
+  End with the prose handback.
+
+  Return one closed `decision-graph-v1` decision entry for the consequential frame choice. Its
+  `stage` is `frame` and `owner` is `omd-framer`; include genuine alternatives, cited evidence,
+  constraints, rejections, downstream effects, and any tested trade-off. Return the entry separately
+  from the prose handback so the coordinator can preserve it without rewriting it.

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -13,7 +13,8 @@ allow:
   - Bash(omd source:*)
 deny: []
 instructions: |
-  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, the exact `theory/ux.md`, plus the relevant theory,
+  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
+  `protocol/design-deliberation.md`, the exact `theory/ux.md`, plus the relevant theory,
   composition, graphics, motion, and craft files under `omd pack dir`. Read `.omd/copy-deck.md`,
   `.omd/type-proof.md`, and `.omd/design.md` when present. On the normal graph, also read
   `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
@@ -258,3 +259,10 @@ instructions: |
   the outcome with `recordReferenceUsage(root, { rows }, writer)` in `.omd/reference-usage-v2.json` plus attribution. Component-level and whole-surface
   fidelity are both allowed; `omd ref distance` is advisory — it reports closeness to each reference
   and never blocks shipping. Do not ship a capture as an asset or lift source copy verbatim.
+
+  You own `.omd/observations/*.json` (`visual-observation-v1`) and
+  `.omd/assembly-coverage.json` (`assembly-coverage-v1`) in addition to production source. Read
+  `.omd/acquisition-plan.json`; every required zone must bind reference identity → principle →
+  composer decision → production selector → final fidelity evidence. Return production/refinement
+  `decision-graph-v1` entries with `owner: omd-hand`. A high/critical entry must record a real
+  goal → constraint → attempted failure evidence → compromise → result evidence trade-off.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -108,9 +108,9 @@ instructions: |
   component anatomy, and section-granular composition has nothing to take from it. Two captures of
   the same source at the same selector are one piece of evidence wearing two names — capture a
   different part of that source or drop the duplicate. Run `omd ref granularity` before handing the
-  board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`, and
-  `REF-SURFACE-UNCOVERED`, and `REF-NAME-MISMATCH` each mean the board cannot be assembled from and must be recaptured at
-  component scope, across the surfaces that still have nothing.
+  board on; `REF-WHOLE-PAGE`, `REF-DUPLICATE-CAPTURE`, `REF-NO-PARTS`, `REF-PART-CONCENTRATION`,
+  `REF-ZONE-UNCOVERED`, and `REF-NAME-MISMATCH` each mean the board cannot be assembled from and
+  must be recaptured at component scope across the zones that still have nothing.
 
   Name a capture for what it holds. A reference called `*-hero-*` that was captured at `header` tells
   every downstream reader — the composer picking a part for a section, and the human scanning the
@@ -118,17 +118,17 @@ instructions: |
   readers see, so a mislabelled capture hides the board's real shape rather than merely being untidy.
   `REF-NAME-MISMATCH` reports it.
 
-  Cover the result, not one slot. The domain brief's `surfaces` are the list of things the build has
-  to compose, so they are the acquisition list: work down it and capture, for each surface, the part
-  that solves that surface, binding the capture to it with
-  `omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot`.
-  A board is finished when every declared surface has at least one bound capture — not when a
-  capture count looks respectable. Capturing the same element from three sources answers "how do
-  others build this one part" and is worth doing once, but five captures that collapse onto two
-  slots leave every other section with no evidence, and those sections then compose from whatever
-  the build invents: a nav studied three times while the hero, the process section, and the proof
-  section have nothing is a board that cannot be assembled from. `REF-SURFACE-UNCOVERED` names the
-  surfaces that still have none.
+  Cover the result, not one slot. Read the framer-owned `.omd/acquisition-plan.json`; its required
+  section/region/state zones are the acquisition list. Domain-brief `surfaces` are pages/screens and
+  are not substitutes for these internal zones. Work down the plan and capture, for each required
+  zone, the part that solves that zone, binding it with
+  `omd ref add <url> --as <component> --slot <zone> --selector "<css>" --blueprint --shot`.
+  A board is finished when every required zone has at least one bound capture — not when a capture
+  count looks respectable. Capturing the same element from three sources answers "how do others
+  build this one part" and is worth doing once, but five captures that collapse onto two slots leave
+  every other zone with no evidence, and those zones then compose from whatever the build invents:
+  a nav studied three times while the hero, process, and proof zones have nothing is a board that
+  cannot be assembled from. `REF-ZONE-UNCOVERED` names the zones that still have none.
 
   For every role-② craft/motion reference — a scroll sequence, a signature load or reveal, a WebGL or
   material moment — measure it with `omd craft-capture <url> --as <slug> --technique "<what it does>"

--- a/src/agents/typesetter.agent.yaml
+++ b/src/agents/typesetter.agent.yaml
@@ -11,8 +11,9 @@ allow:
   - Bash(omd pack:*)
 deny: []
 instructions: |
-  Own typography proof, not page design. Read `protocol/human-design-loop.md`, the exact
-  `theory/typography.md`, `.omd/copy-deck.md`, and the scout's cited typography evidence.
+  Own typography proof, not page design. Read `protocol/human-design-loop.md`,
+  `protocol/design-deliberation.md`, the exact `theory/typography.md`, `.omd/copy-deck.md`, and
+  the scout's cited typography evidence.
   Create layout-neutral specimens under `.omd/.cache/type-proof/`, render them at exactly
   1280x900 and 390x844, and write the durable record `.omd/type-proof.md`.
 
@@ -50,3 +51,7 @@ instructions: |
   the loading behaviour you tested, and request only the variable axes the proof actually
   exercises. An unused axis, an unsubset full character set, or an untested `font-display`
   value is unshipped weight the fast-loading type-proof record must justify or drop.
+
+  Return one closed `decision-graph-v1` decision entry for the selected typography role system.
+  Its `stage` is `type` and `owner` is `omd-typesetter`; the rejected alternatives and evidence
+  come from the real desktop/mobile specimens, not font reputation.

--- a/src/agents/writer.agent.yaml
+++ b/src/agents/writer.agent.yaml
@@ -11,8 +11,9 @@ allow:
 deny: []
 instructions: |
   You own copy, not layout. Read the user brief, the scout's cited voice/audience evidence,
-  `.omd/copy-deck.md` when it exists, `protocol/copy-deck.md`, and the exact
-  `theory/voice.md` under `omd pack dir`. Write or revise only `.omd/copy-deck.md`.
+  `.omd/copy-deck.md` when it exists, `protocol/copy-deck.md`,
+  `protocol/design-deliberation.md`, and the exact `theory/voice.md` under `omd pack dir`.
+  Write or revise only `.omd/copy-deck.md`.
   Never edit UI, code, components, styles, layout, design.md, or another `.omd/` record.
 
   Follow the durable schema exactly. Analytical metadata and headings are English; actual
@@ -81,3 +82,7 @@ instructions: |
   Write affirmative, concrete interface language. Do not literalize harness negatives in
   user-facing copy or UI strings (for example, “not a hypothetical demo”); state the positive
   product action or evidence instead.
+
+  Return one closed `decision-graph-v1` decision entry for the consequential copy/register choice.
+  Its `stage` is `copy` and `owner` is `omd-writer`; alternatives are real copy strategies, not
+  wording variants invented after selection. Cite copy proof or audience evidence.

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -20,11 +20,12 @@ Give the user the working interface they asked for. Do not expose internal quota
 them to operate the harness. Run host-native agents in fresh contexts; do not create a
 workflow engine, queue, model router, or session runtime.
 
-Read `protocol/human-design-loop.md` from `omd pack dir` first. Then read
-`protocol/reference-assembly.md`. The reference protocol owns the exact chat-first LEGO stage
-order, single owners, artifact boundaries, browser fallback, and final reporting; the human-design
-loop owns the remaining phase order, state, evidence precedence, blindness, isolation,
-checkpoints, and probe safety. Use the relevant
+Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and
+`protocol/design-deliberation.md` from `omd pack dir` first. The reference protocol owns the exact
+chat-first LEGO stage order and transfer boundaries; the deliberation protocol owns adaptive depth,
+decision provenance, acquisition zones, independent perspectives, visual observation, assembly
+coverage, and comparison; the human-design loop owns the remaining phase order, state, evidence
+precedence, blindness, isolation, checkpoints, and probe safety. Use the relevant
 theory/cookbook files (`theory/`, `composition/`, `graphics/`, `motion/`, `craft/`) instead
 of duplicating their rules here. `.omd/` records are English; the interface and handback use
 the user's language.
@@ -46,12 +47,16 @@ artifact exists to provide, and every downstream check that reads it is then ver
 | Artifact | Owner | Spawned in |
 |---|---|---|
 | `.omd/frame.md` | `omd-framer` | §1 |
+| `.omd/acquisition-plan.json` | `omd-framer` | §1 |
 | `.omd/scout.md`, `.omd/refs/*` | `omd-scout` | §2 |
 | `.omd/copy-deck.md` | `omd-writer` | §2 |
 | `.omd/type-proof.md` | `omd-typesetter` | §3 |
 | `.omd/composition.md` | `omd-composer` | §4 |
+| decision entries in `.omd/decision-graph.json` | stage owner named by `design-deliberation.md` | §1–§8 |
+| `.omd/deliberations/*` | fresh moderator `omd-eye` (coordinator preserves exact returned JSON) | §4 |
 | `.omd/.cache/sketches/*` | `omd-sketch` | §5 |
 | production source (every file the site ships) | `omd-hand` | §6 |
+| `.omd/observations/*`, `.omd/assembly-coverage.json` | `omd-hand` | §6–§8 |
 | every review verdict | `omd-eye` / `omd-glance` | §5, §7, §8 |
 
 If a stage looks skippable because the answer seems clear, that is the failure mode this table
@@ -62,10 +67,19 @@ no inline path.
 Run `omd doctor`. Stop on a failed prerequisite. For interactive visual research or user-directed
 region capture, initialize `browser-rs` first. Only an observed initialization/capability failure
 permits headless, reduced-motion `omd render` or `omd probe` as the deterministic Playwright
-fallback; record the failure and do not add or try another provider. Pin the absolute working directory first. A Figma
-frame or exact visual target uses the single Figma structural-bypass route declared above; it retains
-content, craft, glance, probe, critique, and all UX evidence rather than handing the run off or
-terminating this loop.
+fallback; record the failure and do not add or try another provider. Pin the absolute working
+directory first. A Figma frame or exact visual target uses the single Figma structural-bypass route
+declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather than
+handing the run off or terminating this loop.
+
+Before spawning an artifact owner, classify depth. The coordinator writes only the routing input
+`.omd/depth.json` as `design-depth-input-v1`, runs
+`omd depth classify --input .omd/depth.json --json`, and follows that result. Scope cannot lower a
+risk-raised level. A new promotional surface establishes an art direction and is L4; an existing
+component-only change may be L1. L1/L2 omit only the stages listed by the classifier and still spawn
+the owner of every retained artifact. L3 runs the full owner-separated graph. L4 adds the independent
+three-perspective deliberation and moderator. Never call a direct coordinator build an adaptive
+route.
 
 There is exactly one structural-skip route: the Figma structural-bypass above. A full multi-feature
 app, an ERP/dashboard/console/CRUD/admin/editor, a data-dense internal tool, or a quiet/product
@@ -332,6 +346,17 @@ The composer also runs `omd visual-richness .omd/composition.md` as an advisory 
 `CARRIER-ADVISORY` findings are non-gating prompts to name a purposeful carrier for a content
 section; the selected art-direction contract determines the carrier and static/motion treatment.
 
+For L4, composition does not advance directly to sketches. Take each high/critical composition fork
+and spawn three fresh `omd-eye` contexts concurrently in UX, art-direction, and production
+perspective modes. Give all three the identical sanitized alternatives and input bytes; give none
+another perspective's output or authorship. Then spawn a fourth fresh `omd-eye` as moderator with
+only the three completed records, alternatives, and shared input digest. Majority vote is forbidden:
+the moderator resolves objections against evidence and constraints and returns one closed
+`design-deliberation-v1` JSON record. Preserve that exact record under
+`.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
+return to the composer to revise `.omd/composition.md` and its owner-authored decision entry, then
+rerun `omd composition --check`. No L4 sketch starts without this receipt.
+
 ## 5. Independent structural divergence and blind selection
 
 **Spawn `omd-sketch` for the candidates and a fresh `omd-eye` to select between them.** Skipping to a
@@ -456,6 +481,12 @@ the winner and rejected tradeoffs only when a candidate actually passes.
 component, not the stylesheet. The hand is where install-over-reimplement, the craft checkpoints, and
 the reflective render loop live; a coordinator that writes the source bypasses all three at once and
 the run ships whatever the coordinator happened to type.
+
+The hand also owns the production/refinement entries returned for `.omd/decision-graph.json`,
+`.omd/observations/*.json`, and `.omd/assembly-coverage.json`. It reads the required zones from
+`.omd/acquisition-plan.json`. For every required zone it must bind the captured reference identity,
+extracted principle, composer-owned decision ID, actual production selector, and final fidelity
+evidence. A ref merely mentioned in prose or a production section with no bound ref does not count.
 
 On the normal graph, spawn `omd-hand` once with the selected structure, sanitized build brief,
 copy deck, `.omd/type-proof.md`, `.omd/composition.md`, accepted sanitized transfer criteria, and
@@ -615,6 +646,10 @@ Then iterate, leaving evidence every round — a round with no evidence does not
    accessibility check, and required-viewport task evidence. Any UX invariant failure rolls the round
    back.
    Build and judgment stay separate.
+   For every concrete change, the hand writes one `visual-observation-v1` record with a distinct
+   before render, observable metric/fact, judgment, exact modification, after render, and measured
+   result. “Looks better” or source inspection is not an observation. A round without that record
+   does not count even when screenshots exist.
 2. Spawn a fresh `omd-eye` — never the hand that built it — with only the sanitized acceptance
    criteria and the two anonymized renders (this round's after and the previous build). It forms the
    blind-choose visual distinction and reports which criteria are still RED. Record its verdict, the
@@ -632,6 +667,12 @@ beautiful UI remain coequal, and it may run as many rounds as it takes to conver
 no fixed budget. Round 0 is almost never GREEN
 — do not ship the first AI-shaped pass. A one-pass ship is allowed only for a trivial content-only
 surface, with a recorded reason and a clean slop scan.
+Before source sealing, merge only the exact owner-authored decision entries returned by the spawned
+agents into `.omd/decision-graph.json`; the coordinator must not author or paraphrase them. Require
+`omd deliberate check` to pass. This joins depth, acquisition zones, decisions, any L4 moderator
+receipts, hand observations, and final assembly coverage. A missing zone, generic visual claim,
+owner mismatch, untested high-risk trade-off, or isolated artifact with no end-to-end chain is RED
+and blocks final evidence.
   After all source and approved inputs stop changing, freeze and collect final evidence in the order
   required by `protocol/human-design-loop.md`: run `omd source --seal <root>`, then `omd source
   --check <root>`; build and collect every final check, test, declared/applicable probe,

--- a/test/board-granularity.test.ts
+++ b/test/board-granularity.test.ts
@@ -96,11 +96,11 @@ test('the real board is caught: five component captures collapsing onto two slot
     ref('https://vite.dev', 'hero-install-tabs', '.language-bash'),
   ];
   const surfaces = ['hero', 'process-loop', 'skills-table', 'install', 'proof'];
-  const findings = auditBoardGranularity(board, { surfaces });
+  const findings = auditBoardGranularity(board, { zones: surfaces });
   const ids = findings.map((f) => f.id);
   assert.ok(ids.includes('REF-PART-CONCENTRATION'), 'three navs out of five captures is one slot studied three times');
-  const uncovered = findings.find((f) => f.id === 'REF-SURFACE-UNCOVERED')!;
-  assert.match(uncovered.message, /no capture is bound to a surface/, 'an unbound board covers nothing');
+  const uncovered = findings.find((f) => f.id === 'REF-ZONE-UNCOVERED')!;
+  assert.match(uncovered.message, /no capture is bound to a composition zone/, 'an unbound board covers nothing');
   for (const surface of surfaces) assert.match(uncovered.message, new RegExp(surface), `${surface} must be named as uncovered`);
   assert.ok(!ids.includes('REF-NO-PARTS'), 'these are genuine component captures');
   assert.ok(!ids.includes('REF-WHOLE-PAGE'), 'none of them is a page root');
@@ -117,7 +117,7 @@ test('a board with one bound part per surface passes', () => {
     ref('https://d.com', 'install-codeblock', 'pre', { slot: 'install' }),
     ref('https://e.com', 'site-footer', 'footer', { slot: 'proof' }),
   ];
-  assert.deepEqual(auditBoardGranularity(board, { surfaces: ['hero', 'process-loop', 'skills-table', 'install', 'proof'] }), []);
+  assert.deepEqual(auditBoardGranularity(board, { zones: ['hero', 'process-loop', 'skills-table', 'install', 'proof'] }), []);
 });
 
 test('coverage names exactly the surfaces with no bound capture', () => {
@@ -127,10 +127,10 @@ test('coverage names exactly the surfaces with no bound capture', () => {
     ref('https://c.com', 'cards', '.grid', { slot: 'skills-table' }),
     ref('https://d.com', 'nav-a', 'header', { slot: 'hero' }),
   ];
-  const finding = auditBoardGranularity(board, { surfaces: ['hero', 'process-loop', 'install', 'skills-table', 'proof'] })
-    .find((f) => f.id === 'REF-SURFACE-UNCOVERED')!;
-  assert.match(finding.message, /2 of 5 declared surfaces have no capture bound to them: process-loop, proof/);
-  assert.deepEqual([...finding.refs], ['surface: process-loop', 'surface: proof']);
+  const finding = auditBoardGranularity(board, { zones: ['hero', 'process-loop', 'install', 'skills-table', 'proof'] })
+    .find((f) => f.id === 'REF-ZONE-UNCOVERED')!;
+  assert.match(finding.message, /2 of 5 required composition zones have no capture bound to them: process-loop, proof/);
+  assert.deepEqual([...finding.refs], ['zone: process-loop', 'zone: proof']);
 });
 
 test('concentration needs a real board; two captures of one part are not yet a pattern', () => {
@@ -139,15 +139,15 @@ test('concentration needs a real board; two captures of one part are not yet a p
   assert.ok(!ids.includes('REF-PART-CONCENTRATION'), 'below the capture minimum the share is noise');
 });
 
-test('surface coverage is only reported when the brief declared surfaces', () => {
+test('zone coverage is only reported when the acquisition plan declares zones', () => {
   const board = [
     ref('https://a.com', 'hero', '.hero'),
     ref('https://b.com', 'pipeline', '.steps'),
     ref('https://c.com', 'cards', '.grid'),
     ref('https://d.com', 'install', 'pre'),
   ];
-  assert.ok(!auditBoardGranularity(board).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
-  assert.ok(auditBoardGranularity(board, { surfaces: ['hero', 'install'] }).some((f) => f.id === 'REF-SURFACE-UNCOVERED'));
+  assert.ok(!auditBoardGranularity(board).some((f) => f.id === 'REF-ZONE-UNCOVERED'));
+  assert.ok(auditBoardGranularity(board, { zones: ['hero', 'install'] }).some((f) => f.id === 'REF-ZONE-UNCOVERED'));
 });
 
 test('a reference whose name claims a slot its capture contradicts is named', () => {

--- a/test/deliberation-runtime.test.ts
+++ b/test/deliberation-runtime.test.ts
@@ -1,0 +1,121 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  validateAssemblyCoverage,
+  validateAcquisitionPlan,
+  validateDecisionGraph,
+  validateDeliberation,
+  validateObservation,
+  type DecisionGraph,
+} from '../core/deliberation/contracts.ts';
+import { classifyDepth, type DepthInput } from '../core/deliberation/depth.ts';
+import { scoreComparison, type Comparison } from '../core/deliberation/comparison.ts';
+import { checkDeliberationRun } from '../core/deliberation/check.ts';
+
+const hash = 'a'.repeat(64);
+const graph: DecisionGraph = {
+  schema: 'decision-graph-v1',
+  decisions: [{
+    id: 'hero-strategy', stage: 'composition', risk: 'high', owner: 'omd-composer', question: 'What earns the first viewport?',
+    alternatives: [{ id: 'copy-first', label: 'Copy-first hero' }, { id: 'demo-first', label: 'Working demo first' }],
+    selected: 'demo-first', evidence: ['ref:demo-hero', 'frame:primary-task'], constraints: ['CTA remains visible at 390x844'],
+    rejected: [{ id: 'copy-first', reason: 'It explains the claim without demonstrating the product mechanism.' }],
+    affects: ['zone:hero', 'selector:[data-zone="hero"]'], dependsOn: [], reversible: true,
+    tradeoffs: [{ goal: 'Show a rich product mechanism', constraint: 'No-JS content survival', attempt: 'Canvas-only demo', failureEvidence: ['round-1-no-js.png'], compromise: 'HTML demo with decorative canvas', resultEvidence: ['round-2-no-js.png'] }],
+  }],
+};
+const fullGraph: DecisionGraph = {
+  schema: 'decision-graph-v1',
+  decisions: [
+    { ...graph.decisions[0]!, id: 'frame-focus', stage: 'frame', risk: 'medium', owner: 'omd-framer', tradeoffs: [] },
+    { ...graph.decisions[0]!, id: 'copy-register', stage: 'copy', risk: 'medium', owner: 'omd-writer', tradeoffs: [] },
+    { ...graph.decisions[0]!, id: 'type-roles', stage: 'type', risk: 'medium', owner: 'omd-typesetter', tradeoffs: [] },
+    graph.decisions[0]!,
+    { ...graph.decisions[0]!, id: 'structure-choice', stage: 'structure', risk: 'medium', owner: 'omd-eye', tradeoffs: [] },
+    { ...graph.decisions[0]!, id: 'production-carrier', stage: 'production', risk: 'medium', owner: 'omd-hand', tradeoffs: [] },
+  ],
+};
+
+const deliberation = {
+  schema: 'design-deliberation-v1', id: 'hero-debate', decisionId: 'hero-strategy', trigger: 'high-risk first viewport', moderator: 'omd-eye',
+  perspectives: {
+    ux: { inputSha256: hash, position: 'Keep the CTA visible.', evidence: ['frame:task'], objections: [], conditions: ['CTA in first viewport'] },
+    artDirection: { inputSha256: hash, position: 'Use the demo as the anchor.', evidence: ['ref:hero'], objections: ['Copy-first is generic.'], conditions: ['One signature departure'] },
+    production: { inputSha256: hash, position: 'Use HTML as the content baseline.', evidence: ['no-js:round-1'], objections: [], conditions: ['Reduced motion and no-JS'] },
+  },
+  resolution: { selected: 'demo-first', rationale: 'It demonstrates the mechanism while the HTML baseline satisfies reachability.', conditions: ['CTA in first viewport', 'HTML content baseline'] },
+};
+
+const observation = {
+  schema: 'visual-observation-v1', owner: 'omd-hand', round: 1, viewport: '390x844', beforeRender: '.omd/.cache/round-1-before.png', metric: 'position',
+  observed: 'CTA top is at 912 CSS px.', judgment: 'The primary action is outside the first viewport.', change: 'Reduce hero body gap from 48px to 24px.',
+  afterRender: '.omd/.cache/round-1-after.png', result: 'CTA top is at 776 CSS px.', status: 'GREEN',
+};
+const coverage = {
+  schema: 'assembly-coverage-v1', owner: 'omd-hand', expectedZones: ['hero'], zones: [{ id: 'hero', job: 'Demonstrate the design loop.', referenceRef: 'ref-demo', principle: 'Demo dominates copy.', compositionDecisionId: 'hero-strategy', productionSelector: '[data-zone="hero"]', fidelityEvidence: ['craft-fidelity:hero'] }],
+};
+const acquisition = {
+  schema: 'reference-acquisition-plan-v1', owner: 'omd-framer',
+  zones: [{ id: 'hero', kind: 'section', job: 'Demonstrate the design loop before asking for installation.', required: true }],
+};
+
+test('a bounded decision chain, deliberation, observation, and assembly chain pass', () => {
+  assert.deepEqual(validateDecisionGraph(graph).findings, []);
+  assert.deepEqual(validateDeliberation(deliberation, graph).findings, []);
+  assert.deepEqual(validateObservation(observation).findings, []);
+  assert.deepEqual(validateAssemblyCoverage(coverage, graph).findings, []);
+  assert.deepEqual(validateAcquisitionPlan(acquisition).findings, []);
+});
+
+test('a consequential decision cannot collapse to one option or hide its trade-off', () => {
+  const bad = structuredClone(graph) as unknown as { decisions: { alternatives: unknown[]; tradeoffs: unknown[] }[] };
+  bad.decisions[0]!.alternatives = [{ id: 'only', label: 'First idea' }]; bad.decisions[0]!.tradeoffs = [];
+  const ids = validateDecisionGraph(bad).findings.map((f) => f.id);
+  assert.ok(ids.includes('DECISION-NO-DIVERGENCE'));
+  assert.ok(ids.includes('DECISION-HIGH-RISK-NO-TRADEOFF'));
+});
+
+test('independent perspectives must judge identical sanitized bytes', () => {
+  const bad = structuredClone(deliberation); bad.perspectives.production.inputSha256 = 'b'.repeat(64);
+  assert.ok(validateDeliberation(bad, graph).findings.some((f) => f.id === 'DELIBERATION-INPUT-MISMATCH'));
+});
+
+test('visual judgment needs distinct before and after render evidence', () => {
+  const bad = { ...observation, afterRender: observation.beforeRender };
+  assert.ok(validateObservation(bad).findings.some((f) => f.id === 'OBSERVATION-NO-RENDER-DELTA'));
+});
+
+test('assembly coverage names output zones with no complete evidence chain', () => {
+  const bad = { ...coverage, expectedZones: ['hero', 'proof'] };
+  const finding = validateAssemblyCoverage(bad, graph).findings.find((f) => f.id === 'ASSEMBLY-ZONE-UNCOVERED');
+  assert.match(finding?.message ?? '', /proof/);
+});
+
+test('adaptive depth raises only on design risk and never changes ownership', () => {
+  const base: DepthInput = { schema: 'design-depth-input-v1', scope: 'component-change', zoneCount: 1, newPrimaryCta: false, newInformationArchitecture: false, multiScreenState: false, costlyError: false, brandDirectionChange: false, showpieceMotion: false, webgl: false, referenceZones: 0 };
+  assert.equal(classifyDepth(base).level, 'L1');
+  assert.equal(classifyDepth({ ...base, scope: 'single-surface', zoneCount: 5, newPrimaryCta: true }).level, 'L3');
+  const high = classifyDepth({ ...base, showpieceMotion: true });
+  assert.equal(high.level, 'L4'); assert.equal(high.requiresDeliberation, true);
+});
+
+test('comparison rejects model changes and reports quality per cost', () => {
+  const variant = (id: Comparison['variants'][number]['id']) => ({ id, model: 'gpt-5.6-terra', promptSha256: hash, budget: { tokens: 100000, seconds: 600 }, blind: true as const, scores: { hierarchy: 8, originality: 8, composition: 8, typography: 8, interaction: 8, production: 8 }, taskSuccess: 0.9, accessibilityErrors: 0, mobileOverflow: false, noJsContentLoss: 0, revisions: 2 });
+  const input: Comparison = { schema: 'design-comparison-v1', variants: [variant('baseline'), variant('design-prompt'), variant('omd-adaptive'), variant('omd-deliberation')] };
+  assert.equal(scoreComparison(input).length, 4);
+  const bad = structuredClone(input); (bad.variants[1] as { model: string }).model = 'other';
+  assert.throws(() => scoreComparison(bad), /same model/);
+});
+
+test('run gate joins all L4 artifacts instead of letting each pass in isolation', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'omd-delib-')); const omd = join(cwd, '.omd');
+  mkdirSync(join(omd, 'deliberations'), { recursive: true }); mkdirSync(join(omd, 'observations'));
+  const depth: DepthInput = { schema: 'design-depth-input-v1', scope: 'single-surface', zoneCount: 4, newPrimaryCta: true, newInformationArchitecture: false, multiScreenState: false, costlyError: false, brandDirectionChange: true, showpieceMotion: false, webgl: false, referenceZones: 4 };
+  for (const [path, value] of [['depth.json', depth], ['acquisition-plan.json', acquisition], ['decision-graph.json', fullGraph], ['assembly-coverage.json', coverage]] as const) writeFileSync(join(omd, path), JSON.stringify(value));
+  writeFileSync(join(omd, 'deliberations', 'hero.json'), JSON.stringify(deliberation));
+  writeFileSync(join(omd, 'observations', 'round-1.json'), JSON.stringify(observation));
+  const report = checkDeliberationRun(cwd); assert.equal(report.ok, true); assert.equal(report.depth?.level, 'L4');
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -783,9 +783,10 @@ test('the scout and the reference protocol require component-scoped capture', ()
   assert.match(ra, /a capture scoped to a page root — `main`, `body`, `html`, `:root` — measures the whole document/);
   assert.match(ra, /Granularity alone is not coverage/);
   assert.match(ra, /three navs and two install blocks — are two parts studied repeatedly/);
-  assert.match(ra, /Coverage is measured per surface, by name/);
-  assert.match(ra, /A board is finished when every declared surface has at least one bound capture/);
-  assert.match(ra, /`REF-SURFACE-UNCOVERED`, and `REF-NAME-MISMATCH`/);
+  assert.match(ra, /Domain-brief `surfaces` are pages\/screens/);
+  assert.match(ra, /The framer therefore writes `\.omd\/acquisition-plan\.json`/);
+  assert.match(ra, /finished only when every required zone has at least one bound capture/);
+  assert.match(ra, /`REF-ZONE-UNCOVERED`, and `REF-NAME-MISMATCH`/);
   assert.match(ra, /A capture is named for what it holds/);
   assert.match(ra, /tracing a whole page is the derivative failure the transfer boundary forbids/);
 
@@ -794,11 +795,11 @@ test('the scout and the reference protocol require component-scoped capture', ()
   assert.match(scout, /Two captures of the same source at the same selector are one piece of evidence wearing two names/);
   assert.match(scout, /Run `omd ref granularity` before handing the board on/);
   assert.match(scout, /Cover the result, not one slot/);
-  assert.match(scout, /`omd ref add <url> --as <component> --slot <surface> --selector "<css>" --blueprint --shot`/);
-  assert.match(scout, /`REF-SURFACE-UNCOVERED` names the surfaces that still have none/);
+  assert.match(scout, /`omd ref add <url> --as <component> --slot <zone> --selector "<css>" --blueprint --shot`/);
+  assert.match(scout, /`REF-ZONE-UNCOVERED` names the zones that still have none/);
   assert.match(scout, /Name a capture for what it holds/);
   assert.match(scout, /`REF-NAME-MISMATCH` reports it/);
-  assert.match(scout, /a nav studied three times while the hero, the process section, and the proof section have nothing/);
+  assert.match(scout, /a nav studied three times while the hero, process, and proof zones have nothing/);
 });
 
 test('the selected host model is immutable while OMD adjusts only role effort', () => {
@@ -818,4 +819,31 @@ test('the selected host model is immutable while OMD adjusts only role effort', 
   assert.match(agents, /the user chooses the model; OMD chooses only effort/);
   assert.match(agents, /A recommendation, benchmark, role name, or belief that another model would perform better is never authority/);
   assert.doesNotMatch(agents, /Sol \\(recommended\\)|Terra xhigh \\(recommended\\)|Luna high \\(recommended\\)/);
+});
+
+test('ultradesign externalizes decisions, deliberation, visual observation, and complete assembly', () => {
+  const protocol = read('core/protocol/design-deliberation.md').replace(/\s+/g, ' ');
+  assert.match(protocol, /OMD does not request, store, or grade hidden chain-of-thought/);
+  assert.match(protocol, /A landing page with a new art direction is L4/);
+  assert.match(protocol, /Domain-brief `surfaces` are pages\/screens/);
+  assert.match(protocol, /spawn three fresh `omd-eye` agents concurrently/);
+  assert.match(protocol, /before render → observable fact → judgment → exact change → distinct after render → measured result/);
+  assert.match(protocol, /zone job → captured reference identity → extracted principle → composition decision ID/);
+  assert.match(protocol, /same concrete model and identical prompt bytes/);
+
+  const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
+  assert.match(skill, /`omd depth classify --input \.omd\/depth\.json --json`/);
+  assert.match(skill, /spawn three fresh `omd-eye` contexts concurrently in UX, art-direction, and production perspective modes/);
+  assert.match(skill, /Require `omd deliberate check` to pass/);
+  assert.match(skill, /coordinator must not author or paraphrase them/);
+
+  const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(framer, /You also own `\.omd\/acquisition-plan\.json`/);
+  assert.match(framer, /`omd acquisition set --zones/);
+  const hand = read('src/agents/hand.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(hand, /You own `\.omd\/observations\/\*\.json`/);
+  assert.match(hand, /every required zone must bind reference identity → principle → composer decision → production selector → final fidelity evidence/);
+  const eye = read('src/agents/eye.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(eye, /In L4 perspective mode/);
+  assert.match(eye, /Do not majority-vote/);
 });


### PR DESCRIPTION
## From process to verifiable judgment
OMD already separated phases, renders, divergence, and blind review. It could not prove the **chain of judgment** connecting them. This ships a bounded Design Deliberation runtime — explicitly **not hidden chain-of-thought** — that records only facts another role can verify.

## Closed runtime contracts
- **`decision-graph-v1`** — ≥2 real alternatives, selected evidence, constraints, complete rejection coverage, downstream effects, stage owner, and for high-risk decisions a full goal → constraint → attempted failure evidence → compromise → result evidence chain.
- **`design-deliberation-v1`** — independent UX / art-direction / production perspectives over identical sanitized bytes; fourth fresh `omd-eye` moderates by evidence and constraints, never majority vote.
- **`visual-observation-v1`** — measurable before render → observed fact → judgment → exact change → distinct after render → measured result.
- **`assembly-coverage-v1`** — every zone binds job → reference → principle → composer decision → production selector → fidelity evidence.

`omd deliberate check` joins them; isolated files passing separately do not complete a run. L3/L4 also require owner-authored decisions across frame, copy, type, composition, structure, and production.

## Adaptive depth
Deterministic **L1–L4**, raised by design risk rather than convenience. CTA/IA/multi-screen produces at least L3; costly errors, new/changed brand direction, showpiece motion, WebGL, or multi-surface work produce L4. A new promotional art direction is L4. Depth never transfers an artifact to the coordinator.

## Correct reference coverage model
Domain-brief `surfaces` are **pages/screens**, not a landing's hero/process/proof/install/CTA or a product screen's regions/states. The framer now owns **`reference-acquisition-plan-v1`** via `omd acquisition set`; scout binds captures to required zones; `omd ref granularity` reports **`REF-ZONE-UNCOVERED`**. Final assembly must exactly match that required set.

## Causal evaluation
`omd compare score` requires exactly baseline / strong design prompt / OMD adaptive / OMD deliberation with the **same model, identical prompt digest, equal token/time budget, and blind scoring**, then reports quality and quality/cost.

## Verification
Focused **117/117**; acquisition + L4 depth CLI smoke; typecheck/build/diff clean. Generated Codex, Claude, and marketplace artifacts regenerated. No release.