### PR TITLE
fix: restore full verification integrity

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -1725,7 +1725,11 @@ async function cmdRecipe(mode: string | undefined, opts: Opts): Promise<never> {
   }
 
   const outDir = opts.out ?? join(process.cwd(), 'src', 'omd');
-  const result = installRecipe(packRoot, name, { stack, outDir });
+  const result = installRecipe(packRoot, name, {
+    stack,
+    outDir,
+    writer: projectWriterFromActivation(opts, 'omd recipe add'),
+  });
   if (opts.json) process.stdout.write(JSON.stringify(result));
   else {
     for (const path of result.written) console.log(`installed ${relative(process.cwd(), path)}`);

--- a/core/recipe/store.ts
+++ b/core/recipe/store.ts
@@ -3,10 +3,11 @@
 // The pack ships with OMD (`omd pack dir`), so nothing here reaches the network or a third-party
 // registry: the assets are OMD's own, versioned with the plugin.
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { parseRecipe, type ParsedRecipe, type RecipeFamily } from './parse.ts';
 import { materializeRecipe, type MaterializeResult, type Stack } from './materialize.ts';
+import type { ProjectWriteAdapter } from '../runtime/project-write.ts';
 
 /** Pack-relative directory for each recipe family. */
 export const FAMILY_DIRS: Readonly<Record<RecipeFamily, string>> = {
@@ -51,6 +52,18 @@ export function loadRecipe(packRoot: string, name: string): ParsedRecipe {
 
 export type InstallResult = MaterializeResult & { readonly written: readonly string[] };
 
+function canonicalOutputDirectory(input: string): string {
+  const unresolved: string[] = [];
+  let existing = resolve(input);
+  while (!existsSync(existing)) {
+    unresolved.unshift(basename(existing));
+    const parent = dirname(existing);
+    if (parent === existing) throw new Error(`recipe output has no existing ancestor: ${input}`);
+    existing = parent;
+  }
+  return join(realpathSync(existing), ...unresolved);
+}
+
 /**
  * Materializes a recipe and writes its files under `outDir`. Returns the absolute paths written
  * alongside the dependency and note list, so the caller can report exactly what landed.
@@ -58,17 +71,15 @@ export type InstallResult = MaterializeResult & { readonly written: readonly str
 export function installRecipe(
   packRoot: string,
   name: string,
-  opts: { readonly stack: Stack; readonly outDir: string },
+  opts: { readonly stack: Stack; readonly outDir: string; readonly writer: ProjectWriteAdapter },
 ): InstallResult {
   const recipe = loadRecipe(packRoot, name);
   const result = materializeRecipe(recipe, { stack: opts.stack });
-  const dir = resolve(opts.outDir);
-  mkdirSync(dir, { recursive: true });
-  const written: string[] = [];
-  for (const file of result.files) {
-    const path = join(dir, file.path);
-    writeFileSync(path, file.contents);
-    written.push(path);
+  const dir = canonicalOutputDirectory(opts.outDir);
+  const fromProject = relative(opts.writer.projectRoot, dir);
+  if (fromProject === '..' || fromProject.startsWith('../') || isAbsolute(fromProject)) {
+    throw new Error(`recipe output must stay under the guarded project root: ${opts.writer.projectRoot}`);
   }
+  const written = result.files.map((file) => opts.writer.write(join(fromProject, file.path), file.contents));
   return { ...result, written };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
-        "playwright": "^1.61.1",
+        "playwright": "1.61.1",
         "smol-toml": "^1.3.0",
         "tsx": "^4.23.1",
         "yaml": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "release:prep": "node scripts/bump.ts"
   },
   "dependencies": {
-    "playwright": "^1.61.1",
+    "playwright": "1.61.1",
     "smol-toml": "^1.3.0",
     "tsx": "^4.23.1",
     "yaml": "^2.6.0"

--- a/test/graphics-cookbook.test.ts
+++ b/test/graphics-cookbook.test.ts
@@ -19,7 +19,7 @@ const REQUIRED_HEADINGS = [
   '## Do not combine with',
 ];
 
-// ── Exactly 6 recipe files ────────────────────────────────────────────────────
+// ── Six parameterized recipe files; protocol notes may live beside them ─────────────────────────
 const EXPECTED_RECIPES = [
   'gradient-mesh.md',
   'noise-grain-texture.md',
@@ -40,13 +40,11 @@ test('all 6 expected graphics recipe files exist', () => {
   }
 });
 
-test('graphics directory contains exactly 6 .md files', () => {
-  const files = readdirSync(recipesDir).filter((f) => f.endsWith('.md'));
-  assert.equal(
-    files.length,
-    6,
-    `expected 6 graphics recipe files, found ${files.length}: ${files.join(', ')}`
-  );
+test('graphics directory contains exactly the six parameterized recipe files', () => {
+  const files = readdirSync(recipesDir)
+    .filter((file) => file.endsWith('.md') && file !== 'photo-sourcing.md')
+    .sort();
+  assert.deepEqual(files, [...EXPECTED_RECIPES].sort());
 });
 
 // ── Each recipe contains all five required sections ───────────────────────────

--- a/test/no-js-content.test.ts
+++ b/test/no-js-content.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
+import { createTestProjectWriteAdapter } from './helpers/project-write.ts';
 import {
   NO_JS_HIDDEN_BLOCK_FLOOR,
   checkNoJsContent,
@@ -44,7 +45,11 @@ test('the installed scroll-reveal recipe does not gate content behind JavaScript
   const { join } = await import('node:path');
   const pack = fileURLToPath(new URL('../core/', import.meta.url));
   const out = mkdtempSync(join(tmpdir(), 'omd-nojs-'));
-  installRecipe(pack, 'scroll-reveal', { stack: 'vanilla', outDir: out });
+  installRecipe(pack, 'scroll-reveal', {
+    stack: 'vanilla',
+    outDir: out,
+    writer: createTestProjectWriteAdapter(out),
+  });
   const css = readFileSync(join(out, 'scroll-reveal.css'), 'utf8');
   const js = readFileSync(join(out, 'scroll-reveal.js'), 'utf8');
   const page = join(out, 'index.html');

--- a/test/packed-playwright.test.ts
+++ b/test/packed-playwright.test.ts
@@ -14,7 +14,7 @@ interface PackedPackage {
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const PLAYWRIGHT_RANGE = '^1.61.1';
+const PLAYWRIGHT_RANGE = '1.61.1';
 const PROBE_FIXTURE = fileURLToPath(new URL('./fixtures/probe.html', import.meta.url));
 const RENDER_FIXTURE = fileURLToPath(new URL('./fixtures/slop.html', import.meta.url));
 const WORKSPACE_DEPENDENCIES = ['playwright', 'playwright-core', 'smol-toml', 'yaml'] as const;

--- a/test/recipe-installed-motion.test.ts
+++ b/test/recipe-installed-motion.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { installRecipe } from '../core/recipe/store.ts';
 import { captureReferenceCraft } from '../core/ref/reference-craft-capture.ts';
 import { checkCraftUsage } from '../core/ref/craft-usage.ts';
+import { createTestProjectWriteAdapter } from './helpers/project-write.ts';
 
 const PACK = fileURLToPath(new URL('../core/', import.meta.url));
 
@@ -20,7 +21,11 @@ const PACK = fileURLToPath(new URL('../core/', import.meta.url));
  */
 test('an installed scroll-reveal recipe reads as real scroll-linked motion in a browser', async () => {
   const out = mkdtempSync(join(tmpdir(), 'omd-installed-'));
-  const result = installRecipe(PACK, 'scroll-reveal', { stack: 'vanilla', outDir: out });
+  const result = installRecipe(PACK, 'scroll-reveal', {
+    stack: 'vanilla',
+    outDir: out,
+    writer: createTestProjectWriteAdapter(out),
+  });
   const css = readFileSync(join(out, 'scroll-reveal.css'), 'utf8');
   const js = readFileSync(join(out, 'scroll-reveal.js'), 'utf8');
   assert.ok(result.written.length >= 2, 'css and js must both land');

--- a/test/recipe-materialize.test.ts
+++ b/test/recipe-materialize.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { parseRecipe, RecipeParseError } from '../core/recipe/parse.ts';
 import { materializeRecipe, MaterializeError } from '../core/recipe/materialize.ts';
 import { installRecipe, listRecipes, loadRecipe, RecipeNotFoundError } from '../core/recipe/store.ts';
+import { createTestProjectWriteAdapter } from './helpers/project-write.ts';
 
 const PACK = fileURLToPath(new URL('../core/', import.meta.url));
 
@@ -74,10 +75,23 @@ test('a recipe with no installable code on a stack raises rather than emitting a
 
 test('installRecipe writes the files to disk and reports what landed', () => {
   const out = mkdtempSync(join(tmpdir(), 'omd-recipe-'));
-  const result = installRecipe(PACK, 'scroll-reveal', { stack: 'vanilla', outDir: out });
+  const result = installRecipe(PACK, 'scroll-reveal', {
+    stack: 'vanilla',
+    outDir: out,
+    writer: createTestProjectWriteAdapter(out),
+  });
   assert.equal(result.written.length, result.files.length);
   for (const path of result.written) {
     assert.ok(readFileSync(path, 'utf8').length > 0, `${path} must not be empty`);
   }
-  assert.throws(() => installRecipe(PACK, 'no-such-recipe', { stack: 'vanilla', outDir: out }), RecipeNotFoundError);
+  assert.throws(() => installRecipe(PACK, 'no-such-recipe', {
+    stack: 'vanilla',
+    outDir: out,
+    writer: createTestProjectWriteAdapter(out),
+  }), RecipeNotFoundError);
+  assert.throws(() => installRecipe(PACK, 'scroll-reveal', {
+    stack: 'vanilla',
+    outDir: join(out, '..', 'recipe-escape'),
+    writer: createTestProjectWriteAdapter(out),
+  }), /guarded project root/);
 });


### PR DESCRIPTION
## Summary
- route recipe installation through the guarded project writer and reject output escapes
- pin Playwright to the actually published runtime pair used by packed installs
- distinguish graphics recipes from colocated sourcing protocol notes

## Verification
- npm test: 1721 pass, 0 fail, 1 skip
- npx tsc --noEmit
- npm run build