### PR TITLE
fix: preserve read-only moderator handbacks

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -1888,10 +1888,33 @@ async function cmdTokens(mode: string | undefined, opts: Opts): Promise<never> {
   process.exit(drift ? 1 : 0);
 }
 
-/** Validates owner-authored design records before production or across the completed run. */
+/** Persists a moderator handback verbatim or validates the joined run before/final. */
 async function cmdDeliberate(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode === 'preserve') {
+    if (!opts.input || opts._.length > 0) throw new Error('usage: omd deliberate preserve --input <moderator.json> [--json]');
+    const source = resolve(opts.input);
+    const body = readFileSync(source, 'utf8').trim();
+    let raw: unknown;
+    try { raw = JSON.parse(body); } catch { throw new Error('DELIBERATION_MODERATOR_JSON_INVALID: input must contain only the moderator JSON object, without a Markdown fence'); }
+    const { validateDeliberation } = await import('../core/deliberation/contracts.ts');
+    const result = validateDeliberation(raw);
+    if (!result.value || result.findings.length > 0) throw new Error(result.findings.map((finding) => `${finding.id} ${finding.path}: ${finding.message}`).join('\n'));
+    if (result.value.moderator !== 'omd-eye' || !/^[a-z0-9][a-z0-9-]*$/.test(result.value.id)) {
+      throw new Error('DELIBERATION_MODERATOR_OWNER_INVALID: receipt needs moderator omd-eye and a kebab-case id');
+    }
+    const relativePath = `.omd/deliberations/${result.value.id}.json`;
+    const destination = join(process.cwd(), relativePath);
+    const content = `${body}\n`;
+    if (existsSync(destination) && readFileSync(destination, 'utf8') !== content) {
+      throw new Error('DELIBERATION_IMMUTABLE_CONFLICT: a different moderator receipt already uses this id');
+    }
+    const path = projectWriterFromActivation(opts, 'omd deliberate preserve').write(relativePath, content);
+    if (opts.json) process.stdout.write(JSON.stringify({ path, id: result.value.id }));
+    else console.log(path);
+    process.exit(0);
+  }
   if (mode !== 'check' || (opts.phase !== undefined && opts.phase !== 'prebuild' && opts.phase !== 'final')) {
-    throw new Error('usage: omd deliberate check [--phase prebuild|final] [--json]');
+    throw new Error('usage: omd deliberate preserve --input <moderator.json> | check [--phase prebuild|final] [--json]');
   }
   const { checkDeliberationRun } = await import('../core/deliberation/check.ts');
   const phase = (opts.phase ?? 'final') as import('../core/deliberation/check.ts').DeliberationRunPhase;
@@ -2869,6 +2892,7 @@ function usage(): never {
     + '  acquisition set --zones <json-array>          persist framer-owned section/region/state reference targets\n'
     + '  depth classify --input depth.json [--json]      choose L1–L4 from design risk, never from convenience\n'
     + '  deliberate check [--phase prebuild|final] [--json] validate owner decisions before build or the complete visual loop\n'
+    + '  deliberate preserve --input moderator.json    validate and persist an exact omd-eye moderator handback\n'
     + '  compare score --input comparison.json [--json] blind same-model quality and quality/cost comparison\n'
     + '  source --seal [root]                        write final approved-input/source byte seal\n'
     + '  source --check [root] [--json]              fail when the source seal is missing or stale\n'

--- a/core/protocol/design-deliberation.md
+++ b/core/protocol/design-deliberation.md
@@ -76,8 +76,11 @@ Then spawn a fourth fresh `omd-eye` as moderator. It receives only the three com
 records, the decision alternatives, and the same sanitized input digest. It does not vote by
 majority: it resolves objections against evidence and constraints, returns one selection plus
 conditions, and authors the `design-deliberation-v1` record. All three perspective `inputSha256`
-values must match. The coordinator only preserves the moderator's closed JSON under
-`.omd/deliberations/<id>.json`.
+values must match. The eye is intentionally read-only. The coordinator copies only its returned JSON,
+without a Markdown fence or semantic edit, to a cache input and runs
+`omd deliberate preserve --input <cache-moderator.json>`. That command validates the moderator owner,
+rejects conflicting reuse of an ID, and persists the exact bytes under
+`.omd/deliberations/<id>.json`; clerical preservation does not transfer authorship to the coordinator.
 For the pre-composition art-direction decision, a host-issued invocation remains the publication
 lane. In an ordinary Codex or Claude session without that launcher receipt, the same three
 perspectives plus moderator bind the exact three register alternatives and selected register.

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -162,8 +162,11 @@ reason to stop the design. When the launcher supplied the activation, use the ho
 `omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
 lane: hash the exact three direction alternatives, spawn fresh `oh-my-design:eye` UX, art-direction, and
 production perspectives concurrently with those identical bytes, then a fourth fresh `oh-my-design:eye`
-moderator. Preserve its exact `design-deliberation-v1` JSON at
-`.omd/deliberations/art-direction.json`; its three `inputSha256` values must equal the alternatives
+moderator. The eye is intentionally read-only: it returns the closed JSON and never writes the
+artifact itself. Copy that JSON byte-for-byte, without its Markdown fence and without editing or
+paraphrasing, to `.omd/.cache/art-direction-moderator.json`, then run
+`omd deliberate preserve --input .omd/.cache/art-direction-moderator.json`. This validated clerical
+persistence is not coordinator authorship. Its three `inputSha256` values must equal the alternatives
 hash and its resolution must equal the evaluator result. Run
 `omd art-direction local-check --input <decision-check.json>` with that `deliberation` path and no
 `invocation` field. This derives only local project-write authority and cannot publish v2 evidence;
@@ -387,8 +390,11 @@ perspective modes. Give all three the identical sanitized alternatives and input
 another perspective's output or authorship. Then spawn a fourth fresh `oh-my-design:eye` as moderator with
 only the three completed records, alternatives, and shared input digest. Majority vote is forbidden:
 the moderator resolves objections against evidence and constraints and returns one closed
-`design-deliberation-v1` JSON record. Preserve that exact record under
-`.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
+`design-deliberation-v1` JSON record. A read-only moderator response is the required success path,
+not a permission blocker. Copy its JSON byte-for-byte without the Markdown fence to a cache input,
+then run `omd deliberate preserve --input <cache-moderator.json>`; never ask the eye to write and
+never recreate its fields yourself. The command validates ownership and preserves that exact record
+under `.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
 return to the composer to revise `.omd/composition.md` and its owner-authored decision entry, then
 rerun `omd composition --check`. No L4 sketch starts without this receipt.
 

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -162,8 +162,11 @@ reason to stop the design. When the launcher supplied the activation, use the ho
 `omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
 lane: hash the exact three direction alternatives, spawn fresh `omd-eye` UX, art-direction, and
 production perspectives concurrently with those identical bytes, then a fourth fresh `omd-eye`
-moderator. Preserve its exact `design-deliberation-v1` JSON at
-`.omd/deliberations/art-direction.json`; its three `inputSha256` values must equal the alternatives
+moderator. The eye is intentionally read-only: it returns the closed JSON and never writes the
+artifact itself. Copy that JSON byte-for-byte, without its Markdown fence and without editing or
+paraphrasing, to `.omd/.cache/art-direction-moderator.json`, then run
+`omd deliberate preserve --input .omd/.cache/art-direction-moderator.json`. This validated clerical
+persistence is not coordinator authorship. Its three `inputSha256` values must equal the alternatives
 hash and its resolution must equal the evaluator result. Run
 `omd art-direction local-check --input <decision-check.json>` with that `deliberation` path and no
 `invocation` field. This derives only local project-write authority and cannot publish v2 evidence;
@@ -387,8 +390,11 @@ perspective modes. Give all three the identical sanitized alternatives and input
 another perspective's output or authorship. Then spawn a fourth fresh `omd-eye` as moderator with
 only the three completed records, alternatives, and shared input digest. Majority vote is forbidden:
 the moderator resolves objections against evidence and constraints and returns one closed
-`design-deliberation-v1` JSON record. Preserve that exact record under
-`.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
+`design-deliberation-v1` JSON record. A read-only moderator response is the required success path,
+not a permission blocker. Copy its JSON byte-for-byte without the Markdown fence to a cache input,
+then run `omd deliberate preserve --input <cache-moderator.json>`; never ask the eye to write and
+never recreate its fields yourself. The command validates ownership and preserves that exact record
+under `.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
 return to the composer to revise `.omd/composition.md` and its owner-authored decision entry, then
 rerun `omd composition --check`. No L4 sketch starts without this receipt.
 

--- a/test/deliberation-preserve.test.ts
+++ b/test/deliberation-preserve.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+const digest = 'a'.repeat(64);
+const perspective = (position: string) => ({ inputSha256: digest, position, evidence: ['bounded:evidence'], objections: [], conditions: ['Keep the primary action reachable.'] });
+const receipt = {
+  schema: 'design-deliberation-v1', id: 'art-direction', decisionId: 'art-direction', trigger: 'Select the local art direction.', moderator: 'omd-eye',
+  perspectives: { ux: perspective('confident'), artDirection: perspective('confident'), production: perspective('confident') },
+  resolution: { selected: 'confident', rationale: 'The evidence-bearing stage rail preserves task clarity and feasible production.', conditions: ['Keep the primary action reachable.'] },
+};
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-deliberation-preserve-'));
+const run = (root: string, input: string) => spawnSync(process.execPath, ['--experimental-strip-types', CLI, 'deliberate', 'preserve', '--input', input, '--json'], { cwd: root, encoding: 'utf8' });
+
+test('preserve validates the read-only moderator handback and writes its exact JSON bytes', () => {
+  const root = project(); const input = join(root, 'moderator.json');
+  const body = JSON.stringify(receipt, null, 2);
+  writeFileSync(input, body);
+  const first = run(root, input);
+  assert.equal(first.status, 0, first.stderr);
+  const output = join(root, '.omd', 'deliberations', 'art-direction.json');
+  assert.equal(existsSync(output), true);
+  assert.equal(readFileSync(output, 'utf8'), `${body}\n`);
+  assert.equal(run(root, input).status, 0, 'replaying identical bytes is idempotent');
+});
+
+test('preserve rejects Markdown fences and conflicting reuse of a moderator id', () => {
+  const root = project(); const input = join(root, 'moderator.json');
+  writeFileSync(input, JSON.stringify(receipt));
+  assert.equal(run(root, input).status, 0);
+  writeFileSync(input, JSON.stringify({ ...receipt, resolution: { ...receipt.resolution, rationale: 'A different rationale.' } }));
+  const conflict = run(root, input);
+  assert.notEqual(conflict.status, 0);
+  assert.match(conflict.stderr, /DELIBERATION_IMMUTABLE_CONFLICT/);
+  const fenced = join(root, 'fenced.json');
+  writeFileSync(fenced, `\`\`\`json\n${JSON.stringify({ ...receipt, id: 'other' })}\n\`\`\``);
+  const invalid = run(root, fenced);
+  assert.notEqual(invalid.status, 0);
+  assert.match(invalid.stderr, /DELIBERATION_MODERATOR_JSON_INVALID/);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -875,6 +875,7 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(protocol, /zone job → captured reference identity → extracted principle → composition decision ID/);
   assert.match(protocol, /same concrete model and identical prompt bytes/);
   assert.match(protocol, /`omd art-direction local-check` accepts only that moderator-owned receipt/);
+  assert.match(protocol, /The eye is intentionally read-only/);
 
   const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
   assert.match(skill, /`omd depth classify --input \.omd\/depth\.json --json`/);
@@ -884,6 +885,8 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /When no activation was supplied, use the moderator-bound local lane/);
   assert.match(skill, /`omd art-direction local-check --input <decision-check\.json>`/);
   assert.match(skill, /do not attempt or claim v2 publication/);
+  assert.match(skill, /`omd deliberate preserve --input/);
+  assert.match(skill, /A read-only moderator response is the required success path/);
 
   const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
   assert.match(framer, /You also own `\.omd\/acquisition-plan\.json`/);


### PR DESCRIPTION
## Summary
- add a validated CLI preservation path for read-only omd-eye moderator receipts
- clarify coordinator clerical persistence without transferring authorship
- cover exact bytes, idempotency, immutable conflicts, and fenced-input rejection

## Verification
- node --test --experimental-strip-types test/deliberation-preserve.test.ts test/deliberation-runtime.test.ts test/prompt-contract.test.ts
- npx tsc --noEmit
- npm run build