### PR TITLE
fix: batch zone-bound reference captures

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -13,6 +13,16 @@ You have write access only because `.omd/scout.md` is your owned durable synthes
 `omd ref:*` and `omd craft-capture:*` commands for the board, captures, and reference records.
 Outside those command-owned records, write or edit only `.omd/scout.md`. Never touch production
 source, another `.omd/` artifact, or ask another agent to write the scout artifact for you.
+Keep acquisition bounded and use the supported CLI path. Never start `browser-rs` yourself,
+handcraft or `curl` its MCP protocol, inspect its implementation to debug transport, or launch
+extra ports/providers. Run the installed browser doctor once; then issue the independent web
+searches concurrently, write one compact batch manifest, and run `omd ref add-batch` once. Every
+entry includes a tight component selector and the framer-owned `slot` it covers. The batch command
+persists that zone binding. If an entry fails, replace that entry once; after `omd ref granularity`
+and `omd ref check`, run at most one missing-zone repair batch. Once every required zone and
+applicable evidence category is covered, stop gathering and synthesize the board—do not continue
+browsing for optional inspiration. A provider failure is reported immediately to the coordinator
+under the fallback rule instead of becoming an infrastructure investigation.
 
 Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
 `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed
@@ -34,8 +44,9 @@ code fidelity; only the internal board evidence record stays scout-side.
 Research the subject before the references. When the brief names a real, existing subject — a
 product, project, company, repository, or brand ("the Hermes agent", a GitHub link) — your first
 pass is to establish what it actually is: web-search the name, open any linked repository and read
-its README, and inspect the wordmark, logo, or brand the source already ships. From that, fix the
-subject's own identity anchor: its real palette (the Hermes repo wordmark is gold/yellow, not
+its first-party source material unless the current brief explicitly excludes that source, and inspect
+the wordmark, logo, or brand the source already ships. The current user's evidence constraint wins.
+From that, fix the subject's own identity anchor: its real palette (the Hermes repo wordmark is gold/yellow, not
 terminal green), its personality and motif (retro / pixel / 8-bit here), what it does, and who uses
 it. This anchor is not one reference among many and it is never outvoted by the category: the colour
 and motif come from the subject, and every gathering lane below exists to learn how to execute that

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -781,13 +781,13 @@ function cmdChoose(opts: Opts): never {
 
 /**
  * `omd ref add-batch <manifest.json>` — capture many references concurrently over ONE browser.
- * The manifest is a JSON array of `{ source, as, selector?, blueprint?, shot?, fromUser?, viewport? }`.
+ * The manifest is a JSON array of `{ source, as, selector?, slot?, blueprint?, shot?, fromUser?, viewport? }`.
  * Same per-reference result as `omd ref add`, minus the energy pass, at a fraction of the wall time.
  */
 async function cmdRefAddBatch(opts: Opts): Promise<never> {
   const manifestPath = opts._[0];
   if (!manifestPath) {
-    console.error('usage: omd ref add-batch <manifest.json>  (JSON array of { source, as, selector?, blueprint?, shot?, fromUser?, viewport? })');
+    console.error('usage: omd ref add-batch <manifest.json>  (JSON array of { source, as, selector?, slot?, blueprint?, shot?, fromUser?, viewport? })');
     process.exit(1);
   }
   const { addRefsBatch } = await import('../core/ref/batch.ts');
@@ -2801,7 +2801,7 @@ function usage(): never {
     + '                                                render, extract invariants, save\n'
     + '  ref add ... --selector ".nav" --blueprint     also capture a component blueprint\n'
     + '  ref add ... --selector ".nav" --blueprint --shot  also save the component screenshot beside its blueprint\n'
-    + '  ref add-batch <manifest.json>               capture many references in parallel over one browser\n'
+    + '  ref add-batch <manifest.json>               capture zone-bound references in parallel over one browser\n'
     + '  ref list                                    one line per saved reference\n'
     + '  ref distance <page>                         compare a page to every saved reference\n'
     + '  ref principles <source> --as C --add "..."   record why a reference works\n'

--- a/core/ref/batch.ts
+++ b/core/ref/batch.ts
@@ -16,6 +16,7 @@ export interface RefSpec {
   source: string;
   as: string;
   selector?: string;
+  slot?: string;
   blueprint?: boolean;
   shot?: boolean;
   fromUser?: boolean;
@@ -77,6 +78,7 @@ export async function addRefsBatch(
             kind: spec.selector ? 'component' : 'page',
             capturedAt: new Date().toISOString(),
             ...(spec.selector ? { selector: spec.selector } : {}),
+            ...(spec.slot ? { slot: spec.slot } : {}),
             invariants,
             principles: [],
             slopCount,

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -21,6 +21,16 @@ instructions: |
   `omd ref:*` and `omd craft-capture:*` commands for the board, captures, and reference records.
   Outside those command-owned records, write or edit only `.omd/scout.md`. Never touch production
   source, another `.omd/` artifact, or ask another agent to write the scout artifact for you.
+  Keep acquisition bounded and use the supported CLI path. Never start `browser-rs` yourself,
+  handcraft or `curl` its MCP protocol, inspect its implementation to debug transport, or launch
+  extra ports/providers. Run the installed browser doctor once; then issue the independent web
+  searches concurrently, write one compact batch manifest, and run `omd ref add-batch` once. Every
+  entry includes a tight component selector and the framer-owned `slot` it covers. The batch command
+  persists that zone binding. If an entry fails, replace that entry once; after `omd ref granularity`
+  and `omd ref check`, run at most one missing-zone repair batch. Once every required zone and
+  applicable evidence category is covered, stop gathering and synthesize the board—do not continue
+  browsing for optional inspiration. A provider failure is reported immediately to the coordinator
+  under the fallback rule instead of becoming an infrastructure investigation.
 
   Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
   `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed
@@ -42,8 +52,9 @@ instructions: |
   Research the subject before the references. When the brief names a real, existing subject — a
   product, project, company, repository, or brand ("the Hermes agent", a GitHub link) — your first
   pass is to establish what it actually is: web-search the name, open any linked repository and read
-  its README, and inspect the wordmark, logo, or brand the source already ships. From that, fix the
-  subject's own identity anchor: its real palette (the Hermes repo wordmark is gold/yellow, not
+  its first-party source material unless the current brief explicitly excludes that source, and inspect
+  the wordmark, logo, or brand the source already ships. The current user's evidence constraint wins.
+  From that, fix the subject's own identity anchor: its real palette (the Hermes repo wordmark is gold/yellow, not
   terminal green), its personality and motif (retro / pixel / 8-bit here), what it does, and who uses
   it. This anchor is not one reference among many and it is never outvoted by the category: the colour
   and motif come from the subject, and every gathering lane below exists to learn how to execute that

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -809,6 +809,17 @@ test('scout can write only its owned synthesis while reference records stay CLI-
   assert.match(scout, /Never touch production source, another `\.omd\/` artifact/);
 });
 
+test('scout batches zone-bound captures without debugging browser transport', () => {
+  const scout = read('src/agents/scout.agent.yaml').replace(/\s+/g, ' ');
+  assert.match(scout, /run `omd ref add-batch` once/);
+  assert.match(scout, /Every entry includes a tight component selector and the framer-owned `slot`/);
+  assert.match(scout, /Never start `browser-rs` yourself, handcraft or `curl` its MCP protocol/);
+  assert.match(scout, /run at most one missing-zone repair batch/);
+  const batch = read('core/ref/batch.ts');
+  assert.match(batch, /slot\?: string/);
+  assert.match(batch, /spec\.slot \? \{ slot: spec\.slot \}/);
+});
+
 test('framer CLI writes its owned frame and acquisition plan without direct file tools', () => {
   const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
   assert.match(framer, /Bash\(omd frame:\*\).*Bash\(omd acquisition:\*\).*deny: \[\]/);


### PR DESCRIPTION
## Summary
- preserve framer acquisition `slot` bindings through `omd ref add-batch`
- bound scout acquisition to the supported CLI instead of manual browser-rs transport debugging
- honor explicit user exclusions for subject source material

## Verification
- 92 focused reference/prompt tests passed
- `npx tsc --noEmit`
- `npm run build`
- local two-zone batch capture persisted `hero` and `proof` slots