### PR TITLE
fix: let framer persist through owned CLI commands

### DIFF
--- a/agents/framer.md
+++ b/agents/framer.md
@@ -3,11 +3,14 @@ name: framer
 description: "Interrogates a design brief and records an evidence-backed framing before drawing."
 model: inherit
 effort: high
-disallowedTools: apply_patch
 ---
 
 Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
 `protocol/design-deliberation.md`, and `theory/ux.md` §Surface types under `omd pack dir`.
+Persist your two owned artifacts only through `omd frame:*` and `omd acquisition:*`; those CLI
+mutations are required work, not forbidden direct source editing. Never use a patch or file-write
+tool, touch production source or another `.omd/` artifact, or ask the coordinator to author the
+frame or acquisition plan.
 You own only the LEGO protocol's `brief blocks`
 stage: do not capture reference fragments, assemble candidates, select a candidate, or
 generate a provenance report. Do not draw or choose a visual style. Restate the given problem, test a

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -7,11 +7,14 @@ allow:
   - Bash(omd frame:*)
   - Bash(omd acquisition:*)
   - Bash(omd pack:*)
-deny:
-  - apply_patch
+deny: []
 instructions: |
   Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
   `protocol/design-deliberation.md`, and `theory/ux.md` §Surface types under `omd pack dir`.
+  Persist your two owned artifacts only through `omd frame:*` and `omd acquisition:*`; those CLI
+  mutations are required work, not forbidden direct source editing. Never use a patch or file-write
+  tool, touch production source or another `.omd/` artifact, or ask the coordinator to author the
+  frame or acquisition plan.
   You own only the LEGO protocol's `brief blocks`
   stage: do not capture reference fragments, assemble candidates, select a candidate, or
   generate a provenance report. Do not draw or choose a visual style. Restate the given problem, test a

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -809,6 +809,13 @@ test('scout can write only its owned synthesis while reference records stay CLI-
   assert.match(scout, /Never touch production source, another `\.omd\/` artifact/);
 });
 
+test('framer CLI writes its owned frame and acquisition plan without direct file tools', () => {
+  const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(framer, /Bash\(omd frame:\*\).*Bash\(omd acquisition:\*\).*deny: \[\]/);
+  assert.match(framer, /those CLI mutations are required work, not forbidden direct source editing/);
+  assert.match(framer, /Never use a patch or file-write tool/);
+});
+
 test('the selected host model is immutable while OMD adjusts only role effort', () => {
   const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
   assert.match(skill, /The user's session model is immutable for this run/);


### PR DESCRIPTION
## Summary
- remove the contradictory Codex no-write hard constraint from the framer
- keep frame and acquisition persistence restricted to their owned CLI commands
- forbid direct file tools and production/foreign artifact edits

## Verification
- 96 focused prompt/adapter tests passed
- `npx tsc --noEmit`
- `npm run build`
- generated Codex framer has no global no-write constraint