### PR TITLE
fix: wait for owner final state before gating

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -18,13 +18,18 @@ handcraft or `curl` its MCP protocol, inspect its implementation to debug transp
 extra ports/providers. Run the installed browser doctor once; then issue the independent web
 searches concurrently, write one compact batch manifest, and run `omd ref add-batch` once. Every
 entry includes a tight component selector and the framer-owned `slot` it covers. The batch command
-persists that zone binding. If an entry fails, replace that entry once. Then run
-`omd ref granularity` and `omd ref check`; when a required zone remains uncovered, run exactly one
-missing-zone repair batch before reporting a blocker. Prefer a different tight selector on an
-already reachable, relevant source when the gap came from a source or selector failure. Once every required zone and
+persists that zone binding. After each batch invocation, wait until its tool process reports
+completion, then poll the saved reference inventory until the artifact set is unchanged across
+two consecutive reads before running `omd ref granularity` and `omd ref check`. If a required zone
+remains uncovered only then, run exactly one missing-zone repair batch, again waiting for process
+completion and two stable inventory reads. Prefer a different tight selector on an already
+reachable, relevant source when the gap came from a source or selector failure. Never call
+`send_message`: it is an intermediate signal that can make the coordinator stop while late
+captures are still joining. Return exactly one final handback after the board and candidates are
+complete, or after the final stable checks prove the blocker. Once every required zone and
 applicable evidence category is covered, stop gathering and synthesize the board—do not continue
-browsing for optional inspiration. A provider failure is reported immediately to the coordinator
-under the fallback rule instead of becoming an infrastructure investigation.
+browsing for optional inspiration. A provider failure is recorded for the final handback under
+the fallback rule instead of becoming an infrastructure investigation.
 
 Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
 `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -43,6 +43,12 @@ On Codex, every named-role launch uses `fork_turns: "none"` together with `agent
 then inherits the coordinator agent type instead of loading the OMD role, and the launch is invalid.
 A failed launch is retried once with the same role, effort, sanitized message, and
 `fork_turns: "none"`; it is never replaced by a generic `worker`.
+A child `send_message` is progress only, never its handback and never proof that the role stopped.
+Wait until the child agent state is `completed`, then consume its final response and run the
+artifact gate. Do not cancel a still-running owner or stop the graph because an intermediate
+message describes a temporary gap; capture and browser writes may still be joining. A timeout
+requires both an unfinished child and no ongoing tool/process activity, not merely several wait
+polls with no chat message.
 **Artifact ownership is not advisory.** Each durable artifact below is written by the agent that owns
 it, spawned for that purpose. The coordinator orchestrates, gathers, sanitizes, and gates — it never
 writes an owned artifact itself, however obvious the content seems or however much time a direct

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -26,13 +26,18 @@ instructions: |
   extra ports/providers. Run the installed browser doctor once; then issue the independent web
   searches concurrently, write one compact batch manifest, and run `omd ref add-batch` once. Every
   entry includes a tight component selector and the framer-owned `slot` it covers. The batch command
-  persists that zone binding. If an entry fails, replace that entry once. Then run
-  `omd ref granularity` and `omd ref check`; when a required zone remains uncovered, run exactly one
-  missing-zone repair batch before reporting a blocker. Prefer a different tight selector on an
-  already reachable, relevant source when the gap came from a source or selector failure. Once every required zone and
+  persists that zone binding. After each batch invocation, wait until its tool process reports
+  completion, then poll the saved reference inventory until the artifact set is unchanged across
+  two consecutive reads before running `omd ref granularity` and `omd ref check`. If a required zone
+  remains uncovered only then, run exactly one missing-zone repair batch, again waiting for process
+  completion and two stable inventory reads. Prefer a different tight selector on an already
+  reachable, relevant source when the gap came from a source or selector failure. Never call
+  `send_message`: it is an intermediate signal that can make the coordinator stop while late
+  captures are still joining. Return exactly one final handback after the board and candidates are
+  complete, or after the final stable checks prove the blocker. Once every required zone and
   applicable evidence category is covered, stop gathering and synthesize the board—do not continue
-  browsing for optional inspiration. A provider failure is reported immediately to the coordinator
-  under the fallback rule instead of becoming an infrastructure investigation.
+  browsing for optional inspiration. A provider failure is recorded for the final handback under
+  the fallback rule instead of becoming an infrastructure investigation.
 
   Read `.omd/domain-brief.json` first (the domain-analysis step's output) and run its
   `referenceQueries` as your acquisition list: `referenceQueries.component` seeds role ① (detailed

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -43,6 +43,12 @@ On Codex, every named-role launch uses `fork_turns: "none"` together with `agent
 then inherits the coordinator agent type instead of loading the OMD role, and the launch is invalid.
 A failed launch is retried once with the same role, effort, sanitized message, and
 `fork_turns: "none"`; it is never replaced by a generic `worker`.
+A child `send_message` is progress only, never its handback and never proof that the role stopped.
+Wait until the child agent state is `completed`, then consume its final response and run the
+artifact gate. Do not cancel a still-running owner or stop the graph because an intermediate
+message describes a temporary gap; capture and browser writes may still be joining. A timeout
+requires both an unfinished child and no ongoing tool/process activity, not merely several wait
+polls with no chat message.
 **Artifact ownership is not advisory.** Each durable artifact below is written by the agent that owns
 it, spawned for that purpose. The coordinator orchestrates, gathers, sanitizes, and gates — it never
 writes an owned artifact itself, however obvious the content seems or however much time a direct

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -814,7 +814,8 @@ test('scout batches zone-bound captures without debugging browser transport', ()
   assert.match(scout, /run `omd ref add-batch` once/);
   assert.match(scout, /Every entry includes a tight component selector and the framer-owned `slot`/);
   assert.match(scout, /Never start `browser-rs` yourself, handcraft or `curl` its MCP protocol/);
-  assert.match(scout, /run exactly one missing-zone repair batch before reporting a blocker/);
+  assert.match(scout, /run exactly one missing-zone repair batch, again waiting for process completion and two stable inventory reads/);
+  assert.match(scout, /Never call `send_message`/);
   const batch = read('core/ref/batch.ts');
   assert.match(batch, /slot\?: string/);
   assert.match(batch, /spec\.slot \? \{ slot: spec\.slot \}/);
@@ -833,6 +834,8 @@ test('the selected host model is immutable while OMD adjusts only role effort', 
   assert.match(skill, /On Codex, omit `model` from every `spawn_agent` call/);
   assert.match(skill, /on Claude Code, use the installed agent whose metadata says `model: inherit`/);
   assert.match(skill, /This applies to every named pipeline agent and every ad-hoc worker/);
+  assert.match(skill, /A child `send_message` is progress only, never its handback/);
+  assert.match(skill, /Wait until the child agent state is `completed`/);
 
   const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
   assert.match(loop, /Model ownership belongs to the user/);


### PR DESCRIPTION
## Summary
- treat child messages as progress and wait for the named owner final state
- stabilize reference inventory after each asynchronous batch before checking coverage
- prevent interim scout blocker messages from racing late capture writes

## Verification
- 97 focused prompt/adapter tests passed
- `npx tsc --noEmit`
- `npm run build`
- diagnosis of the latest Terra run confirmed granularity turned green after late captures joined, while the coordinator had already stopped on an intermediate scout message