### PR TITLE
fix: stabilize repository CTA capture

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -41,6 +41,13 @@ marketing-site navigation: include
 uses `https://designsystem.digital.gov/components/header/` with selector `.usa-header`. Bind the
 result to `slot: "navigation-preferences"`; do not spend both attempts guessing hashed classes on
 Vite, Mintlify, or another frequently changing marketing header.
+A required `repository-cta` or `source-cta` zone first captures the user-supplied repository with
+`omd ref add https://github.com/3x-haust/oh-my-design --as repository-source-header
+--from-user --slot <exact-zone-id> --selector "#repository-container-header" --blueprint --shot
+--no-energy` before the general batch. If GitHub blocks or changes that selector, the one repair
+batch uses `https://designsystem.digital.gov/components/button/` with selector `.usa-button`,
+bound to the same exact zone ID. The fallback transfers accessible outbound-action anatomy while
+subject identity remains grounded in the user-supplied repository facts.
 Never call `send_message`: it is an intermediate signal that can make the coordinator stop while late
 captures are still joining. Return exactly one final handback after the board and candidates are
 complete, or after the final stable checks prove the blocker. Once every required zone and

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -49,6 +49,13 @@ instructions: |
   uses `https://designsystem.digital.gov/components/header/` with selector `.usa-header`. Bind the
   result to `slot: "navigation-preferences"`; do not spend both attempts guessing hashed classes on
   Vite, Mintlify, or another frequently changing marketing header.
+  A required `repository-cta` or `source-cta` zone first captures the user-supplied repository with
+  `omd ref add https://github.com/3x-haust/oh-my-design --as repository-source-header
+  --from-user --slot <exact-zone-id> --selector "#repository-container-header" --blueprint --shot
+  --no-energy` before the general batch. If GitHub blocks or changes that selector, the one repair
+  batch uses `https://designsystem.digital.gov/components/button/` with selector `.usa-button`,
+  bound to the same exact zone ID. The fallback transfers accessible outbound-action anatomy while
+  subject identity remains grounded in the user-supplied repository facts.
   Never call `send_message`: it is an intermediate signal that can make the coordinator stop while late
   captures are still joining. Return exactly one final handback after the board and candidates are
   complete, or after the final stable checks prove the blocker. Once every required zone and

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -823,6 +823,10 @@ test('scout batches zone-bound captures without debugging browser transport', ()
   assert.match(scout, /Acquisition comes before exhaustive reading/);
   assert.match(scout, /Do not inspect the installed scout skill, every theory\/cookbook file/);
   assert.match(scout, /start `omd ref add-batch`/);
+  assert.match(scout, /required `repository-cta` or `source-cta` zone first captures the user-supplied repository/);
+  assert.match(scout, /#repository-container-header/);
+  assert.match(scout, /designsystem\.digital\.gov\/components\/button/);
+  assert.match(scout, /bound to the same exact zone ID/);
   const batch = read('core/ref/batch.ts');
   assert.match(batch, /slot\?: string/);
   assert.match(batch, /spec\.slot \? \{ slot: spec\.slot \}/);


### PR DESCRIPTION
## Summary
- capture the user-supplied repository header before the general batch for repository/source CTA zones
- fall back to stable accessible USWDS button anatomy when GitHub blocks or changes its selector
- preserve exact acquisition-zone binding in either path

## Verification
- 63 focused prompt contracts passed
- `npx tsc --noEmit`
- `npm run build`
- derived from the latest Terra run where every other zone passed and only repository-cta failed