### PR TITLE
fix: authenticate recipe project writers

### DIFF
--- a/core/recipe/store.ts
+++ b/core/recipe/store.ts
@@ -7,7 +7,7 @@ import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { parseRecipe, type ParsedRecipe, type RecipeFamily } from './parse.ts';
 import { materializeRecipe, type MaterializeResult, type Stack } from './materialize.ts';
-import type { ProjectWriteAdapter } from '../runtime/project-write.ts';
+import { requireProjectWriteAdapter, type ProjectWriteAdapter } from '../runtime/project-write.ts';
 
 /** Pack-relative directory for each recipe family. */
 export const FAMILY_DIRS: Readonly<Record<RecipeFamily, string>> = {
@@ -75,11 +75,12 @@ export function installRecipe(
 ): InstallResult {
   const recipe = loadRecipe(packRoot, name);
   const result = materializeRecipe(recipe, { stack: opts.stack });
+  const writer = requireProjectWriteAdapter(opts.writer.projectRoot, opts.writer);
   const dir = canonicalOutputDirectory(opts.outDir);
-  const fromProject = relative(opts.writer.projectRoot, dir);
+  const fromProject = relative(writer.projectRoot, dir);
   if (fromProject === '..' || fromProject.startsWith('../') || isAbsolute(fromProject)) {
-    throw new Error(`recipe output must stay under the guarded project root: ${opts.writer.projectRoot}`);
+    throw new Error(`recipe output must stay under the guarded project root: ${writer.projectRoot}`);
   }
-  const written = result.files.map((file) => opts.writer.write(join(fromProject, file.path), file.contents));
+  const written = result.files.map((file) => writer.write(join(fromProject, file.path), file.contents));
   return { ...result, written };
 }

--- a/test/packed-playwright.test.ts
+++ b/test/packed-playwright.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,7 +14,7 @@ interface PackedPackage {
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const PLAYWRIGHT_RANGE = '1.61.1';
+const PLAYWRIGHT_VERSION = '1.61.1';
 const PROBE_FIXTURE = fileURLToPath(new URL('./fixtures/probe.html', import.meta.url));
 const RENDER_FIXTURE = fileURLToPath(new URL('./fixtures/slop.html', import.meta.url));
 const WORKSPACE_DEPENDENCIES = ['playwright', 'playwright-core', 'smol-toml', 'yaml'] as const;
@@ -95,7 +95,7 @@ test('Given a packed release When an isolated consumer installs it Then Playwrig
     mkdirSync(packs);
     const rootPackage = pack(packs);
     const packedManifest = manifestFromTarball(rootPackage.archive);
-    assert.equal(dependencyRecord(packedManifest, 'dependencies')['playwright'], PLAYWRIGHT_RANGE);
+    assert.equal(dependencyRecord(packedManifest, 'dependencies')['playwright'], PLAYWRIGHT_VERSION);
     assert.equal(optionalRecord(packedManifest['devDependencies'], 'devDependencies')?.['playwright'], undefined);
 
     installTarballWithoutScripts(rootPackage.archive, packedRuntime);

--- a/test/recipe-materialize.test.ts
+++ b/test/recipe-materialize.test.ts
@@ -75,10 +75,11 @@ test('a recipe with no installable code on a stack raises rather than emitting a
 
 test('installRecipe writes the files to disk and reports what landed', () => {
   const out = mkdtempSync(join(tmpdir(), 'omd-recipe-'));
+  const writer = createTestProjectWriteAdapter(out);
   const result = installRecipe(PACK, 'scroll-reveal', {
     stack: 'vanilla',
     outDir: out,
-    writer: createTestProjectWriteAdapter(out),
+    writer,
   });
   assert.equal(result.written.length, result.files.length);
   for (const path of result.written) {
@@ -87,11 +88,21 @@ test('installRecipe writes the files to disk and reports what landed', () => {
   assert.throws(() => installRecipe(PACK, 'no-such-recipe', {
     stack: 'vanilla',
     outDir: out,
-    writer: createTestProjectWriteAdapter(out),
+    writer,
   }), RecipeNotFoundError);
   assert.throws(() => installRecipe(PACK, 'scroll-reveal', {
     stack: 'vanilla',
     outDir: join(out, '..', 'recipe-escape'),
-    writer: createTestProjectWriteAdapter(out),
+    writer,
   }), /guarded project root/);
+  const forged = {
+    projectRoot: out,
+    mkdir: (path: string) => path,
+    write: (path: string) => path,
+  };
+  assert.throws(() => installRecipe(PACK, 'scroll-reveal', {
+    stack: 'vanilla',
+    outDir: out,
+    writer: forged,
+  }), /trusted active project-write adapter/);
 });


### PR DESCRIPTION
## Summary
- authenticate the injected recipe writer through the runtime WeakSet trust boundary
- reject structurally forged writer objects before any recipe mutation
- clean the exact Playwright version assertion

## Verification
- node --test --experimental-strip-types test/recipe-materialize.test.ts test/runtime-isolation.test.ts test/packed-playwright.test.ts
- npx tsc --noEmit
- npm run build