### PR TITLE
fix: gate Codex production on completed owner stages

### DIFF
--- a/agents/hand.md
+++ b/agents/hand.md
@@ -14,6 +14,14 @@ applies, inspect the selected lawful local part-image capture projections under 
 `.omd/reference-selection-v2.json`, current `.omd/motion-resolutions/sha256-<digest>.json` projection,
 and decision-bound `.omd/reference-handoffs/composer.json` and `hand.json` receipts; they are the
 production fidelity evidence, not optional context.
+Before touching production source on the normal graph, run
+`omd deliberate check --phase prebuild` and `omd composition --check`. Both must pass, and
+`.omd/type-proof.md`, `.omd/composition.md`, the selected structure, reference-selection/handoff
+records, and every required L4 deliberation must exist. A missing or stale prerequisite is a
+blocker: return it to the coordinator and stop without writing source. Never call it an
+“unavailable prerequisite,” “scoped deviation,” or reason to continue. Never spawn or delegate to
+another agent; you are the sole production-source owner, so a worker cannot implement on your
+behalf.
 Build the selected reference's macro visual system — its composition, spacing rhythm, hierarchy,
 material treatment, and named landing rules — into the approved destination, while writing the
 product's own copy. Do not inspect source URLs or unselected/raw source material. Start only after

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -84,6 +84,7 @@ interface Opts {
   evidence?: string;
   zones?: string;
   input?: string;
+  phase?: string;
   activation?: string;
   /** Capture a full-resolution structural blueprint of the selected component. */
   blueprint?: boolean;
@@ -1871,15 +1872,18 @@ async function cmdTokens(mode: string | undefined, opts: Opts): Promise<never> {
   process.exit(drift ? 1 : 0);
 }
 
-/** Validates the externalized decision, observation, assembly, and deliberation records for this run. */
+/** Validates owner-authored design records before production or across the completed run. */
 async function cmdDeliberate(mode: string | undefined, opts: Opts): Promise<never> {
-  if (mode !== 'check') throw new Error('usage: omd deliberate check [--json]');
+  if (mode !== 'check' || (opts.phase !== undefined && opts.phase !== 'prebuild' && opts.phase !== 'final')) {
+    throw new Error('usage: omd deliberate check [--phase prebuild|final] [--json]');
+  }
   const { checkDeliberationRun } = await import('../core/deliberation/check.ts');
-  const report = checkDeliberationRun(process.cwd());
+  const phase = (opts.phase ?? 'final') as import('../core/deliberation/check.ts').DeliberationRunPhase;
+  const report = checkDeliberationRun(process.cwd(), phase);
   if (opts.json) process.stdout.write(JSON.stringify(report));
   else {
     for (const finding of report.findings) console.error(`[error] ${finding.id} ${finding.path}: ${finding.message}`);
-    if (report.ok) console.log(`ok — ${report.depth?.level ?? '?'} decision chain (${report.counts.decisions} decisions, ${report.counts.deliberations} deliberations, ${report.counts.observations} observations, ${report.counts.zones} assembled zones)`);
+    if (report.ok) console.log(`ok — ${report.depth?.level ?? '?'} ${phase} decision gate (${report.counts.decisions} decisions, ${report.counts.deliberations} deliberations, ${report.counts.observations} observations, ${report.counts.zones} assembled zones)`);
   }
   process.exit(report.ok ? 0 : 1);
 }
@@ -2818,7 +2822,7 @@ function usage(): never {
     + '  composition --check [--json]                validate composition sections and input freshness\n'
     + '  acquisition set --zones <json-array>          persist framer-owned section/region/state reference targets\n'
     + '  depth classify --input depth.json [--json]      choose L1–L4 from design risk, never from convenience\n'
-    + '  deliberate check [--json]                      validate decisions, visual observations, assembly, and debate\n'
+    + '  deliberate check [--phase prebuild|final] [--json] validate owner decisions before build or the complete visual loop\n'
     + '  compare score --input comparison.json [--json] blind same-model quality and quality/cost comparison\n'
     + '  source --seal [root]                        write final approved-input/source byte seal\n'
     + '  source --check [root] [--json]              fail when the source seal is missing or stale\n'

--- a/core/deliberation/check.ts
+++ b/core/deliberation/check.ts
@@ -11,9 +11,11 @@ import {
   validateObservation,
 } from './contracts.ts';
 import { classifyDepth, type DepthInput, type DepthResult } from './depth.ts';
+export type DeliberationRunPhase = 'prebuild' | 'final';
 
 export type DeliberationRunReport = {
   readonly ok: boolean;
+  readonly phase: DeliberationRunPhase;
   readonly depth?: DepthResult;
   readonly findings: readonly ContractFinding[];
   readonly counts: { readonly decisions: number; readonly deliberations: number; readonly observations: number; readonly zones: number };
@@ -22,7 +24,7 @@ export type DeliberationRunReport = {
 const parse = (path: string): unknown => JSON.parse(readFileSync(path, 'utf8'));
 const missing = (path: string, message: string): ContractFinding => ({ id: 'DELIBERATION-ARTIFACT-MISSING', path, message });
 
-export function checkDeliberationRun(cwd: string): DeliberationRunReport {
+export function checkDeliberationRun(cwd: string, phase: DeliberationRunPhase = 'final'): DeliberationRunReport {
   const dir = join(cwd, '.omd'); const findings: ContractFinding[] = [];
   const depthPath = join(dir, 'depth.json');
   let depth: DepthResult | undefined;
@@ -47,44 +49,49 @@ export function checkDeliberationRun(cwd: string): DeliberationRunReport {
     catch (error) { findings.push({ id: 'DECISION-GRAPH-JSON', path: '.omd/decision-graph.json', message: error instanceof Error ? error.message : String(error) }); }
   }
   if (depth && graph) {
-    const requiredStages = depth.level === 'L1'
+    const finalStages = depth.level === 'L1'
       ? ['refinement']
       : depth.level === 'L2'
         ? ['frame', 'composition', 'production']
         : ['frame', 'copy', 'type', 'composition', 'structure', 'production'];
+    const requiredStages = phase === 'prebuild'
+      ? finalStages.filter((stage) => stage !== 'production' && stage !== 'refinement')
+      : finalStages;
     const present = new Set(graph.decisions.map((decision) => decision.stage));
     for (const stage of requiredStages) {
       if (!present.has(stage as import('./contracts.ts').DecisionStage)) findings.push({
         id: 'DECISION-STAGE-UNCOVERED',
         path: '.omd/decision-graph.json',
-        message: `${depth.level} requires an owner-authored ${stage} decision entry`,
+        message: `${depth.level} ${phase} gate requires an owner-authored ${stage} decision entry`,
       });
     }
   }
 
   const coveragePath = join(dir, 'assembly-coverage.json'); let zones = 0;
-  if (depth && ['L3', 'L4'].includes(depth.level)) {
-    if (!existsSync(coveragePath)) findings.push(missing('.omd/assembly-coverage.json', 'bind every selected composition zone from reference to final evidence'));
-    else try {
-      const raw = parse(coveragePath); if (typeof raw === 'object' && raw !== null && Array.isArray((raw as { zones?: unknown }).zones)) zones = (raw as { zones: unknown[] }).zones.length;
-      findings.push(...validateAssemblyCoverage(raw, graph).findings);
-      if (acquisition && typeof raw === 'object' && raw !== null && Array.isArray((raw as { expectedZones?: unknown }).expectedZones)) {
-        const required = acquisition.zones.filter((zone) => zone.required).map((zone) => zone.id).sort();
-        const expected = [...((raw as { expectedZones: string[] }).expectedZones)].sort();
-        if (required.length !== expected.length || required.some((id, i) => id !== expected[i])) {
-          findings.push({ id: 'ASSEMBLY-ACQUISITION-DRIFT', path: '.omd/assembly-coverage.json:expectedZones', message: 'final assembly zones must exactly cover the required acquisition zones; revise the plan explicitly before composition rather than silently dropping a section' });
-        }
-      }
-    } catch (error) { findings.push({ id: 'ASSEMBLY-COVERAGE-JSON', path: '.omd/assembly-coverage.json', message: error instanceof Error ? error.message : String(error) }); }
-  }
-
   const observationDir = join(dir, 'observations'); let observations = 0;
-  if (!existsSync(observationDir)) findings.push(missing('.omd/observations/', 'record observable before/after render judgments'));
-  else {
-    const files = readdirSync(observationDir).filter((name) => name.endsWith('.json')).sort(); observations = files.length;
-    if (files.length === 0) findings.push(missing('.omd/observations/*.json', 'at least one Observe → Judge → Modify → Re-observe record is required'));
-    for (const file of files) try { findings.push(...validateObservation(parse(join(observationDir, file))).findings.map((f) => ({ ...f, path: `.omd/observations/${file}:${f.path}` }))); }
-    catch (error) { findings.push({ id: 'OBSERVATION-JSON', path: `.omd/observations/${file}`, message: error instanceof Error ? error.message : String(error) }); }
+  if (phase === 'final') {
+    if (depth && ['L3', 'L4'].includes(depth.level)) {
+      if (!existsSync(coveragePath)) findings.push(missing('.omd/assembly-coverage.json', 'bind every selected composition zone from reference to final evidence'));
+      else try {
+        const raw = parse(coveragePath); if (typeof raw === 'object' && raw !== null && Array.isArray((raw as { zones?: unknown }).zones)) zones = (raw as { zones: unknown[] }).zones.length;
+        findings.push(...validateAssemblyCoverage(raw, graph).findings);
+        if (acquisition && typeof raw === 'object' && raw !== null && Array.isArray((raw as { expectedZones?: unknown }).expectedZones)) {
+          const required = acquisition.zones.filter((zone) => zone.required).map((zone) => zone.id).sort();
+          const expected = [...((raw as { expectedZones: string[] }).expectedZones)].sort();
+          if (required.length !== expected.length || required.some((id, i) => id !== expected[i])) {
+            findings.push({ id: 'ASSEMBLY-ACQUISITION-DRIFT', path: '.omd/assembly-coverage.json:expectedZones', message: 'final assembly zones must exactly cover the required acquisition zones; revise the plan explicitly before composition rather than silently dropping a section' });
+          }
+        }
+      } catch (error) { findings.push({ id: 'ASSEMBLY-COVERAGE-JSON', path: '.omd/assembly-coverage.json', message: error instanceof Error ? error.message : String(error) }); }
+    }
+
+    if (!existsSync(observationDir)) findings.push(missing('.omd/observations/', 'record observable before/after render judgments'));
+    else {
+      const files = readdirSync(observationDir).filter((name) => name.endsWith('.json')).sort(); observations = files.length;
+      if (files.length === 0) findings.push(missing('.omd/observations/*.json', 'at least one Observe → Judge → Modify → Re-observe record is required'));
+      for (const file of files) try { findings.push(...validateObservation(parse(join(observationDir, file))).findings.map((f) => ({ ...f, path: `.omd/observations/${file}:${f.path}` }))); }
+      catch (error) { findings.push({ id: 'OBSERVATION-JSON', path: `.omd/observations/${file}`, message: error instanceof Error ? error.message : String(error) }); }
+    }
   }
 
   const deliberationDir = join(dir, 'deliberations'); let deliberations = 0;
@@ -99,6 +106,7 @@ export function checkDeliberationRun(cwd: string): DeliberationRunReport {
   }
 
   return {
+    phase,
     ok: findings.length === 0,
     ...(depth ? { depth } : {}),
     findings,

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -20,8 +20,8 @@ Give the user the working interface they asked for. Do not expose internal quota
 them to operate the harness. Run host-native agents in fresh contexts; do not create a
 workflow engine, queue, model router, or session runtime.
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and
-`protocol/design-deliberation.md` from `omd pack dir` first. The reference protocol owns the exact
+Read `protocol/human-design-loop.md` from `omd pack dir` first. Also read
+`protocol/reference-assembly.md` and `protocol/design-deliberation.md` there. The reference protocol owns the exact
 chat-first LEGO stage order and transfer boundaries; the deliberation protocol owns adaptive depth,
 decision provenance, acquisition zones, independent perspectives, visual observation, assembly
 coverage, and comparison; the human-design loop owns the remaining phase order, state, evidence
@@ -38,6 +38,11 @@ Code, use the installed agent whose metadata says `model: inherit` and its role 
 name Sol, Terra, Luna, Opus, Sonnet, Haiku, or any other concrete model in a child launch. A model
 recommendation, role label, or belief that another model is stronger does not override the user's
 selection. This applies to every named pipeline agent and every ad-hoc worker.
+On Codex, every named-role launch uses `fork_turns: "none"` together with `agent_type` and
+`reasoning_effort`. Never use `fork_turns: "all"` or a full-history fork for a named role: Codex
+then inherits the coordinator agent type instead of loading the OMD role, and the launch is invalid.
+A failed launch is retried once with the same role, effort, sanitized message, and
+`fork_turns: "none"`; it is never replaced by a generic `worker`.
 **Artifact ownership is not advisory.** Each durable artifact below is written by the agent that owns
 it, spawned for that purpose. The coordinator orchestrates, gathers, sanitizes, and gates — it never
 writes an owned artifact itself, however obvious the content seems or however much time a direct
@@ -63,6 +68,12 @@ If a stage looks skippable because the answer seems clear, that is the failure m
 exists to stop: a run that writes its own composition contract and its own production source has
 performed one agent's guess wearing the loop's name. Stages §4, §5, and §6 are not optional and have
 no inline path.
+**Gate failure is terminal for the run, not permission to improvise.** If an owner fails, returns no
+required artifact, reports a read/write boundary, times out, or leaves its deterministic check RED,
+stop the graph and report that blocker. Do not mark the stage “unavailable,” record it as a scoped
+deviation, advance to a later owner, or spawn a generic/ad-hoc worker to finish that owner's task.
+In particular, only `oh-my-design:hand` may write production source; neither the coordinator nor any
+`worker` may substitute for it.
 
 Run `omd doctor`. Stop on a failed prerequisite. For interactive visual research or user-directed
 region capture, initialize `browser-rs` first. Only an observed initialization/capability failure
@@ -476,6 +487,15 @@ requires a human decision. Never create an execution engine or unbounded retry l
 the winner and rejected tradeoffs only when a candidate actually passes.
 
 ## 6. Production build with reflective craft
+Before spawning the hand, wait for every retained upstream owner and review context to finish.
+Merge their exact returned decision JSON without rewriting it, then run `omd ref check`,
+`omd copy --check`, the required type-proof review/check, `omd composition --check`, and
+`omd deliberate check --phase prebuild`. The prebuild gate must prove the depth, acquisition plan,
+all required frame/copy/type/composition/structure owner decisions, and every L4 moderated
+deliberation while intentionally excluding hand-owned production observations and coverage.
+Any missing artifact or RED command blocks the hand; it cannot be documented away as a deviation.
+Do not launch the hand while a typesetter, composer, perspective, moderator, sketch, or selector is
+still running.
 
 **Spawn `oh-my-design:hand`. The coordinator never writes production source itself** — not the scaffold, not a
 component, not the stylesheet. The hand is where install-over-reimplement, the craft checkpoints, and
@@ -669,7 +689,8 @@ no fixed budget. Round 0 is almost never GREEN
 surface, with a recorded reason and a clean slop scan.
 Before source sealing, merge only the exact owner-authored decision entries returned by the spawned
 agents into `.omd/decision-graph.json`; the coordinator must not author or paraphrase them. Require
-`omd deliberate check` to pass. This joins depth, acquisition zones, decisions, any L4 moderator
+`omd deliberate check` to pass by running its explicit final gate:
+`omd deliberate check --phase final`. This joins depth, acquisition zones, decisions, any L4 moderator
 receipts, hand observations, and final assembly coverage. A missing zone, generic visual claim,
 owner mismatch, untested high-risk trade-off, or isolated artifact with no end-to-end chain is RED
 and blocks final evidence.

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -22,6 +22,14 @@ instructions: |
   `.omd/reference-selection-v2.json`, current `.omd/motion-resolutions/sha256-<digest>.json` projection,
   and decision-bound `.omd/reference-handoffs/composer.json` and `hand.json` receipts; they are the
   production fidelity evidence, not optional context.
+  Before touching production source on the normal graph, run
+  `omd deliberate check --phase prebuild` and `omd composition --check`. Both must pass, and
+  `.omd/type-proof.md`, `.omd/composition.md`, the selected structure, reference-selection/handoff
+  records, and every required L4 deliberation must exist. A missing or stale prerequisite is a
+  blocker: return it to the coordinator and stop without writing source. Never call it an
+  “unavailable prerequisite,” “scoped deviation,” or reason to continue. Never spawn or delegate to
+  another agent; you are the sole production-source owner, so a worker cannot implement on your
+  behalf.
   Build the selected reference's macro visual system — its composition, spacing rhythm, hierarchy,
   material treatment, and named landing rules — into the approved destination, while writing the
   product's own copy. Do not inspect source URLs or unselected/raw source material. Start only after

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -20,8 +20,8 @@ Give the user the working interface they asked for. Do not expose internal quota
 them to operate the harness. Run host-native agents in fresh contexts; do not create a
 workflow engine, queue, model router, or session runtime.
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and
-`protocol/design-deliberation.md` from `omd pack dir` first. The reference protocol owns the exact
+Read `protocol/human-design-loop.md` from `omd pack dir` first. Also read
+`protocol/reference-assembly.md` and `protocol/design-deliberation.md` there. The reference protocol owns the exact
 chat-first LEGO stage order and transfer boundaries; the deliberation protocol owns adaptive depth,
 decision provenance, acquisition zones, independent perspectives, visual observation, assembly
 coverage, and comparison; the human-design loop owns the remaining phase order, state, evidence
@@ -38,6 +38,11 @@ Code, use the installed agent whose metadata says `model: inherit` and its role 
 name Sol, Terra, Luna, Opus, Sonnet, Haiku, or any other concrete model in a child launch. A model
 recommendation, role label, or belief that another model is stronger does not override the user's
 selection. This applies to every named pipeline agent and every ad-hoc worker.
+On Codex, every named-role launch uses `fork_turns: "none"` together with `agent_type` and
+`reasoning_effort`. Never use `fork_turns: "all"` or a full-history fork for a named role: Codex
+then inherits the coordinator agent type instead of loading the OMD role, and the launch is invalid.
+A failed launch is retried once with the same role, effort, sanitized message, and
+`fork_turns: "none"`; it is never replaced by a generic `worker`.
 **Artifact ownership is not advisory.** Each durable artifact below is written by the agent that owns
 it, spawned for that purpose. The coordinator orchestrates, gathers, sanitizes, and gates — it never
 writes an owned artifact itself, however obvious the content seems or however much time a direct
@@ -63,6 +68,12 @@ If a stage looks skippable because the answer seems clear, that is the failure m
 exists to stop: a run that writes its own composition contract and its own production source has
 performed one agent's guess wearing the loop's name. Stages §4, §5, and §6 are not optional and have
 no inline path.
+**Gate failure is terminal for the run, not permission to improvise.** If an owner fails, returns no
+required artifact, reports a read/write boundary, times out, or leaves its deterministic check RED,
+stop the graph and report that blocker. Do not mark the stage “unavailable,” record it as a scoped
+deviation, advance to a later owner, or spawn a generic/ad-hoc worker to finish that owner's task.
+In particular, only `omd-hand` may write production source; neither the coordinator nor any
+`worker` may substitute for it.
 
 Run `omd doctor`. Stop on a failed prerequisite. For interactive visual research or user-directed
 region capture, initialize `browser-rs` first. Only an observed initialization/capability failure
@@ -476,6 +487,15 @@ requires a human decision. Never create an execution engine or unbounded retry l
 the winner and rejected tradeoffs only when a candidate actually passes.
 
 ## 6. Production build with reflective craft
+Before spawning the hand, wait for every retained upstream owner and review context to finish.
+Merge their exact returned decision JSON without rewriting it, then run `omd ref check`,
+`omd copy --check`, the required type-proof review/check, `omd composition --check`, and
+`omd deliberate check --phase prebuild`. The prebuild gate must prove the depth, acquisition plan,
+all required frame/copy/type/composition/structure owner decisions, and every L4 moderated
+deliberation while intentionally excluding hand-owned production observations and coverage.
+Any missing artifact or RED command blocks the hand; it cannot be documented away as a deviation.
+Do not launch the hand while a typesetter, composer, perspective, moderator, sketch, or selector is
+still running.
 
 **Spawn `omd-hand`. The coordinator never writes production source itself** — not the scaffold, not a
 component, not the stylesheet. The hand is where install-over-reimplement, the craft checkpoints, and
@@ -669,7 +689,8 @@ no fixed budget. Round 0 is almost never GREEN
 surface, with a recorded reason and a clean slop scan.
 Before source sealing, merge only the exact owner-authored decision entries returned by the spawned
 agents into `.omd/decision-graph.json`; the coordinator must not author or paraphrase them. Require
-`omd deliberate check` to pass. This joins depth, acquisition zones, decisions, any L4 moderator
+`omd deliberate check` to pass by running its explicit final gate:
+`omd deliberate check --phase final`. This joins depth, acquisition zones, decisions, any L4 moderator
 receipts, hand observations, and final assembly coverage. A missing zone, generic visual claim,
 owner mismatch, untested high-risk trade-off, or isolated artifact with no end-to-end chain is RED
 and blocks final evidence.

--- a/test/deliberation-runtime.test.ts
+++ b/test/deliberation-runtime.test.ts
@@ -119,3 +119,24 @@ test('run gate joins all L4 artifacts instead of letting each pass in isolation'
   writeFileSync(join(omd, 'observations', 'round-1.json'), JSON.stringify(observation));
   const report = checkDeliberationRun(cwd); assert.equal(report.ok, true); assert.equal(report.depth?.level, 'L4');
 });
+
+test('prebuild gate blocks production until upstream owner decisions and L4 moderation are complete', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'omd-prebuild-')); const omd = join(cwd, '.omd');
+  mkdirSync(join(omd, 'deliberations'), { recursive: true });
+  const depth: DepthInput = { schema: 'design-depth-input-v1', scope: 'single-surface', zoneCount: 4, newPrimaryCta: true, newInformationArchitecture: false, multiScreenState: false, costlyError: false, brandDirectionChange: true, showpieceMotion: false, webgl: false, referenceZones: 4 };
+  const upstreamGraph = { ...fullGraph, decisions: fullGraph.decisions.filter((decision) => decision.stage !== 'production') };
+  for (const [path, value] of [['depth.json', depth], ['acquisition-plan.json', acquisition], ['decision-graph.json', upstreamGraph]] as const) writeFileSync(join(omd, path), JSON.stringify(value));
+  writeFileSync(join(omd, 'deliberations', 'hero.json'), JSON.stringify(deliberation));
+
+  const prebuild = checkDeliberationRun(cwd, 'prebuild');
+  assert.equal(prebuild.ok, true);
+  assert.equal(prebuild.phase, 'prebuild');
+  assert.equal(prebuild.counts.observations, 0);
+  assert.equal(checkDeliberationRun(cwd, 'final').ok, false);
+
+  writeFileSync(join(omd, 'decision-graph.json'), JSON.stringify({
+    ...upstreamGraph,
+    decisions: upstreamGraph.decisions.filter((decision) => decision.stage !== 'structure'),
+  }));
+  assert.ok(checkDeliberationRun(cwd, 'prebuild').findings.some((finding) => finding.id === 'DECISION-STAGE-UNCOVERED'));
+});


### PR DESCRIPTION
## Summary
- force fresh named-role Codex spawns with inherited host model and no full-history fork
- add a deterministic prebuild deliberation gate before the hand can write source
- forbid coordinator/worker fallbacks when an owner or prerequisite fails

## Verification
- focused deliberation and prompt contracts: 80 passed
- `npx tsc --noEmit`
- `npm run build`
- full suite: 1702 passed; 7 pre-existing/environment failures (2 stale contract expectations fixed here, remaining failures are graphics count/runtime inventory plus unavailable playwright-core@1.62.0 package installs)