### PR TITLE
fix: load captured reference zone bindings

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -18,8 +18,10 @@ handcraft or `curl` its MCP protocol, inspect its implementation to debug transp
 extra ports/providers. Run the installed browser doctor once; then issue the independent web
 searches concurrently, write one compact batch manifest, and run `omd ref add-batch` once. Every
 entry includes a tight component selector and the framer-owned `slot` it covers. The batch command
-persists that zone binding. If an entry fails, replace that entry once; after `omd ref granularity`
-and `omd ref check`, run at most one missing-zone repair batch. Once every required zone and
+persists that zone binding. If an entry fails, replace that entry once. Then run
+`omd ref granularity` and `omd ref check`; when a required zone remains uncovered, run exactly one
+missing-zone repair batch before reporting a blocker. Prefer a different tight selector on an
+already reachable, relevant source when the gap came from a source or selector failure. Once every required zone and
 applicable evidence category is covered, stop gathering and synthesize the board—do not continue
 browsing for optional inspiration. A provider failure is reported immediately to the coordinator
 under the fallback rule instead of becoming an infrastructure investigation.

--- a/core/ref/store.ts
+++ b/core/ref/store.ts
@@ -79,6 +79,7 @@ export function loadRefs(cwd: string): Reference[] {
           kind: parsed.kind ?? 'page',
           capturedAt: parsed.capturedAt ?? '',
           ...(parsed.selector !== undefined ? { selector: parsed.selector } : {}),
+          ...(parsed.slot !== undefined ? { slot: parsed.slot } : {}),
           invariants: withInvariantDefaults(parsed.invariants),
           principles: parsed.principles ?? [],
           ...(parsed.slopCount !== undefined ? { slopCount: parsed.slopCount } : {}),

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -26,8 +26,10 @@ instructions: |
   extra ports/providers. Run the installed browser doctor once; then issue the independent web
   searches concurrently, write one compact batch manifest, and run `omd ref add-batch` once. Every
   entry includes a tight component selector and the framer-owned `slot` it covers. The batch command
-  persists that zone binding. If an entry fails, replace that entry once; after `omd ref granularity`
-  and `omd ref check`, run at most one missing-zone repair batch. Once every required zone and
+  persists that zone binding. If an entry fails, replace that entry once. Then run
+  `omd ref granularity` and `omd ref check`; when a required zone remains uncovered, run exactly one
+  missing-zone repair batch before reporting a blocker. Prefer a different tight selector on an
+  already reachable, relevant source when the gap came from a source or selector failure. Once every required zone and
   applicable evidence category is covered, stop gathering and synthesize the board—do not continue
   browsing for optional inspiration. A provider failure is reported immediately to the coordinator
   under the fallback rule instead of becoming an infrastructure investigation.

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -814,7 +814,7 @@ test('scout batches zone-bound captures without debugging browser transport', ()
   assert.match(scout, /run `omd ref add-batch` once/);
   assert.match(scout, /Every entry includes a tight component selector and the framer-owned `slot`/);
   assert.match(scout, /Never start `browser-rs` yourself, handcraft or `curl` its MCP protocol/);
-  assert.match(scout, /run at most one missing-zone repair batch/);
+  assert.match(scout, /run exactly one missing-zone repair batch before reporting a blocker/);
   const batch = read('core/ref/batch.ts');
   assert.match(batch, /slot\?: string/);
   assert.match(batch, /spec\.slot \? \{ slot: spec\.slot \}/);

--- a/test/reference.test.ts
+++ b/test/reference.test.ts
@@ -204,7 +204,7 @@ test('distances ranks every reference and names what drove the score', () => {
 // ── store ──
 
 const ref: Reference = {
-  source: 'https://linear.app', component: 'search-bar', kind: 'component', capturedAt: new Date().toISOString(),
+  source: 'https://linear.app', component: 'search-bar', kind: 'component', capturedAt: new Date().toISOString(), slot: 'hero',
   invariants: base, principles: ['Radii split into three rungs, so an input and a card are different materials.'],
 };
 


### PR DESCRIPTION
## Summary
- preserve reference `slot` when loading saved captures so granularity sees batch zone coverage
- require one bounded repair batch for a failed zone before stopping
- prefer an already reachable relevant source when a source/selector failed

## Verification
- 85 focused persistence/prompt tests passed
- broader 51 reference/granularity tests passed
- `npx tsc --noEmit`
- `npm run build`
- replaying the real blocked run now reports only the genuinely missing `fit-and-limits` zone instead of all seven zones