### PR TITLE
fix: audit explicit reference batch provenance

### DIFF
--- a/core/ref/batch.ts
+++ b/core/ref/batch.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { dirname, relative } from 'node:path';
 import { capturePageForRef, withBrowser, parseViewport } from '../render/index.ts';
 import { normalize } from '../ir/normalize.ts';
@@ -51,6 +52,7 @@ export async function addRefsBatch(
   const concurrency = Math.max(1, opts.concurrency ?? 4);
   const rules = loadRules(opts.rulesRoot);
   const outcomes: BatchOutcome[] = new Array<BatchOutcome>(specs.length);
+  const captureBatchId = `batch-${randomUUID()}`;
 
   await withBrowser(async (browser) => {
     let next = 0;
@@ -77,6 +79,7 @@ export async function addRefsBatch(
             component: spec.as,
             kind: spec.selector ? 'component' : 'page',
             capturedAt: new Date().toISOString(),
+            captureBatchId,
             ...(spec.selector ? { selector: spec.selector } : {}),
             ...(spec.slot ? { slot: spec.slot } : {}),
             invariants,

--- a/core/ref/capture-audit.ts
+++ b/core/ref/capture-audit.ts
@@ -25,6 +25,36 @@ const SEQUENTIAL_GAP_MS = 15_000;
 /** Batching is only material once several references were captured. */
 const MIN_REFS = 4;
 
+export type CaptureAuditRecord = {
+  readonly capturedAt: string;
+  readonly captureBatchId?: string;
+};
+
+export function auditCaptureRecords(records: readonly CaptureAuditRecord[], now: number = Date.now()): CaptureAudit {
+  const recent = records.filter((record) => {
+    const time = Date.parse(record.capturedAt);
+    return Number.isFinite(time) && time <= now && now - time <= RECENT_MS;
+  });
+  if (recent.length >= MIN_REFS) {
+    const groups = new Map<string, number>();
+    for (const record of recent) {
+      if (record.captureBatchId !== undefined) groups.set(record.captureBatchId, (groups.get(record.captureBatchId) ?? 0) + 1);
+    }
+    const batchedRefs = recent.reduce((count, record) => count + (
+      record.captureBatchId !== undefined && (groups.get(record.captureBatchId) ?? 0) >= 2 ? 1 : 0
+    ), 0);
+    if (batchedRefs >= recent.length - 1) {
+      const timing = auditCaptureTimes(recent.map((record) => record.capturedAt), now);
+      return {
+        ok: true,
+        refs: recent.length,
+        medianGapSeconds: timing.medianGapSeconds,
+        reason: `${batchedRefs} of ${recent.length} references carry explicit shared-batch provenance; remote completion gaps do not imply separate browser launches`,
+      };
+    }
+  }
+  return auditCaptureTimes(recent.map((record) => record.capturedAt), now);
+}
 /** Pure core: judge a list of `capturedAt` strings. */
 export function auditCaptureTimes(capturedAt: readonly string[], now: number = Date.now()): CaptureAudit {
   const times = capturedAt
@@ -57,7 +87,10 @@ export function auditCaptureTimes(capturedAt: readonly string[], now: number = D
   };
 }
 
-/** Read the saved reference records for `cwd` and audit their capture times. */
+/** Read the saved reference records for `cwd` and audit explicit batch provenance before legacy timing. */
 export function auditCaptureParallelism(cwd: string, now: number = Date.now()): CaptureAudit {
-  return auditCaptureTimes(loadRefs(cwd).map((r) => r.capturedAt), now);
+  return auditCaptureRecords(loadRefs(cwd).map((reference) => ({
+    capturedAt: reference.capturedAt,
+    ...(reference.captureBatchId === undefined ? {} : { captureBatchId: reference.captureBatchId }),
+  })), now);
 }

--- a/core/ref/store.ts
+++ b/core/ref/store.ts
@@ -80,6 +80,7 @@ export function loadRefs(cwd: string): Reference[] {
           capturedAt: parsed.capturedAt ?? '',
           ...(parsed.selector !== undefined ? { selector: parsed.selector } : {}),
           ...(parsed.slot !== undefined ? { slot: parsed.slot } : {}),
+          ...(parsed.captureBatchId !== undefined ? { captureBatchId: parsed.captureBatchId } : {}),
           invariants: withInvariantDefaults(parsed.invariants),
           principles: parsed.principles ?? [],
           ...(parsed.slopCount !== undefined ? { slopCount: parsed.slopCount } : {}),

--- a/core/types.ts
+++ b/core/types.ts
@@ -531,6 +531,12 @@ export interface Reference {
    */
   slot?: string;
   /**
+   * Explicit provenance for one `omd ref add-batch` invocation. References in the same batch may
+   * finish far apart when remote pages vary in latency; the shared ID proves one-browser parallel
+   * acquisition without guessing from completion timestamps.
+   */
+  captureBatchId?: string;
+  /**
    * Null for an image, and the type says so on purpose. Pixels cannot be measured this way:
    * there is no spacing ladder to read out of a JPEG. An image reference carries reasoning
    * and nothing else, which also means `ref distance` cannot check it for cloning.

--- a/test/capture-audit.test.ts
+++ b/test/capture-audit.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { auditCaptureTimes } from '../core/ref/capture-audit.ts';
+import { auditCaptureRecords, auditCaptureTimes } from '../core/ref/capture-audit.ts';
 
 const NOW = Date.parse('2026-07-21T12:00:00.000Z');
 const iso = (msAgo: number): string => new Date(NOW - msAgo).toISOString();
@@ -40,4 +40,31 @@ test('auditCaptureTimes tolerates a lone late straggler among a batched set', ()
   // three tight captures + one much later — median gap stays small, so it passes
   const a = auditCaptureTimes([iso(600_000), iso(12_000), iso(10_000), iso(8_000)], NOW);
   assert.equal(a.ok, true);
+});
+
+test('explicit batch provenance passes despite slow remote completion gaps and one direct capture', () => {
+  const records = [
+    { capturedAt: iso(420_000) },
+    { capturedAt: iso(360_000), captureBatchId: 'batch-a' },
+    { capturedAt: iso(300_000), captureBatchId: 'batch-a' },
+    { capturedAt: iso(240_000), captureBatchId: 'batch-a' },
+    { capturedAt: iso(180_000), captureBatchId: 'batch-b' },
+    { capturedAt: iso(120_000), captureBatchId: 'batch-b' },
+    { capturedAt: iso(60_000), captureBatchId: 'batch-b' },
+  ];
+  const result = auditCaptureRecords(records, NOW);
+  assert.equal(result.ok, true);
+  assert.match(result.reason, /explicit shared-batch provenance/);
+});
+
+test('a small batch does not launder a mostly sequential pass', () => {
+  const records = [
+    { capturedAt: iso(360_000), captureBatchId: 'batch-a' },
+    { capturedAt: iso(300_000), captureBatchId: 'batch-a' },
+    { capturedAt: iso(240_000) },
+    { capturedAt: iso(180_000) },
+    { capturedAt: iso(120_000) },
+    { capturedAt: iso(60_000) },
+  ];
+  assert.equal(auditCaptureRecords(records, NOW).ok, false);
 });

--- a/test/reference.test.ts
+++ b/test/reference.test.ts
@@ -204,7 +204,7 @@ test('distances ranks every reference and names what drove the score', () => {
 // ── store ──
 
 const ref: Reference = {
-  source: 'https://linear.app', component: 'search-bar', kind: 'component', capturedAt: new Date().toISOString(), slot: 'hero',
+  source: 'https://linear.app', component: 'search-bar', kind: 'component', capturedAt: new Date().toISOString(), slot: 'hero', captureBatchId: 'batch-test',
   invariants: base, principles: ['Radii split into three rungs, so an input and a card are different materials.'],
 };
 


### PR DESCRIPTION
## Summary
- stamp every successful `omd ref add-batch` capture with a shared invocation ID
- preserve that provenance through reference loading
- audit explicit batch membership before the legacy timestamp heuristic, while refusing to let a small batch launder a mostly sequential pass

## Verification
- 44 focused reference/audit tests passed
- `npx tsc --noEmit`
- `npm run build`
- local two-reference browser batch persisted one shared batch ID
- derived from the latest Terra run where `ref check` and granularity passed but slow remote pages made a real batch look sequential