### PR TITLE
fix: align scout role skill bootstrap

### DIFF
--- a/agents/scout.md
+++ b/agents/scout.md
@@ -10,11 +10,15 @@ contamination, and transfer-boundary sections of `protocol/human-design-loop.md`
 file only when one acquisition zone directly needs it. Receive the concept, product, working
 directory, component inventory, explicit functions or product goal, surface classification, and
 any user URLs. Run all commands from that directory. Capture user URLs first with `--from-user`.
-Acquisition comes before exhaustive reading. Your first operational pass is: (1) read only
-`.omd/domain-brief.json`, `.omd/frame.md`, `.omd/acquisition-plan.json`, and the two bounded
-protocol slices above; (2) run the supported browser doctor; (3) write the zone-bound manifest and
-start `omd ref add-batch`. Do not inspect the installed scout skill, every theory/cookbook file,
-`src/agents`, adapters, CLI implementation, or tests before that batch. Do not recursively inventory
+Acquisition comes before exhaustive reading. A host may require one initial read of the installed
+`oh-my-design:scout` skill because this child role matches that skill; that host-required bootstrap read is
+permitted but is not operational research. Do not act on a standalone-skill instruction that
+conflicts with this injected pipeline role, do not spawn another scout, and load no other skill.
+Immediately afterward, your first operational pass is: (1) read only `.omd/domain-brief.json`,
+`.omd/frame.md`, `.omd/acquisition-plan.json`, and the two bounded protocol slices above; (2) run
+the supported browser doctor; (3) write the zone-bound manifest and start `omd ref add-batch`.
+Do not otherwise inspect the installed scout skill, every theory/cookbook file, `src/agents`,
+adapters, CLI implementation, or tests before that batch. Do not recursively inventory
 packs or use image generation. After capture, read only the contract material needed to serialize
 `.omd/scout.md` and `.omd/reference-board.json`. This is an evidence role, not a repository-audit
 role; the coordinator already supplies the validated subject/domain facts.

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -19,6 +19,14 @@ A LEGO reference assembly, measured instead of pinned. Read
 their single owners, and their artifact/stop boundaries. This skill collects evidence and
 names transferable principles; it does not design or implement the result.
 
+## Pipeline-role bootstrap
+
+When this skill is loaded inside an already spawned `oh-my-design:scout` child that has injected role
+instructions, the injected role is authoritative for acquisition order, read bounds, fallbacks,
+and owned artifacts. This read only satisfies the host's skill bootstrap. Do not spawn another
+scout, do not broaden the standalone workflow, and immediately execute the injected role's first
+operational pass.
+
 Spawn `oh-my-design:scout` with the concept (ask one short question only when neither the request nor
 `.omd/frame.md` supplies one), the component inventory, working directory, and user URLs.
 User URLs are captured first and marked `--from-user`.

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -18,11 +18,15 @@ instructions: |
   file only when one acquisition zone directly needs it. Receive the concept, product, working
   directory, component inventory, explicit functions or product goal, surface classification, and
   any user URLs. Run all commands from that directory. Capture user URLs first with `--from-user`.
-  Acquisition comes before exhaustive reading. Your first operational pass is: (1) read only
-  `.omd/domain-brief.json`, `.omd/frame.md`, `.omd/acquisition-plan.json`, and the two bounded
-  protocol slices above; (2) run the supported browser doctor; (3) write the zone-bound manifest and
-  start `omd ref add-batch`. Do not inspect the installed scout skill, every theory/cookbook file,
-  `src/agents`, adapters, CLI implementation, or tests before that batch. Do not recursively inventory
+  Acquisition comes before exhaustive reading. A host may require one initial read of the installed
+  `omd-scout` skill because this child role matches that skill; that host-required bootstrap read is
+  permitted but is not operational research. Do not act on a standalone-skill instruction that
+  conflicts with this injected pipeline role, do not spawn another scout, and load no other skill.
+  Immediately afterward, your first operational pass is: (1) read only `.omd/domain-brief.json`,
+  `.omd/frame.md`, `.omd/acquisition-plan.json`, and the two bounded protocol slices above; (2) run
+  the supported browser doctor; (3) write the zone-bound manifest and start `omd ref add-batch`.
+  Do not otherwise inspect the installed scout skill, every theory/cookbook file, `src/agents`,
+  adapters, CLI implementation, or tests before that batch. Do not recursively inventory
   packs or use image generation. After capture, read only the contract material needed to serialize
   `.omd/scout.md` and `.omd/reference-board.json`. This is an evidence role, not a repository-audit
   role; the coordinator already supplies the validated subject/domain facts.

--- a/src/skills/omd-scout/SKILL.md
+++ b/src/skills/omd-scout/SKILL.md
@@ -19,6 +19,14 @@ A LEGO reference assembly, measured instead of pinned. Read
 their single owners, and their artifact/stop boundaries. This skill collects evidence and
 names transferable principles; it does not design or implement the result.
 
+## Pipeline-role bootstrap
+
+When this skill is loaded inside an already spawned `omd-scout` child that has injected role
+instructions, the injected role is authoritative for acquisition order, read bounds, fallbacks,
+and owned artifacts. This read only satisfies the host's skill bootstrap. Do not spawn another
+scout, do not broaden the standalone workflow, and immediately execute the injected role's first
+operational pass.
+
 Spawn `omd-scout` with the concept (ask one short question only when neither the request nor
 `.omd/frame.md` supplies one), the component inventory, working directory, and user URLs.
 User URLs are captured first and marked `--from-user`.

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -823,8 +823,13 @@ test('scout batches zone-bound captures without debugging browser transport', ()
   assert.match(scout, /\.site-page-title/);
   assert.match(scout, /Never request the nonexistent `designsystem\.digital\.gov\/components\/hero\/` page/);
   assert.match(scout, /Acquisition comes before exhaustive reading/);
-  assert.match(scout, /Do not inspect the installed scout skill, every theory\/cookbook file/);
+  assert.match(scout, /host-required bootstrap read is permitted but is not operational research/);
+  assert.match(scout, /Do not act on a standalone-skill instruction that conflicts with this injected pipeline role/);
+  assert.match(scout, /Do not otherwise inspect the installed scout skill, every theory\/cookbook file/);
   assert.match(scout, /start `omd ref add-batch`/);
+  const standaloneScout = read('src/skills/omd-scout/SKILL.md').replace(/\s+/g, ' ');
+  assert.match(standaloneScout, /When this skill is loaded inside an already spawned `omd-scout` child/);
+  assert.match(standaloneScout, /immediately execute the injected role's first operational pass/);
   assert.match(scout, /required `repository-cta` or `source-cta` zone first captures the user-supplied repository/);
   assert.match(scout, /#repository-container-header/);
   assert.match(scout, /designsystem\.digital\.gov\/components\/button/);


### PR DESCRIPTION
## Summary
- make host-required scout skill loading a bounded bootstrap
- keep injected scout role authoritative during the pipeline
- add prompt-contract coverage

## Verification
- node --test test/prompt-contract.test.ts
- npm run build