### PR TITLE
fix: support moderator-bound local art direction

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -2029,25 +2029,54 @@ async function cmdIntent(mode: string | undefined, opts: Opts): Promise<never> {
 }
 
 async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<never> {
-  if (mode !== 'check' || !opts.input || opts._.length > 0) {
-    throw new Error('usage: omd art-direction check --input <decision-check.json> [--json]');
+  const localMode = mode === 'local-check';
+  if ((mode !== 'check' && !localMode) || !opts.input || opts._.length > 0) {
+    throw new Error('usage: omd art-direction check|local-check --input <decision-check.json> [--json]');
   }
-  const payload = inputJson(opts.input, 'omd art-direction check');
-  if (!isRecord(payload)) throw new Error('omd art-direction check input must contain host-authorized evaluator assessment and result payloads');
-  const allowed = new Set(['alternatives', 'references', 'eligibility', 'evaluatorAssessment', 'evaluatorResult', 'beats', 'invocation', 'route', 'implementationLane', 'fallbackPath', 'performanceAccessibilityBudget']);
-  if (Object.keys(payload).some((key) => !allowed.has(key))) throw new Error('ART_DIRECTION_CALLER_DECISION_FORBIDDEN: evaluator choices, scores, and motion sources must be inside the host-authorized evaluator bytes');
-  const { alternatives, references, eligibility, evaluatorAssessment, evaluatorResult, beats, invocation, route, implementationLane, fallbackPath, performanceAccessibilityBudget } = payload;
-  const run = validateProjectRunInvocation(invocation);
+  const command = localMode ? 'omd art-direction local-check' : 'omd art-direction check';
+  const payload = inputJson(opts.input, command);
+  if (!isRecord(payload)) throw new Error(`${command} input must contain evaluator assessment and result payloads`);
+  const allowed = new Set(['alternatives', 'references', 'eligibility', 'evaluatorAssessment', 'evaluatorResult', 'beats', 'invocation', 'deliberation', 'route', 'implementationLane', 'fallbackPath', 'performanceAccessibilityBudget']);
+  if (Object.keys(payload).some((key) => !allowed.has(key))) throw new Error('ART_DIRECTION_CALLER_DECISION_FORBIDDEN: evaluator choices, scores, and motion sources must remain inside the evaluator bytes');
+  const { alternatives, references, eligibility, evaluatorAssessment, evaluatorResult, beats, invocation, deliberation, route, implementationLane, fallbackPath, performanceAccessibilityBudget } = payload;
+  if (localMode && invocation !== undefined) throw new Error('ART_DIRECTION_LOCAL_INVOCATION_FORBIDDEN: local-check derives write authority from the running CLI');
+  const run = localMode
+    ? createLocalCliInvocation({ cliPath: fileURLToPath(import.meta.url), argv: process.argv.slice(2), brief: command, projectRoot: process.cwd() })
+    : validateProjectRunInvocation(invocation);
   if (evaluatorAssessment === undefined || evaluatorResult === undefined) throw new Error('ART_DIRECTION_EVALUATOR_AUTHORIZATION_REQUIRED: evaluator assessment and result payloads are required');
   const assessmentBytes = Buffer.from(canonicalJson(evaluatorAssessment));
   const resultBytes = Buffer.from(canonicalJson(evaluatorResult));
-  requireEvaluatorAssessmentAuthorization(run, process.cwd(), assessmentBytes);
-  requireEvaluatorResultAuthorization(run, process.cwd(), resultBytes);
-  const closedResult = parseClosedEvaluatorResult(evaluatorResult, sha256(canonicalJson(alternatives)));
+  if (!localMode) {
+    requireEvaluatorAssessmentAuthorization(run, process.cwd(), assessmentBytes);
+    requireEvaluatorResultAuthorization(run, process.cwd(), resultBytes);
+  }
+  const alternativesSha256 = sha256(canonicalJson(alternatives));
+  const closedResult = parseClosedEvaluatorResult(evaluatorResult, alternativesSha256);
+  if (localMode && closedResult.approvedMotionRecipe !== undefined) {
+    throw new Error('ART_DIRECTION_LOCAL_RECIPE_FORBIDDEN: local-check cannot authorize a motion recipe');
+  }
   if (!isRecord(evaluatorAssessment) || !Array.isArray(evaluatorAssessment.assessments)) evaluatorResultError('assessment must contain assessments');
   const assessments = evaluatorAssessment.assessments as { register?: unknown; score?: unknown }[];
   const winner = [...assessments].sort((left, right) => Number(right.score) - Number(left.score) || String(left.register).localeCompare(String(right.register)))[0];
-  if (winner?.register !== closedResult.winner) evaluatorResultError('winner must match the host-authorized assessment ranking');
+  if (winner?.register !== closedResult.winner) evaluatorResultError('winner must match the evaluator assessment ranking');
+  if (localMode) {
+    if (typeof deliberation !== 'string' || !deliberation.startsWith('.omd/deliberations/') || !deliberation.endsWith('.json')) {
+      throw new Error('ART_DIRECTION_LOCAL_DELIBERATION_REQUIRED: local-check requires a moderator-owned .omd/deliberations/*.json receipt');
+    }
+    const deliberationPath = resolve(process.cwd(), deliberation);
+    const deliberationRoot = resolve(process.cwd(), '.omd', 'deliberations');
+    if (!deliberationPath.startsWith(`${deliberationRoot}/`) || !existsSync(deliberationPath)) {
+      throw new Error('ART_DIRECTION_LOCAL_DELIBERATION_REQUIRED: local deliberation receipt is missing or outside .omd/deliberations');
+    }
+    const { validateDeliberation } = await import('../core/deliberation/contracts.ts');
+    const debateResult = validateDeliberation(inputJson(deliberationPath, 'local art-direction deliberation'));
+    if (debateResult.findings.length > 0 || debateResult.value === undefined) throw new Error(`ART_DIRECTION_LOCAL_DELIBERATION_INVALID: ${debateResult.findings.map((finding) => finding.id).join(', ')}`);
+    const debate = debateResult.value;
+    const sharedDigest = debate.perspectives.ux.inputSha256;
+    if (sharedDigest !== alternativesSha256 || debate.resolution.selected !== closedResult.winner) {
+      throw new Error('ART_DIRECTION_LOCAL_DELIBERATION_STALE: moderator receipt must bind the exact alternatives and selected register');
+    }
+  }
   const evaluatorEvidence = {
     invocationSha256: sha256(assessmentBytes),
     payloadSha256: sha256(assessmentBytes),
@@ -2071,7 +2100,7 @@ async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<ne
     ledger = validateIntentLedger(inputJson(join(process.cwd(), '.omd', pointer.record), 'intent immutable record'));
     if (intentLedgerSha256(ledger) !== pointer.sha256) throw new Error('ART_DIRECTION_INTENT_STALE: current intent pointer does not match immutable ledger');
     intentSha256 = pointer.sha256;
-    requireCurrentIntentLedgerAuthorization(run, process.cwd(), readFileSync(join(process.cwd(), '.omd', pointer.record)));
+    if (!localMode) requireCurrentIntentLedgerAuthorization(run, process.cwd(), readFileSync(join(process.cwd(), '.omd', pointer.record)));
   } else {
     const record = `intent-runs/sha256-${intentSha256}.json`;
     writeImmutableProjectFile({ projectRoot: process.cwd(), relativePath: `.omd/${record}`, content: JSON.stringify(ledger, null, 2), invocation: run });
@@ -2143,7 +2172,7 @@ async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<ne
   if (exceedsCanonicalBeatBudget(checked.selectedRegister, beats, currentBeatExceptionReceipt)) {
     throw new Error(`ART_DIRECTION_BEAT_BUDGET_EXCEEDED: ${checked.selectedRegister} permits at most ${beatBudgetForRegister(checked.selectedRegister)} Beats without an exact current-user host-authorized Beat-exception receipt`);
   }
-  const motion = persistMotionResolutionProjection(process.cwd(), motionInput, { assessmentBytes, resultBytes, ...(recipeBytes === undefined ? {} : { approvedRecipeBytes: recipeBytes }) }, run);
+  const motion = persistMotionResolutionProjection(process.cwd(), motionInput, { assessmentBytes, resultBytes, ...(recipeBytes === undefined ? {} : { approvedRecipeBytes: recipeBytes }) }, run, localMode ? 'local-moderator' : 'host');
   const settledSelection = persistSettledReferenceSelection(process.cwd(), selection, { ...motion.projection, selection }, run);
   const settledMotionResolutionSha256 = motionResolutionProjectionSha256(motion.projection);
   if (checked.motionResolutionProjectionSha256 !== settledMotionResolutionSha256 || checked.settledSelectionSha256 !== referenceSelectionV2Sha256(settledSelection)) {
@@ -2839,7 +2868,7 @@ function usage(): never {
     + '  evidence tasks --input .omd/.cache/task-evidence-manifest.json  publish strict production task evidence\n'
     + '  evidence tasks-check [--json]               revalidate strict production task evidence\n'
     + '\n'
-    + '  art-direction check --input decision-check.json [--json]  persist the canonical selected direction before composition\n'
+    + '  art-direction check|local-check --input decision-check.json [--json]  persist a host-authorized or moderator-bound local direction\n'
     + '  intent append --input trusted-intent.json [--json]  append trusted intent and update its guarded current pointer\n'
     + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
     + '  craft-fidelity check --input pair.json [--json]  verify a generated part reproduced the reference craft\n'

--- a/core/protocol/design-deliberation.md
+++ b/core/protocol/design-deliberation.md
@@ -78,6 +78,13 @@ majority: it resolves objections against evidence and constraints, returns one s
 conditions, and authors the `design-deliberation-v1` record. All three perspective `inputSha256`
 values must match. The coordinator only preserves the moderator's closed JSON under
 `.omd/deliberations/<id>.json`.
+For the pre-composition art-direction decision, a host-issued invocation remains the publication
+lane. In an ordinary Codex or Claude session without that launcher receipt, the same three
+perspectives plus moderator bind the exact three register alternatives and selected register.
+`omd art-direction local-check` accepts only that moderator-owned receipt, derives write authority
+inside the running CLI, and persists the immutable direction and downstream handoffs. It grants no
+v2 publication authority. Missing host publication authority therefore limits the final evidence
+marker; it does not make the design/build loop unusable or authorize a handwritten direction.
 
 ## Visual observation
 

--- a/core/ref/reference-selection.ts
+++ b/core/ref/reference-selection.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import { canonicalJson, readReferenceBoardArtifacts, sha256 } from './board-artifacts.ts';
 import type { ReferenceAxis, ReferenceRights, ReferenceSignal } from './board-projection.ts';
 import { requireApprovedMotionRecipeAuthorization, requireEvaluatorAssessmentAuthorization, requireEvaluatorResultAuthorization, type ProjectRunInvocation } from '../runtime/invocation.ts';
+import { isHostDerivedLocalCliInvocation } from '../runtime/activation.ts';
 import { ProjectWriteError, replaceProjectFileAtomically, writeImmutableProjectFile } from '../runtime/project-write.ts';
 
 export const REFERENCE_SELECTION_SCHEMA_VERSION = 'reference-selection-v1';
@@ -279,16 +280,21 @@ export function persistMotionResolutionProjection(
   input: ResolveMotionProjectionInput,
   evidence: MotionResolutionEvidenceBytes,
   invocation: ProjectRunInvocation,
+  authorization: 'host' | 'local-moderator' = 'host',
 ): { readonly path: string; readonly projection: MotionResolutionProjection } {
   const projection = resolveMotionProjection(input);
   if (sha256(evidence.assessmentBytes) !== projection.evaluatorPayloadSha256 || sha256(evidence.resultBytes) !== projection.evaluatorResultSha256
     || (projection.approvedRecipe !== undefined && (evidence.approvedRecipeBytes === undefined || sha256(evidence.approvedRecipeBytes) !== projection.approvedRecipe.recipeSha256))) return fail('motion resolution evidence bytes do not match evaluator provenance');
-  try {
-    requireEvaluatorAssessmentAuthorization(invocation, root, evidence.assessmentBytes);
-    requireEvaluatorResultAuthorization(invocation, root, evidence.resultBytes);
-    if (projection.approvedRecipe !== undefined) requireApprovedMotionRecipeAuthorization(invocation, root, evidence.approvedRecipeBytes!);
-  } catch (error) {
-    return fail(error instanceof Error ? error.message : 'missing evaluator host authorization');
+  if (authorization === 'host') {
+    try {
+      requireEvaluatorAssessmentAuthorization(invocation, root, evidence.assessmentBytes);
+      requireEvaluatorResultAuthorization(invocation, root, evidence.resultBytes);
+      if (projection.approvedRecipe !== undefined) requireApprovedMotionRecipeAuthorization(invocation, root, evidence.approvedRecipeBytes!);
+    } catch (error) {
+      return fail(error instanceof Error ? error.message : 'missing evaluator host authorization');
+    }
+  } else if (!isHostDerivedLocalCliInvocation(invocation) || projection.approvedRecipe !== undefined) {
+    return fail('local moderator persistence requires CLI-derived local authority and forbids unapproved motion recipes');
   }
   const digest = motionResolutionProjectionSha256(projection);
   const relativePath = `.omd/motion-resolutions/sha256-${digest}.json`;

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -152,6 +152,19 @@ prior explicit taste, which beats agent choices. Record conflicts.
   carries the exact hash of a host-authorized typed exception event. The selected register and
   `motionDecision: none|one` control the macro visual system; quiet or restraint never
   authorizes a generic template or skipped visual work.
+A normal Codex or Claude session may not carry a host-issued invocation/FD receipt. That is not a
+reason to stop the design. When the launcher supplied the activation, use the host-authorized
+`omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
+lane: hash the exact three direction alternatives, spawn fresh `oh-my-design:eye` UX, art-direction, and
+production perspectives concurrently with those identical bytes, then a fourth fresh `oh-my-design:eye`
+moderator. Preserve its exact `design-deliberation-v1` JSON at
+`.omd/deliberations/art-direction.json`; its three `inputSha256` values must equal the alternatives
+hash and its resolution must equal the evaluator result. Run
+`omd art-direction local-check --input <decision-check.json>` with that `deliberation` path and no
+`invocation` field. This derives only local project-write authority and cannot publish v2 evidence;
+it still creates the immutable art-direction, motion settlement, composer handoff, and hand handoff
+required to build. Never fabricate a host activation or downgrade to an unsigned handwritten
+`.omd/art-direction.json`.
 
 ## 0.5 Domain analysis
 
@@ -706,20 +719,24 @@ and blocks final evidence.
   fixed-viewport screenshot/render, and applicable motion filmstrip from sealed source; then run
   `omd source --check <root>` again. For `product` or `mixed`, publish the task index with `omd
   evidence tasks --input .omd/.cache/task-evidence-manifest.json`, then `omd evidence tasks-check
-  --json`. Write the `final-evidence-v2` manifest at
-  `.omd/.cache/final-evidence-v2-manifest.json`; it binds the immutable art-direction record,
-  `.omd/reference-selection-v2.json`, settled motion projection, copy receipt, source seal, and
-  exactly one branch: `motionDecision: none` with `static-direction-evidence-v1`, or
-  `motionDecision: one` with exactly one `motion-evidence-v2`. It contains no unselected
-  direction or raw evidence. Publish only with
+  `--json`. When the launcher supplied a host-issued invocation, write the `final-evidence-v2`
+  manifest at `.omd/.cache/final-evidence-v2-manifest.json`; it binds the immutable art-direction
+  record, `.omd/reference-selection-v2.json`, settled motion projection, copy receipt, source seal,
+  and exactly one branch: `motionDecision: none` with `static-direction-evidence-v1`, or
+  `motionDecision: one` with exactly one `motion-evidence-v2`. It contains no unselected direction
+  or raw evidence. Publish only with
   `omd evidence v2 finalize --input .omd/.cache/final-evidence-v2-manifest.json --activation
   <host-issued-invocation.json>`, using a final-reviewer-authorized activation. Then run
   `omd evidence v2 check --activation <host-issued-invocation.json> --json`. The sole publication
   marker is `.omd/final-evidence-v2.json`, pointing at one immutable
   `.omd/final-evidence-v2-runs/sha256-<digest>.json` record. Never invoke the v1 finalizer/checker
-  or write `.omd/final-evidence.json`; any source or build mutation requires the protocol's
-  reseal, rebuild, rerun, and v2 republish sequence. The seal proves byte freshness only and does
-  not prove semantic copy/source fidelity.
+  or write `.omd/final-evidence.json`.
+  In the moderator-bound local lane, do not attempt or claim v2 publication. Finish with the same
+  source seal before/after checks, build, typecheck, required fixed-viewport renders, probes,
+  `omd deliberate check --phase final`, and applicable evidence checks; report those as local run
+  evidence rather than treating the absent host publisher as a blocker. Any source or build
+  mutation in either lane requires reseal, rebuild, and rerun. The seal proves byte freshness only
+  and does not prove semantic copy/source fidelity.
 Deliver the working artifact and briefly state the frame,
 concept, structural choice, what the two craft renders changed, glance/critique outcome,
 and any deliberate overruling. Do not release, deploy, or wait for further approval unless

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -152,6 +152,19 @@ prior explicit taste, which beats agent choices. Record conflicts.
   carries the exact hash of a host-authorized typed exception event. The selected register and
   `motionDecision: none|one` control the macro visual system; quiet or restraint never
   authorizes a generic template or skipped visual work.
+A normal Codex or Claude session may not carry a host-issued invocation/FD receipt. That is not a
+reason to stop the design. When the launcher supplied the activation, use the host-authorized
+`omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
+lane: hash the exact three direction alternatives, spawn fresh `omd-eye` UX, art-direction, and
+production perspectives concurrently with those identical bytes, then a fourth fresh `omd-eye`
+moderator. Preserve its exact `design-deliberation-v1` JSON at
+`.omd/deliberations/art-direction.json`; its three `inputSha256` values must equal the alternatives
+hash and its resolution must equal the evaluator result. Run
+`omd art-direction local-check --input <decision-check.json>` with that `deliberation` path and no
+`invocation` field. This derives only local project-write authority and cannot publish v2 evidence;
+it still creates the immutable art-direction, motion settlement, composer handoff, and hand handoff
+required to build. Never fabricate a host activation or downgrade to an unsigned handwritten
+`.omd/art-direction.json`.
 
 ## 0.5 Domain analysis
 
@@ -706,20 +719,24 @@ and blocks final evidence.
   fixed-viewport screenshot/render, and applicable motion filmstrip from sealed source; then run
   `omd source --check <root>` again. For `product` or `mixed`, publish the task index with `omd
   evidence tasks --input .omd/.cache/task-evidence-manifest.json`, then `omd evidence tasks-check
-  --json`. Write the `final-evidence-v2` manifest at
-  `.omd/.cache/final-evidence-v2-manifest.json`; it binds the immutable art-direction record,
-  `.omd/reference-selection-v2.json`, settled motion projection, copy receipt, source seal, and
-  exactly one branch: `motionDecision: none` with `static-direction-evidence-v1`, or
-  `motionDecision: one` with exactly one `motion-evidence-v2`. It contains no unselected
-  direction or raw evidence. Publish only with
+  `--json`. When the launcher supplied a host-issued invocation, write the `final-evidence-v2`
+  manifest at `.omd/.cache/final-evidence-v2-manifest.json`; it binds the immutable art-direction
+  record, `.omd/reference-selection-v2.json`, settled motion projection, copy receipt, source seal,
+  and exactly one branch: `motionDecision: none` with `static-direction-evidence-v1`, or
+  `motionDecision: one` with exactly one `motion-evidence-v2`. It contains no unselected direction
+  or raw evidence. Publish only with
   `omd evidence v2 finalize --input .omd/.cache/final-evidence-v2-manifest.json --activation
   <host-issued-invocation.json>`, using a final-reviewer-authorized activation. Then run
   `omd evidence v2 check --activation <host-issued-invocation.json> --json`. The sole publication
   marker is `.omd/final-evidence-v2.json`, pointing at one immutable
   `.omd/final-evidence-v2-runs/sha256-<digest>.json` record. Never invoke the v1 finalizer/checker
-  or write `.omd/final-evidence.json`; any source or build mutation requires the protocol's
-  reseal, rebuild, rerun, and v2 republish sequence. The seal proves byte freshness only and does
-  not prove semantic copy/source fidelity.
+  or write `.omd/final-evidence.json`.
+  In the moderator-bound local lane, do not attempt or claim v2 publication. Finish with the same
+  source seal before/after checks, build, typecheck, required fixed-viewport renders, probes,
+  `omd deliberate check --phase final`, and applicable evidence checks; report those as local run
+  evidence rather than treating the absent host publisher as a blocker. Any source or build
+  mutation in either lane requires reseal, rebuild, and rerun. The seal proves byte freshness only
+  and does not prove semantic copy/source fidelity.
 Deliver the working artifact and briefly state the frame,
 concept, structural choice, what the two craft renders changed, glance/critique outcome,
 and any deliberate overruling. Do not release, deploy, or wait for further approval unless

--- a/test/harness-v2-cli.test.ts
+++ b/test/harness-v2-cli.test.ts
@@ -474,6 +474,40 @@ test('doctor and preflight are read-only', () => {
   assert.equal(run(root, ['preflight', '--input', activation]).status, 0);
   assert.equal(existsSync(join(root, '.omd')), false);
 });
+
+test('moderator-bound local art direction unlocks ordinary sessions without host publication authority', () => {
+  const root = project();
+  const source = 'https://capture.example/local-hero'; const component = 'hero';
+  const image = refImagePath(root, { source, component });
+  const invariants: Invariants = { spacingLadder: [8], radiusLadder: [4], elevationLevels: 0, centeredRatio: 0, tokenCoverage: 1, paddingWeight: 8, typeScale: [], fontFamilies: [], weightLadder: [], motionDurations: [], easingVocab: [], animatedShare: 0, hoverCoverage: 0, focusCoverage: 0, animatedProperties: [], hasReducedMotion: false, scrollChoreography: [] };
+  const blueprint: Blueprint = { selector: '#hero', capturedAt: '2026-01-01T00:00:00.000Z', nodes: [{ id: 'hero', role: 'container', children: [], box: { w: 160, h: 40 } }] };
+  saveRef(root, { source, component, kind: 'component', capturedAt: '2026-01-01T00:00:00.000Z', selector: '#hero', invariants, principles: ['Keep the hierarchy.'], blueprint, imagePath: relative(root, image) }, createTestProjectWriteAdapter(root));
+  writeFileSync(image, Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC', 'base64'));
+  const slot = { slotId: 'static', sourceKind: 'component-capture', referenceId: refIdentity(source, component), targetComponent: 'Hero', targetSelector: '#hero', taskIds: ['T1'], reason: 'Use structure', take: ['structure'], avoid: 'Avoid copying', adaptation: 'Adapt lawfully', evidenceAxes: { rights: 'lawful', signal: 'high-visual-system', staticAxis: 'available', motionAxis: 'absent' }, grid: { column: 1, span: 12, order: 0 } };
+  mkdirSync(join(root, '.omd'), { recursive: true });
+  writeFileSync(join(root, '.omd', 'reference-board.json'), JSON.stringify({ schemaVersion: 'reference-board-v1', frameSha256: sha('frame'), candidates: [{ id: 'candidate', label: 'Candidate', route: '/', rationale: 'Lawful evidence', pieces: [slot] }] }));
+  const selected = run(root, ['ref', 'select', 'candidate', '--json']);
+  assert.equal(selected.status, 0, selected.stderr);
+
+  const alternatives = [
+    { register: 'quiet', subjectIdentityFit: 'Quiet editorial framing fits the subject.', staticReferenceSlotIds: ['static'], motionReferenceSlotIds: [], conceptRole: 'Editorial clarity', macroCompositionHypothesis: 'Template-breaking asymmetric editorial departure.', motionHypothesis: 'none', uxAccessibilityPerformanceRisks: ['Reduced motion remains available.'], lawfulImplementationPath: 'CSS and SVG implementation.', rejectionCondition: 'The evidence better supports another direction.' },
+    { register: 'confident', subjectIdentityFit: 'Confident framing fits the subject.', staticReferenceSlotIds: ['static'], motionReferenceSlotIds: [], conceptRole: 'Launch transition', macroCompositionHypothesis: 'Layered promotional composition.', motionHypothesis: 'one', uxAccessibilityPerformanceRisks: ['Reduced motion remains available.'], lawfulImplementationPath: 'CSS and SVG implementation.', rejectionCondition: 'The evidence does not establish the required motion scene.' },
+    { register: 'showpiece', subjectIdentityFit: 'Showpiece framing fits the subject.', staticReferenceSlotIds: ['static'], motionReferenceSlotIds: [], conceptRole: 'Signature reveal', macroCompositionHypothesis: 'Sculptural promotional composition.', motionHypothesis: 'one', uxAccessibilityPerformanceRisks: ['Reduced motion remains available.'], lawfulImplementationPath: 'CSS and SVG implementation.', rejectionCondition: 'The evidence does not establish the required motion scene.' },
+  ];
+  const alternativesSha256 = sha(canonicalPayload(alternatives));
+  const perspective = (position: string) => ({ inputSha256: alternativesSha256, position, evidence: ['reference:static'], objections: [], conditions: ['Preserve the primary task.'] });
+  const deliberation = { schema: 'design-deliberation-v1', id: 'art-direction', decisionId: 'art-direction-register', trigger: 'local session requires independent art-direction selection', moderator: 'omd-eye', perspectives: { ux: perspective('Keep the primary action legible.'), artDirection: perspective('Use the quiet editorial register.'), production: perspective('Use the static CSS/SVG lane.') }, resolution: { selected: 'quiet', rationale: 'Quiet wins on evidence, task clarity, and lawful static feasibility.', conditions: ['Preserve the primary task.'] } };
+  mkdirSync(join(root, '.omd', 'deliberations'), { recursive: true });
+  writeFileSync(join(root, '.omd', 'deliberations', 'art-direction.json'), JSON.stringify(deliberation));
+  const evaluatorAssessment = { assessments: alternatives.map((alternative) => ({ register: alternative.register, score: alternative.register === 'quiet' ? 3 : 1, subjectIdentityRationale: `${alternative.register} subject assessment.`, conceptRoleRationale: `${alternative.register} role assessment.`, uxAccessibilityPerformanceRationale: `${alternative.register} accessibility assessment.`, lawfulFeasibilityRationale: `${alternative.register} lawful assessment.`, referenceEvidenceRationale: `${alternative.register} evidence assessment.`, rejectionRationale: `${alternative.register} ranking assessment.` })) };
+  const evaluatorResult = { winner: 'quiet', alternativesSha256, motionResolution: { motionDecision: 'none', slots: [] } };
+  const input = writeManifest(root, 'local-art-direction.json', { route: '/', alternatives, references: [{ slotId: 'static', signal: 'high-visual-system', positive: true, lawful: true, motionObligation: 'none' }], evaluatorAssessment, evaluatorResult, eligibility: { sceneRoles: [], fallbackAttempted: true, qualityGates: { blindSignatureGreen: true, narrativeGreen: true, motionFitGreen: true, fidelityDecisionFitGreen: true, macroLandingScore: 3, staticReferenceInfluenceScore: 3, templateBreakingLandingScore: 3 } }, beats: ['B-1'], implementationLane: 'browser', fallbackPath: 'CSS/SVG static reduced-motion fallback.', performanceAccessibilityBudget: 'Within the declared accessibility and performance budget.', deliberation: '.omd/deliberations/art-direction.json' });
+  const directed = run(root, ['art-direction', 'local-check', '--input', input, '--json']);
+  assert.equal(directed.status, 0, directed.stderr);
+  assert.equal(existsSync(join(root, '.omd', 'art-direction.json')), true);
+  assert.equal(existsSync(join(root, '.omd', 'reference-handoffs', 'composer.json')), true);
+  assert.equal(existsSync(join(root, '.omd', 'reference-handoffs', 'hand.json')), true);
+});
 test('art direction rejects over-budget Beat sets before settlement and accepts a host-authorized exception', async () => {
   for (const [selectedRegister, count] of [['quiet', 6], ['confident', 8]] as const) {
     const root = project();

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -858,12 +858,16 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(protocol, /before render → observable fact → judgment → exact change → distinct after render → measured result/);
   assert.match(protocol, /zone job → captured reference identity → extracted principle → composition decision ID/);
   assert.match(protocol, /same concrete model and identical prompt bytes/);
+  assert.match(protocol, /`omd art-direction local-check` accepts only that moderator-owned receipt/);
 
   const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
   assert.match(skill, /`omd depth classify --input \.omd\/depth\.json --json`/);
   assert.match(skill, /spawn three fresh `omd-eye` contexts concurrently in UX, art-direction, and production perspective modes/);
   assert.match(skill, /Require `omd deliberate check` to pass/);
   assert.match(skill, /coordinator must not author or paraphrase them/);
+  assert.match(skill, /When no activation was supplied, use the moderator-bound local lane/);
+  assert.match(skill, /`omd art-direction local-check --input <decision-check\.json>`/);
+  assert.match(skill, /do not attempt or claim v2 publication/);
 
   const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
   assert.match(framer, /You also own `\.omd\/acquisition-plan\.json`/);


### PR DESCRIPTION
## Summary
- add `omd art-direction local-check` for ordinary Codex/Claude sessions without host publication receipts
- require exact three-perspective moderator evidence bound to the alternatives and winning register
- preserve immutable art direction, motion settlement, composer/hand handoffs while withholding v2 publication authority
- route local ultradesign completion through source/build/render/deliberation evidence instead of stopping before composition

## Verification
- moderator-bound local integration creates art direction and both downstream handoffs
- host-authorized art-direction and stale-binding tests remain green
- `npx tsc --noEmit`
- `npm run build`