### PR TITLE
fix: let scout write its owned synthesis

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -3,13 +3,16 @@ name: scout
 description: "Builds a coverage-complete measured LEGO reference assembly without copying pixels."
 model: inherit
 effort: high
-disallowedTools: Write, Edit, apply_patch
 ---
 
 Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and the relevant theory/cookbook files under
 `omd pack dir`. Receive the concept, product, working directory, component inventory, explicit
 functions or product goal, surface classification, and any user URLs. Run all commands from that
 directory. Capture user URLs first with `--from-user`.
+You have write access only because `.omd/scout.md` is your owned durable synthesis; use the
+`omd ref:*` and `omd craft-capture:*` commands for the board, captures, and reference records.
+Outside those command-owned records, write or edit only `.omd/scout.md`. Never touch production
+source, another `.omd/` artifact, or ask another agent to write the scout artifact for you.
 
 Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
 `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -8,15 +8,19 @@ allow:
   - Bash(omd craft-capture:*)
   - Read
   - WebSearch
-deny:
   - Write
   - Edit
   - apply_patch
+deny: []
 instructions: |
   Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and the relevant theory/cookbook files under
   `omd pack dir`. Receive the concept, product, working directory, component inventory, explicit
   functions or product goal, surface classification, and any user URLs. Run all commands from that
   directory. Capture user URLs first with `--from-user`.
+  You have write access only because `.omd/scout.md` is your owned durable synthesis; use the
+  `omd ref:*` and `omd craft-capture:*` commands for the board, captures, and reference records.
+  Outside those command-owned records, write or edit only `.omd/scout.md`. Never touch production
+  source, another `.omd/` artifact, or ask another agent to write the scout artifact for you.
 
   Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
   `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -802,6 +802,13 @@ test('the scout and the reference protocol require component-scoped capture', ()
   assert.match(scout, /a nav studied three times while the hero, process, and proof zones have nothing/);
 });
 
+test('scout can write only its owned synthesis while reference records stay CLI-owned', () => {
+  const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(scout, /- Write - Edit - apply_patch deny: \[\]/);
+  assert.match(scout, /Outside those command-owned records, write or edit only `\.omd\/scout\.md`/);
+  assert.match(scout, /Never touch production source, another `\.omd\/` artifact/);
+});
+
 test('the selected host model is immutable while OMD adjusts only role effort', () => {
   const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
   assert.match(skill, /The user's session model is immutable for this run/);


### PR DESCRIPTION
## Summary
- grant the scout the write capability required for its owned `.omd/scout.md`
- keep reference-board/capture records behind `omd ref` and forbid production or foreign artifact writes
- verify generated Codex scout no longer receives the global no-write hard constraint

## Verification
- 95 focused prompt/adapter tests passed
- `npx tsc --noEmit`
- `npm run build`
- generated Codex scout ownership smoke passed