### PR TITLE
fix: validate reference principles before board assembly

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -108,8 +108,13 @@ explicit decline per user reference, merge duplicate primitives, and never let i
 tokens substitute for applicable layout or visual evidence. Include only stable source
 keys/labels, trust, uncertainty, destination criteria, and mobile coverage; keep source
 identity scout-side and pass downstream only sanitized records.
-Record accepted evidence with `omd ref principles`. Never pass raw URLs, screenshots, pixels,
-or source-page descriptions to composer, hand, or eye. Record the navigation model, density,
+Record accepted evidence with `omd ref principles`. That command validates the final transfer
+sanitizer before writing. If it returns `REF-PRINCIPLE-UNSAFE`, rewrite the same observed rule
+without URLs, filesystem-like text, source IDs, or slash-separated choice labels (write
+`Korean and English`, not `Korean/English`) and rerun the principle command. This wording repair
+is not a capture repair batch. Never continue to board authoring after a failed principle command.
+Never pass raw URLs, screenshots, pixels, or source-page descriptions to composer, hand, or eye.
+Record the navigation model, density,
 and state behavior. Only for an applicable list-detail workspace, apply the canonical
 non-primary-object identity and object-local-state evidence boundary in
 `protocol/human-design-loop.md`. Separately, only for an applicable support-ticket conversation,

--- a/core/ref/store.ts
+++ b/core/ref/store.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import type { Invariants, Reference } from '../types.ts';
 import { type ProjectWriteAdapter, requireProjectWriteAdapter } from '../runtime/project-write.ts';
+import { hasAssemblyPayload } from './board-sanitization.ts';
 
 /** Backfills invariants written before typography/motion/interaction measurement existed. */
 function withInvariantDefaults(invariants: Invariants | null | undefined): Invariants | null {
@@ -117,6 +118,15 @@ export function addPrinciples(
   const path = join(refsDir(cwd), `${slugFor({ source, component })}.json`);
   if (!existsSync(path)) {
     throw new Error(`no reference found for ${source} (${component})`);
+  }
+
+  for (const principle of principles) {
+    if (principle.trim() === '' || hasAssemblyPayload(principle)) {
+      throw new Error(
+        'REF-PRINCIPLE-UNSAFE: principles must be non-empty sanitized design rules without URLs, '
+        + 'filesystem paths, source IDs, or slash-separated labels; write choice pairs with words such as "and"',
+      );
+    }
   }
 
   const ref = JSON.parse(readFileSync(path, 'utf8')) as Reference;

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -116,8 +116,13 @@ instructions: |
   tokens substitute for applicable layout or visual evidence. Include only stable source
   keys/labels, trust, uncertainty, destination criteria, and mobile coverage; keep source
   identity scout-side and pass downstream only sanitized records.
-  Record accepted evidence with `omd ref principles`. Never pass raw URLs, screenshots, pixels,
-  or source-page descriptions to composer, hand, or eye. Record the navigation model, density,
+  Record accepted evidence with `omd ref principles`. That command validates the final transfer
+  sanitizer before writing. If it returns `REF-PRINCIPLE-UNSAFE`, rewrite the same observed rule
+  without URLs, filesystem-like text, source IDs, or slash-separated choice labels (write
+  `Korean and English`, not `Korean/English`) and rerun the principle command. This wording repair
+  is not a capture repair batch. Never continue to board authoring after a failed principle command.
+  Never pass raw URLs, screenshots, pixels, or source-page descriptions to composer, hand, or eye.
+  Record the navigation model, density,
   and state behavior. Only for an applicable list-detail workspace, apply the canonical
   non-primary-object identity and object-local-state evidence boundary in
   `protocol/human-design-loop.md`. Separately, only for an applicable support-ticket conversation,

--- a/test/principles.test.ts
+++ b/test/principles.test.ts
@@ -67,6 +67,29 @@ test('omd ref principles wires the same behaviour through the CLI', () => {
   assert.match(must(must(loadRefs(dir)[0]).principles[0]), /emphasis only/);
 });
 
+test('principles reject transfer-unsafe text before persistence and explain safe wording', () => {
+  const dir = project();
+  saveRef(dir, ref(), createTestProjectWriteAdapter(dir));
+  const unsafe = 'Keep Korean/English and light/dark choices in one stable band.';
+  assert.throws(
+    () => addPrinciples(dir, 'https://linear.app', 'page', [unsafe], createTestProjectWriteAdapter(dir)),
+    /REF-PRINCIPLE-UNSAFE[\s\S]*slash-separated labels/,
+  );
+  assert.deepEqual(must(loadRefs(dir)[0]).principles, []);
+
+  const cli = run(['ref', 'principles', 'https://linear.app', '--as', 'page', '--add', unsafe], dir);
+  assert.equal(cli.status, 1);
+  assert.match(cli.stderr, /write choice pairs with words such as "and"/);
+  assert.deepEqual(must(loadRefs(dir)[0]).principles, []);
+
+  const safe = run([
+    'ref', 'principles', 'https://linear.app', '--as', 'page', '--add',
+    'Keep Korean and English choices with light and dark appearance controls in one stable band.',
+  ], dir);
+  assert.equal(safe.status, 0, safe.stderr);
+  assert.equal(must(loadRefs(dir)[0]).principles.length, 1);
+});
+
 test('omd ref principles needs something to add', () => {
   const dir = project();
   saveRef(dir, ref(), createTestProjectWriteAdapter(dir));

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -835,6 +835,9 @@ test('scout batches zone-bound captures without debugging browser transport', ()
   assert.match(scout, /`omd ref board --input <candidate-assemblies\.json>`/);
   assert.match(scout, /Do not guess or hand-write the internal board schema/);
   assert.match(scout, /requires every candidate to cover every required acquisition zone/);
+  assert.match(scout, /If it returns `REF-PRINCIPLE-UNSAFE`, rewrite the same observed rule/);
+  assert.match(scout, /This wording repair is not a capture repair batch/);
+  assert.match(scout, /Never continue to board authoring after a failed principle command/);
   const batch = read('core/ref/batch.ts');
   assert.match(batch, /slot\?: string/);
   assert.match(batch, /spec\.slot \? \{ slot: spec\.slot \}/);


### PR DESCRIPTION
## Summary
- reject unsafe transfer principles at the owning CLI write instead of failing later during board assembly
- preserve the reference unchanged on validation failure with actionable wording guidance
- teach scout that wording repair does not consume the capture repair batch

## Verification
- node --test --experimental-strip-types test/principles.test.ts test/ref-board-transfer.test.ts test/prompt-contract.test.ts
- npx tsc --noEmit
- npm run build