### PR TITLE
Unblock repeated art-direction resolution

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -38,7 +38,7 @@ import {
 import { beatBudgetForRegister, exceedsCanonicalBeatBudget, NO_CURRENT_USER_BEAT_EXCEPTION_RECEIPT_SHA256, recipeDecisionProjectionSha256, resolveMarketingArtDirection, type ApprovedMotionRecipeReceipt, type ArtDirectionEligibility } from '../core/art-direction/decision.ts';
 import { validateActivationContext } from '../core/runtime/activation.ts';
 import { createLocalCliInvocation, requireCurrentIntentLedgerAuthorization, requireCurrentUserIntentEventAuthorization, requireEvaluatorAssessmentAuthorization, requireEvaluatorResultAuthorization, requireFinalEvidenceManifestAuthorization, requireFinalReviewerLaneAuthorization, requireStaticEvidenceResultAuthorization, requireStaticReviewReceiptAuthorization, validateCurrentProjectRun, type ProjectRunInvocation } from '../core/runtime/invocation.ts';
-import { acquireProjectLock, createExternalObservationDirectory, createProjectWriteAdapter, replaceProjectFileAtomically, writeExternalObservationFile, writeImmutableProjectFile, type ExternalObservationKind, type ProjectWriteAdapter } from '../core/runtime/project-write.ts';
+import { acquireProjectLock, createExternalObservationDirectory, createProjectWriteAdapter, replaceProjectFileAtomically, writeContentAddressedProjectFile, writeExternalObservationFile, writeImmutableProjectFile, type ExternalObservationKind, type ProjectWriteAdapter } from '../core/runtime/project-write.ts';
 import { intentLedgerSha256, resolveCurrentUserBeatExceptionReceipt, serializeIntentLedger, validateIntentCurrentPointer, validateIntentLedger } from '../core/runtime/intent.ts';
 import { validateDecisionBoundReferenceHandoffs, validateReferenceHandoffCurrentness } from '../core/ref/reference-handoff.ts';
 import { parseReferenceSelectionV2, referenceSelectionV2Sha256, resolveMotionProjection, validatePreReferenceSelectionV2 } from '../core/ref/reference-selection.ts';
@@ -2083,9 +2083,22 @@ async function cmdIntent(mode: string | undefined, opts: Opts): Promise<never> {
 }
 
 async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode === 'alternatives-sha') {
+    if (!opts.input || opts._.length > 0) throw new Error('usage: omd art-direction alternatives-sha --input <alternatives.json> [--json]');
+    const payload = inputJson(opts.input, 'omd art-direction alternatives-sha');
+    const alternatives = Array.isArray(payload)
+      ? payload
+      : isRecord(payload) && Array.isArray(payload.alternatives)
+        ? payload.alternatives
+        : undefined;
+    if (alternatives === undefined) throw new Error('ART_DIRECTION_ALTERNATIVES_INVALID: input must be an alternatives array or contain an alternatives array');
+    const result = { alternativesSha256: sha256(canonicalJson(alternatives)) };
+    console.log(opts.json ? JSON.stringify(result) : result.alternativesSha256);
+    process.exit(0);
+  }
   const localMode = mode === 'local-check';
   if ((mode !== 'check' && !localMode) || !opts.input || opts._.length > 0) {
-    throw new Error('usage: omd art-direction check|local-check --input <decision-check.json> [--json]');
+    throw new Error('usage: omd art-direction check|local-check|alternatives-sha --input <json> [--json]');
   }
   const command = localMode ? 'omd art-direction local-check' : 'omd art-direction check';
   const payload = inputJson(opts.input, command);
@@ -2138,7 +2151,7 @@ async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<ne
     assessments: evaluatorAssessment.assessments,
   };
   const evaluatorResultDigest = sha256(resultBytes);
-  writeImmutableProjectFile({
+  writeContentAddressedProjectFile({
     projectRoot: process.cwd(),
     relativePath: `.omd/evaluator-results/sha256-${evaluatorResultDigest}.json`,
     content: resultBytes,
@@ -2157,7 +2170,7 @@ async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<ne
     if (!localMode) requireCurrentIntentLedgerAuthorization(run, process.cwd(), readFileSync(join(process.cwd(), '.omd', pointer.record)));
   } else {
     const record = `intent-runs/sha256-${intentSha256}.json`;
-    writeImmutableProjectFile({ projectRoot: process.cwd(), relativePath: `.omd/${record}`, content: JSON.stringify(ledger, null, 2), invocation: run });
+    writeContentAddressedProjectFile({ projectRoot: process.cwd(), relativePath: `.omd/${record}`, content: JSON.stringify(ledger, null, 2), invocation: run });
     replaceProjectFileAtomically({ projectRoot: process.cwd(), relativePath: '.omd/intent-current.json', content: JSON.stringify({ schemaVersion: INTENT_CURRENT_POINTER_SCHEMA_VERSION, record, sha256: intentSha256 }, null, 2), invocation: run });
   }
   const lock = resolveCurrentUserIntent(ledger);
@@ -2239,7 +2252,7 @@ async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<ne
   const record = { schemaVersion: ART_DIRECTION_RECORD_SCHEMA_VERSION, decision: checked, decisionSha256: artDirectionSha256(checked), referenceHandoffSha256: handoff.payloadSha256, intentLedgerSha256: intentSha256, activationSha256, beatIds: beats };
   const digest = artDirectionSha256(record);
   const recordPath = `art-direction-runs/sha256-${digest}.json`;
-  writeImmutableProjectFile({ projectRoot: process.cwd(), relativePath: `.omd/${recordPath}`, content: JSON.stringify(record, null, 2), invocation: run });
+  writeContentAddressedProjectFile({ projectRoot: process.cwd(), relativePath: `.omd/${recordPath}`, content: JSON.stringify(record, null, 2), invocation: run });
   const pointer = { schemaVersion: ART_DIRECTION_POINTER_SCHEMA_VERSION, record: recordPath, sha256: digest };
   const path = replaceProjectFileAtomically({ projectRoot: process.cwd(), relativePath: '.omd/art-direction.json', content: JSON.stringify(pointer, null, 2), invocation: run });
   const { writeReferenceHandoffReceipt } = await import('../core/ref/reference-handoff.ts');

--- a/core/runtime/project-write.ts
+++ b/core/runtime/project-write.ts
@@ -316,6 +316,26 @@ export function writeImmutableProjectFile(request: ProjectWriteRequest): string 
     return target;
   });
 }
+
+/**
+ * Persist a content-addressed immutable receipt idempotently. The digest is in the path, so a
+ * repeated write of the exact same bytes is the same receipt and must not fail a resumed run;
+ * different bytes under one address stay a hard error.
+ */
+export function writeContentAddressedProjectFile(request: ProjectWriteRequest): string {
+  try {
+    return writeImmutableProjectFile(request);
+  } catch (error) {
+    if (!(error instanceof ProjectWriteError) || !error.reason.startsWith('immutable project artifact already exists:')) throw error;
+    const target = resolveProjectPath(request.projectRoot, request.relativePath);
+    const existing = readFileSync(target);
+    const written = typeof request.content === 'string' ? Buffer.from(request.content, 'utf8') : Buffer.from(request.content);
+    if (!existing.equals(written)) {
+      throw new ProjectWriteError(`content-addressed artifact already exists with different bytes: ${request.relativePath}`);
+    }
+    return target;
+  }
+}
 function acquireRawProjectLock(request: ProjectLockRequest, content = ''): () => void {
   requireGuardedProjectWrite(request.projectRoot, request.invocation);
   const target = resolveProjectPath(request.projectRoot, request.relativePath);

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -173,7 +173,12 @@ prior explicit taste, which beats agent choices. Record conflicts.
 A normal Codex or Claude session may not carry a host-issued invocation/FD receipt. That is not a
 reason to stop the design. When the launcher supplied the activation, use the host-authorized
 `omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
-lane: hash the exact three direction alternatives, spawn fresh `oh-my-design:eye` UX, art-direction, and
+lane: persist the exact three direction alternatives, then run
+`omd art-direction alternatives-sha --input <alternatives.json> --json`. Use the returned
+`alternativesSha256` verbatim for every perspective, moderator, and evaluator result; never
+reimplement canonical JSON hashing in shell or ad-hoc JavaScript. A hash mismatch caused by
+coordinator-authored check input is a clerical preparation failure: correct it before launching
+roles rather than spending a role retry. Spawn fresh `oh-my-design:eye` UX, art-direction, and
 production perspectives concurrently with those identical bytes, then a fourth fresh `oh-my-design:eye`
 moderator. Paste the literal closed `design-deliberation-v1` key skeleton from
 `protocol/design-deliberation.md` into the moderator task; never ask it to infer the schema from
@@ -269,8 +274,12 @@ explicitly named still wins. Do not invoke composer, eye, or hand yet. Once each
 project-owned brief/copy/type/register/palette/material input has its normal clean check, the
 coordinator/host derives the two-to-three independent image-first art-direction directions directly
 from the selected assembly, the selected references, any project rough, and permitted project-owned
-inputs. It does not read `.omd/composition.md` or ask composer for a prompt. With image capability,
-generate the drafts concurrently and select one. Without capability, take the CSS/SVG path. Only then
+inputs. It does not read `.omd/composition.md` or ask composer for a prompt. Use image generation
+only when the selected direction materially benefits from a bitmap/raster draft. Typography-led,
+diagrammatic, vector, and other code-native directions take the CSS/SVG path even when an image
+tool is installed. When image generation is justified, start the drafts concurrently; if the batch
+does not complete within 120 seconds, cancel it, record the capability as unavailable for this run,
+and take the CSS/SVG path without retrying image generation. Only then
 invoke composer: pass its selected sanitized assembly plus the chosen draft, or the selected assembly
 plus the CSS/SVG evidence path on the fallback. Never pass raw records, source URLs, screenshots,
 pixels, or source-page prose.
@@ -381,15 +390,20 @@ media, explanatory graphics, real interaction/data, or concept-bearing typograph
 mandatory photo or invented fact/asset. When mechanism/material/workflow is central, Media
 roles assigns a lawful carrier or an explicit alternate non-media mental-model carrier with
 its limitation; `none because no approved photo` is insufficient.
-For the selected art-direction contract, the host/coordinator derives 2–3 independent image-first
+For the selected art-direction contract, the host/coordinator derives 2–3 independent art-direction
 directions from the committed palette/type/material, sanitized measured principles, the selected
 references, any project rough, and other permitted project-owned inputs before composer starts.
-The host/coordinator owns concurrent draft generation, cache management, and blind selection. The
-composer may consume only the coordinator-chosen draft as art-direction input. Composer neither
-generates nor supplies/revises prompts, inspects raw source material, manages the cache, or selects
-a draft. Drafts are design references, never shipped page assets; `omd ref distance` still reports
-fidelity as an advisory signal. When image capability is unavailable, use the selected sanitized
-assembly and CSS/SVG graphics recipes while still implementing the selected macro visual system.
+Use image-first drafts only when the selected direction materially benefits from bitmap/raster
+exploration; typography-led, diagrammatic, vector, and other code-native systems use CSS/SVG
+evidence instead. The host/coordinator owns concurrent image draft generation,
+cache management, and blind selection. The composer may consume only the
+coordinator-chosen draft as art-direction input. Composer neither generates nor supplies/revises
+prompts, inspects raw source material, manages the cache, or selects a draft.
+Drafts are design references, never shipped page assets;
+`omd ref distance` still reports fidelity as an advisory signal. Bound the whole concurrent image
+batch to 120 seconds. On timeout or tool failure, cancel outstanding generation, do not retry, and
+use the selected sanitized assembly and CSS/SVG graphics recipes while still implementing the
+selected macro visual system.
 
 Run `omd composition --check`. Missing sections, malformed fingerprints, or stale inputs
 stop divergence and return to the composer. A later change to frame, copy, type proof, or

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -173,7 +173,12 @@ prior explicit taste, which beats agent choices. Record conflicts.
 A normal Codex or Claude session may not carry a host-issued invocation/FD receipt. That is not a
 reason to stop the design. When the launcher supplied the activation, use the host-authorized
 `omd art-direction check` path above. When no activation was supplied, use the moderator-bound local
-lane: hash the exact three direction alternatives, spawn fresh `omd-eye` UX, art-direction, and
+lane: persist the exact three direction alternatives, then run
+`omd art-direction alternatives-sha --input <alternatives.json> --json`. Use the returned
+`alternativesSha256` verbatim for every perspective, moderator, and evaluator result; never
+reimplement canonical JSON hashing in shell or ad-hoc JavaScript. A hash mismatch caused by
+coordinator-authored check input is a clerical preparation failure: correct it before launching
+roles rather than spending a role retry. Spawn fresh `omd-eye` UX, art-direction, and
 production perspectives concurrently with those identical bytes, then a fourth fresh `omd-eye`
 moderator. Paste the literal closed `design-deliberation-v1` key skeleton from
 `protocol/design-deliberation.md` into the moderator task; never ask it to infer the schema from
@@ -269,8 +274,12 @@ explicitly named still wins. Do not invoke composer, eye, or hand yet. Once each
 project-owned brief/copy/type/register/palette/material input has its normal clean check, the
 coordinator/host derives the two-to-three independent image-first art-direction directions directly
 from the selected assembly, the selected references, any project rough, and permitted project-owned
-inputs. It does not read `.omd/composition.md` or ask composer for a prompt. With image capability,
-generate the drafts concurrently and select one. Without capability, take the CSS/SVG path. Only then
+inputs. It does not read `.omd/composition.md` or ask composer for a prompt. Use image generation
+only when the selected direction materially benefits from a bitmap/raster draft. Typography-led,
+diagrammatic, vector, and other code-native directions take the CSS/SVG path even when an image
+tool is installed. When image generation is justified, start the drafts concurrently; if the batch
+does not complete within 120 seconds, cancel it, record the capability as unavailable for this run,
+and take the CSS/SVG path without retrying image generation. Only then
 invoke composer: pass its selected sanitized assembly plus the chosen draft, or the selected assembly
 plus the CSS/SVG evidence path on the fallback. Never pass raw records, source URLs, screenshots,
 pixels, or source-page prose.
@@ -381,15 +390,20 @@ media, explanatory graphics, real interaction/data, or concept-bearing typograph
 mandatory photo or invented fact/asset. When mechanism/material/workflow is central, Media
 roles assigns a lawful carrier or an explicit alternate non-media mental-model carrier with
 its limitation; `none because no approved photo` is insufficient.
-For the selected art-direction contract, the host/coordinator derives 2–3 independent image-first
+For the selected art-direction contract, the host/coordinator derives 2–3 independent art-direction
 directions from the committed palette/type/material, sanitized measured principles, the selected
 references, any project rough, and other permitted project-owned inputs before composer starts.
-The host/coordinator owns concurrent draft generation, cache management, and blind selection. The
-composer may consume only the coordinator-chosen draft as art-direction input. Composer neither
-generates nor supplies/revises prompts, inspects raw source material, manages the cache, or selects
-a draft. Drafts are design references, never shipped page assets; `omd ref distance` still reports
-fidelity as an advisory signal. When image capability is unavailable, use the selected sanitized
-assembly and CSS/SVG graphics recipes while still implementing the selected macro visual system.
+Use image-first drafts only when the selected direction materially benefits from bitmap/raster
+exploration; typography-led, diagrammatic, vector, and other code-native systems use CSS/SVG
+evidence instead. The host/coordinator owns concurrent image draft generation,
+cache management, and blind selection. The composer may consume only the
+coordinator-chosen draft as art-direction input. Composer neither generates nor supplies/revises
+prompts, inspects raw source material, manages the cache, or selects a draft.
+Drafts are design references, never shipped page assets;
+`omd ref distance` still reports fidelity as an advisory signal. Bound the whole concurrent image
+batch to 120 seconds. On timeout or tool failure, cancel outstanding generation, do not retry, and
+use the selected sanitized assembly and CSS/SVG graphics recipes while still implementing the
+selected macro visual system.
 
 Run `omd composition --check`. Missing sections, malformed fingerprints, or stale inputs
 stop divergence and return to the composer. A later change to frame, copy, type proof, or

--- a/test/omd-cli-wiring.test.ts
+++ b/test/omd-cli-wiring.test.ts
@@ -83,3 +83,37 @@ test('visual-richness quiet register yields no findings (register-aware, never g
   const parsed = JSON.parse(result.stdout) as { findings: unknown[] };
   assert.equal(parsed.findings.length, 0, result.stdout);
 });
+
+// ── art-direction alternatives-sha ──────────────────────────────────────────
+
+// The local art-direction lane binds perspectives, the moderator receipt, and the evaluator
+// result to one canonical alternatives digest. The CLI owns that digest so no coordinator has to
+// reimplement canonical JSON in shell; a mismatch there costs a whole deliberation round.
+
+const ALTERNATIVES = [
+  { register: 'quiet', conceptRole: 'Calm evidence dossier' },
+  { register: 'confident', conceptRole: 'Evidence signal field' },
+  { register: 'showpiece', conceptRole: 'Evidence theatre' },
+];
+
+test('art-direction alternatives-sha emits the canonical digest the local check binds', async () => {
+  const { canonicalJson, sha256 } = await import('../core/ref/board-artifacts.ts');
+  const dir = project();
+  const file = writeFile(dir, 'alternatives.json', JSON.stringify(ALTERNATIVES));
+  const result = run(['art-direction', 'alternatives-sha', '--input', file, '--json']);
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as { alternativesSha256: string };
+  assert.equal(parsed.alternativesSha256, sha256(canonicalJson(ALTERNATIVES)));
+});
+
+test('art-direction alternatives-sha accepts a decision-check payload and rejects a shapeless one', () => {
+  const dir = project();
+  const decisionCheck = writeFile(dir, 'decision-check.json', JSON.stringify({ route: '/', alternatives: ALTERNATIVES }));
+  const bare = run(['art-direction', 'alternatives-sha', '--input', writeFile(dir, 'bare.json', JSON.stringify(ALTERNATIVES)), '--json']);
+  const wrapped = run(['art-direction', 'alternatives-sha', '--input', decisionCheck, '--json']);
+  assert.equal(wrapped.status, 0, wrapped.stderr);
+  assert.equal(JSON.parse(wrapped.stdout).alternativesSha256, JSON.parse(bare.stdout).alternativesSha256);
+  const invalid = run(['art-direction', 'alternatives-sha', '--input', writeFile(dir, 'invalid.json', '{"route":"/"}'), '--json']);
+  assert.notEqual(invalid.status, 0);
+  assert.match(invalid.stderr, /ART_DIRECTION_ALTERNATIVES_INVALID/);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -899,6 +899,8 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /coordinator must not author or paraphrase them/);
   assert.match(skill, /When no activation was supplied, use the moderator-bound local lane/);
   assert.match(skill, /`omd art-direction local-check --input <decision-check\.json>`/);
+  assert.match(skill, /`omd art-direction alternatives-sha --input <alternatives\.json> --json`/);
+  assert.match(skill, /never reimplement canonical JSON hashing in shell or ad-hoc JavaScript/);
   assert.match(skill, /do not attempt or claim v2 publication/);
   assert.match(skill, /`omd deliberate preserve --input/);
   assert.match(skill, /A read-only moderator response is the required success path/);

--- a/test/runtime-isolation.test.ts
+++ b/test/runtime-isolation.test.ts
@@ -11,7 +11,7 @@ import { ACTIVATION_CONTEXT_SCHEMA_VERSION, validateActivationContext, type Acti
 import { createReviewerEvidenceProxy, MAX_INLINE_EVIDENCE_BYTES, ReviewerIsolationError } from '../core/runtime/evidence-proxy.ts';
 import { requireReviewerIsolationInvocation, type ProjectRunInvocation } from '../core/runtime/invocation.ts';
 import { assertProjectRunMutationInventory, inventoryProjectRunMutations } from '../core/runtime/project-write-inventory.ts';
-import { acquireProjectLock, acquireProjectMutationLock, ProjectWriteError, writeProjectFile } from '../core/runtime/project-write.ts';
+import { acquireProjectLock, acquireProjectMutationLock, ProjectWriteError, writeContentAddressedProjectFile, writeImmutableProjectFile, writeProjectFile } from '../core/runtime/project-write.ts';
 import { createTestProjectRunInvocation } from './helpers/project-write.ts';
 
 const hash = (value: string): string => value.repeat(64);
@@ -56,6 +56,35 @@ test('project mutation lock recovers only a stable dead same-host owner', () => 
       /owner is live or ambiguous/,
     );
     assert.equal(existsSync(lock), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// A content-addressed receipt carries its own digest in its path, so a resumed run recomputing
+// identical bytes must not be blocked by the first write. Different bytes under one address stay
+// fatal, and the plain immutable receipt keeps its strict single-write contract.
+test('content-addressed receipts are idempotent for identical bytes and fatal for different bytes', () => {
+  const root = mkdtempSync(join(tmpdir(), 'omd-content-addressed-'));
+  try {
+    const run = createTestProjectRunInvocation(root, 'content-addressed');
+    const relativePath = '.omd/evaluator-results/sha256-fixture.json';
+    const content = '{"winner":"confident"}';
+    const first = writeContentAddressedProjectFile({ projectRoot: root, relativePath, content, invocation: run });
+    assert.equal(writeContentAddressedProjectFile({ projectRoot: root, relativePath, content, invocation: run }), first);
+    assert.equal(readFileSync(first, 'utf8'), content);
+
+    assert.throws(
+      () => writeContentAddressedProjectFile({ projectRoot: root, relativePath, content: '{"winner":"quiet"}', invocation: run }),
+      /content-addressed artifact already exists with different bytes/,
+    );
+    assert.equal(readFileSync(first, 'utf8'), content);
+
+    writeImmutableProjectFile({ projectRoot: root, relativePath: '.omd/strict-receipt.json', content, invocation: run });
+    assert.throws(
+      () => writeImmutableProjectFile({ projectRoot: root, relativePath: '.omd/strict-receipt.json', content, invocation: run }),
+      (error: unknown) => error instanceof ProjectWriteError && /immutable project artifact already exists/.test(error.reason),
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Two real-use runs of the L4 marketing loop stopped before writing any production source. Both failures were in the coordinator's path to `omd art-direction local-check`.

- `omd art-direction alternatives-sha` now owns the canonical alternatives digest, so no coordinator reimplements canonical JSON in shell; the ultradesign skill routes every perspective, moderator receipt, and evaluator result through it.
- `writeContentAddressedProjectFile` makes an identical rewrite of a content-addressed receipt a no-op and keeps different bytes under one address fatal. The evaluator-result, art-direction, and intent-bootstrap receipts use it, so a resumed check no longer dies on `immutable project artifact already exists`.
- Image-first drafts are reserved for directions that need raster exploration and the batch is bounded to 120s before the CSS/SVG fallback.

Verification: `npm test` 1749 pass / 0 fail / 1 skip, `npx tsc --noEmit` clean, `npm run build` succeeds, `git diff --check` clean.