### PR TITLE
fix: give moderators an exact receipt schema

### DIFF
--- a/core/protocol/design-deliberation.md
+++ b/core/protocol/design-deliberation.md
@@ -81,6 +81,52 @@ without a Markdown fence or semantic edit, to a cache input and runs
 `omd deliberate preserve --input <cache-moderator.json>`. That command validates the moderator owner,
 rejects conflicting reuse of an ID, and persists the exact bytes under
 `.omd/deliberations/<id>.json`; clerical preservation does not transfer authorship to the coordinator.
+
+The moderator receives and returns this exact closed key shape; replace angle-bracket strings with
+the bounded values from its prompt, add no keys, and return JSON only:
+
+```json
+{
+  "schema": "design-deliberation-v1",
+  "id": "<kebab-case-deliberation-id>",
+  "decisionId": "<existing-kebab-case-decision-id>",
+  "trigger": "<specific high-impact fork>",
+  "moderator": "omd-eye",
+  "perspectives": {
+    "ux": {
+      "inputSha256": "<same-64-lowercase-hex>",
+      "position": "<plain-string-position>",
+      "evidence": ["<bounded-evidence-reference>"],
+      "objections": [],
+      "conditions": []
+    },
+    "artDirection": {
+      "inputSha256": "<same-64-lowercase-hex>",
+      "position": "<plain-string-position>",
+      "evidence": ["<bounded-evidence-reference>"],
+      "objections": [],
+      "conditions": []
+    },
+    "production": {
+      "inputSha256": "<same-64-lowercase-hex>",
+      "position": "<plain-string-position>",
+      "evidence": ["<bounded-evidence-reference>"],
+      "objections": [],
+      "conditions": []
+    }
+  },
+  "resolution": {
+    "selected": "<alternative-id>",
+    "rationale": "<evidence-and-constraint-based-resolution>",
+    "conditions": ["<binding-condition>"]
+  }
+}
+```
+
+`position` is one non-empty string, not an object. Each perspective uses the key `evidence`, not
+`evidenceReferences`. There is no top-level `inputSha256`, perspective `lens`, or other metadata.
+The coordinator must paste this literal contract into every moderator task rather than asking the
+eye to infer it from prose.
 For the pre-composition art-direction decision, a host-issued invocation remains the publication
 lane. In an ordinary Codex or Claude session without that launcher receipt, the same three
 perspectives plus moderator bind the exact three register alternatives and selected register.

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -162,8 +162,10 @@ reason to stop the design. When the launcher supplied the activation, use the ho
 `omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
 lane: hash the exact three direction alternatives, spawn fresh `oh-my-design:eye` UX, art-direction, and
 production perspectives concurrently with those identical bytes, then a fourth fresh `oh-my-design:eye`
-moderator. The eye is intentionally read-only: it returns the closed JSON and never writes the
-artifact itself. Copy that JSON byte-for-byte, without its Markdown fence and without editing or
+moderator. Paste the literal closed `design-deliberation-v1` key skeleton from
+`protocol/design-deliberation.md` into the moderator task; never ask it to infer the schema from
+prose. The eye is intentionally read-only: it returns the closed JSON and never writes the artifact
+itself. Copy that JSON byte-for-byte, without its Markdown fence and without editing or
 paraphrasing, to `.omd/.cache/art-direction-moderator.json`, then run
 `omd deliberate preserve --input .omd/.cache/art-direction-moderator.json`. This validated clerical
 persistence is not coordinator authorship. Its three `inputSha256` values must equal the alternatives
@@ -388,11 +390,13 @@ For L4, composition does not advance directly to sketches. Take each high/critic
 and spawn three fresh `oh-my-design:eye` contexts concurrently in UX, art-direction, and production
 perspective modes. Give all three the identical sanitized alternatives and input bytes; give none
 another perspective's output or authorship. Then spawn a fourth fresh `oh-my-design:eye` as moderator with
-only the three completed records, alternatives, and shared input digest. Majority vote is forbidden:
-the moderator resolves objections against evidence and constraints and returns one closed
-`design-deliberation-v1` JSON record. A read-only moderator response is the required success path,
-not a permission blocker. Copy its JSON byte-for-byte without the Markdown fence to a cache input,
-then run `omd deliberate preserve --input <cache-moderator.json>`; never ask the eye to write and
+only the three completed records, alternatives, shared input digest, and the literal exact-key
+`design-deliberation-v1` skeleton from `protocol/design-deliberation.md`. The moderator must fill
+that skeleton, add no keys, use a plain string for each `position`, and return JSON only. Majority
+vote is forbidden: the moderator resolves objections against evidence and constraints. A read-only
+moderator response is the required success path, not a permission blocker. Copy its JSON
+byte-for-byte without the Markdown fence to a cache input, then run
+`omd deliberate preserve --input <cache-moderator.json>`; never ask the eye to write and
 never recreate its fields yourself. The command validates ownership and preserves that exact record
 under `.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
 return to the composer to revise `.omd/composition.md` and its owner-authored decision entry, then

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -162,8 +162,10 @@ reason to stop the design. When the launcher supplied the activation, use the ho
 `omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
 lane: hash the exact three direction alternatives, spawn fresh `omd-eye` UX, art-direction, and
 production perspectives concurrently with those identical bytes, then a fourth fresh `omd-eye`
-moderator. The eye is intentionally read-only: it returns the closed JSON and never writes the
-artifact itself. Copy that JSON byte-for-byte, without its Markdown fence and without editing or
+moderator. Paste the literal closed `design-deliberation-v1` key skeleton from
+`protocol/design-deliberation.md` into the moderator task; never ask it to infer the schema from
+prose. The eye is intentionally read-only: it returns the closed JSON and never writes the artifact
+itself. Copy that JSON byte-for-byte, without its Markdown fence and without editing or
 paraphrasing, to `.omd/.cache/art-direction-moderator.json`, then run
 `omd deliberate preserve --input .omd/.cache/art-direction-moderator.json`. This validated clerical
 persistence is not coordinator authorship. Its three `inputSha256` values must equal the alternatives
@@ -388,11 +390,13 @@ For L4, composition does not advance directly to sketches. Take each high/critic
 and spawn three fresh `omd-eye` contexts concurrently in UX, art-direction, and production
 perspective modes. Give all three the identical sanitized alternatives and input bytes; give none
 another perspective's output or authorship. Then spawn a fourth fresh `omd-eye` as moderator with
-only the three completed records, alternatives, and shared input digest. Majority vote is forbidden:
-the moderator resolves objections against evidence and constraints and returns one closed
-`design-deliberation-v1` JSON record. A read-only moderator response is the required success path,
-not a permission blocker. Copy its JSON byte-for-byte without the Markdown fence to a cache input,
-then run `omd deliberate preserve --input <cache-moderator.json>`; never ask the eye to write and
+only the three completed records, alternatives, shared input digest, and the literal exact-key
+`design-deliberation-v1` skeleton from `protocol/design-deliberation.md`. The moderator must fill
+that skeleton, add no keys, use a plain string for each `position`, and return JSON only. Majority
+vote is forbidden: the moderator resolves objections against evidence and constraints. A read-only
+moderator response is the required success path, not a permission blocker. Copy its JSON
+byte-for-byte without the Markdown fence to a cache input, then run
+`omd deliberate preserve --input <cache-moderator.json>`; never ask the eye to write and
 never recreate its fields yourself. The command validates ownership and preserves that exact record
 under `.omd/deliberations/<id>.json`. If its resolution differs from the composer's selected alternative,
 return to the composer to revise `.omd/composition.md` and its owner-authored decision entry, then

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -881,6 +881,10 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(protocol, /same concrete model and identical prompt bytes/);
   assert.match(protocol, /`omd art-direction local-check` accepts only that moderator-owned receipt/);
   assert.match(protocol, /The eye is intentionally read-only/);
+  assert.match(protocol, /"id": "<kebab-case-deliberation-id>"/);
+  assert.match(protocol, /"decisionId": "<existing-kebab-case-decision-id>"/);
+  assert.match(protocol, /`position` is one non-empty string, not an object/);
+  assert.match(protocol, /There is no top-level `inputSha256`, perspective `lens`, or other metadata/);
 
   const skill = read('src/skills/omd-ultradesign/SKILL.md').replace(/\s+/g, ' ');
   assert.match(skill, /`omd depth classify --input \.omd\/depth\.json --json`/);
@@ -892,6 +896,8 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /do not attempt or claim v2 publication/);
   assert.match(skill, /`omd deliberate preserve --input/);
   assert.match(skill, /A read-only moderator response is the required success path/);
+  assert.match(skill, /Paste the literal closed `design-deliberation-v1` key skeleton/);
+  assert.match(skill, /use a plain string for each `position`, and return JSON only/);
 
   const framer = read('src/agents/framer.agent.yaml').replace(/\s+/g, ' ');
   assert.match(framer, /You also own `\.omd\/acquisition-plan\.json`/);


### PR DESCRIPTION
## Summary
- publish the exact closed design-deliberation receipt shape in the protocol
- require coordinator prompts to paste the literal skeleton into every moderator task
- forbid the extra keys and nested positions observed in the Terra smoke run

## Verification
- node --test --experimental-strip-types test/deliberation-preserve.test.ts test/deliberation-runtime.test.ts test/prompt-contract.test.ts
- npx tsc --noEmit
- npm run build