### PR TITLE
fix: start scout acquisition before broad reading

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -5,10 +5,19 @@ model: inherit
 effort: high
 ---
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and the relevant theory/cookbook files under
-`omd pack dir`. Receive the concept, product, working directory, component inventory, explicit
-functions or product goal, surface classification, and any user URLs. Run all commands from that
-directory. Capture user URLs first with `--from-user`.
+Read `protocol/reference-assembly.md` and only the reference-gallery, concept-exploration,
+contamination, and transfer-boundary sections of `protocol/human-design-loop.md`, plus a theory
+file only when one acquisition zone directly needs it. Receive the concept, product, working
+directory, component inventory, explicit functions or product goal, surface classification, and
+any user URLs. Run all commands from that directory. Capture user URLs first with `--from-user`.
+Acquisition comes before exhaustive reading. Your first operational pass is: (1) read only
+`.omd/domain-brief.json`, `.omd/frame.md`, `.omd/acquisition-plan.json`, and the two bounded
+protocol slices above; (2) run the supported browser doctor; (3) write the zone-bound manifest and
+start `omd ref add-batch`. Do not inspect the installed scout skill, every theory/cookbook file,
+`src/agents`, adapters, CLI implementation, or tests before that batch. Do not recursively inventory
+packs or use image generation. After capture, read only the contract material needed to serialize
+`.omd/scout.md` and `.omd/reference-board.json`. This is an evidence role, not a repository-audit
+role; the coordinator already supplies the validated subject/domain facts.
 You have write access only because `.omd/scout.md` is your owned durable synthesis; use the
 `omd ref:*` and `omd craft-capture:*` commands for the board, captures, and reference records.
 Outside those command-owned records, write or edit only `.omd/scout.md`. Never touch production

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -49,6 +49,11 @@ artifact gate. Do not cancel a still-running owner or stop the graph because an 
 message describes a temporary gap; capture and browser writes may still be joining. A timeout
 requires both an unfinished child and no ongoing tool/process activity, not merely several wait
 polls with no chat message.
+For the scout specifically, acquisition and browser work can be quiet while a batch is active.
+Allow at least fifteen minutes for its first final state, and never retry or cancel it while its
+child state or a capture/browser tool is active. Six empty chat polls are not a timeout. Inspecting
+the `.omd/refs/` directory during an in-flight batch is observation only, not evidence that the
+owner is stalled.
 **Artifact ownership is not advisory.** Each durable artifact below is written by the agent that owns
 it, spawned for that purpose. The coordinator orchestrates, gathers, sanitizes, and gates — it never
 writes an owned artifact itself, however obvious the content seems or however much time a direct

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -13,10 +13,19 @@ allow:
   - apply_patch
 deny: []
 instructions: |
-  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`, and the relevant theory/cookbook files under
-  `omd pack dir`. Receive the concept, product, working directory, component inventory, explicit
-  functions or product goal, surface classification, and any user URLs. Run all commands from that
-  directory. Capture user URLs first with `--from-user`.
+  Read `protocol/reference-assembly.md` and only the reference-gallery, concept-exploration,
+  contamination, and transfer-boundary sections of `protocol/human-design-loop.md`, plus a theory
+  file only when one acquisition zone directly needs it. Receive the concept, product, working
+  directory, component inventory, explicit functions or product goal, surface classification, and
+  any user URLs. Run all commands from that directory. Capture user URLs first with `--from-user`.
+  Acquisition comes before exhaustive reading. Your first operational pass is: (1) read only
+  `.omd/domain-brief.json`, `.omd/frame.md`, `.omd/acquisition-plan.json`, and the two bounded
+  protocol slices above; (2) run the supported browser doctor; (3) write the zone-bound manifest and
+  start `omd ref add-batch`. Do not inspect the installed scout skill, every theory/cookbook file,
+  `src/agents`, adapters, CLI implementation, or tests before that batch. Do not recursively inventory
+  packs or use image generation. After capture, read only the contract material needed to serialize
+  `.omd/scout.md` and `.omd/reference-board.json`. This is an evidence role, not a repository-audit
+  role; the coordinator already supplies the validated subject/domain facts.
   You have write access only because `.omd/scout.md` is your owned durable synthesis; use the
   `omd ref:*` and `omd craft-capture:*` commands for the board, captures, and reference records.
   Outside those command-owned records, write or edit only `.omd/scout.md`. Never touch production

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -49,6 +49,11 @@ artifact gate. Do not cancel a still-running owner or stop the graph because an 
 message describes a temporary gap; capture and browser writes may still be joining. A timeout
 requires both an unfinished child and no ongoing tool/process activity, not merely several wait
 polls with no chat message.
+For the scout specifically, acquisition and browser work can be quiet while a batch is active.
+Allow at least fifteen minutes for its first final state, and never retry or cancel it while its
+child state or a capture/browser tool is active. Six empty chat polls are not a timeout. Inspecting
+the `.omd/refs/` directory during an in-flight batch is observation only, not evidence that the
+owner is stalled.
 **Artifact ownership is not advisory.** Each durable artifact below is written by the agent that owns
 it, spawned for that purpose. The coordinator orchestrates, gathers, sanitizes, and gates — it never
 writes an owned artifact itself, however obvious the content seems or however much time a direct

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -820,6 +820,9 @@ test('scout batches zone-bound captures without debugging browser transport', ()
   assert.match(scout, /designsystem\.digital\.gov\/patterns\/select-a-language\/two-languages/);
   assert.match(scout, /designsystem\.digital\.gov\/components\/header/);
   assert.match(scout, /do not spend both attempts guessing hashed classes/);
+  assert.match(scout, /Acquisition comes before exhaustive reading/);
+  assert.match(scout, /Do not inspect the installed scout skill, every theory\/cookbook file/);
+  assert.match(scout, /start `omd ref add-batch`/);
   const batch = read('core/ref/batch.ts');
   assert.match(batch, /slot\?: string/);
   assert.match(batch, /spec\.slot \? \{ slot: spec\.slot \}/);
@@ -840,6 +843,8 @@ test('the selected host model is immutable while OMD adjusts only role effort', 
   assert.match(skill, /This applies to every named pipeline agent and every ad-hoc worker/);
   assert.match(skill, /A child `send_message` is progress only, never its handback/);
   assert.match(skill, /Wait until the child agent state is `completed`/);
+  assert.match(skill, /Allow at least fifteen minutes for its first final state/);
+  assert.match(skill, /Six empty chat polls are not a timeout/);
 
   const loop = read('core/protocol/human-design-loop.md').replace(/\s+/g, ' ');
   assert.match(loop, /Model ownership belongs to the user/);


### PR DESCRIPTION
## Summary
- make the scout start its zone-bound batch before broad theory/repository inspection
- limit pre-capture reading to the owned artifacts and protocol slices it actually needs
- prevent the coordinator from retrying an active scout after a handful of quiet polls

## Verification
- 63 focused prompt contracts passed
- `npx tsc --noEmit`
- `npm run build`
- based on the latest Terra trace: both scouts spent their entire coordinator wait window reading packs/source and were canceled before their first capture batch