### PR TITLE
Stop the loop losing stages to hand-authored input

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -29,13 +29,14 @@ import { evaluateVisualRichness } from '../core/composition-contract/visual-rich
 import type { VisualRichnessRegister } from '../core/composition-contract/visual-richness.ts';
 import type { Category, EnergyCurve, Layer, RawIr, Violation } from '../core/types.ts';
 import {
+  ART_DIRECTION_CHECK_INPUT_KEYS,
   ART_DIRECTION_POINTER_SCHEMA_VERSION,
   ART_DIRECTION_RECORD_SCHEMA_VERSION,
   artDirectionSha256,
   validateArtDirectionPointer,
   validateArtDirectionRecord,
 } from '../core/art-direction/schema.ts';
-import { beatBudgetForRegister, exceedsCanonicalBeatBudget, NO_CURRENT_USER_BEAT_EXCEPTION_RECEIPT_SHA256, recipeDecisionProjectionSha256, resolveMarketingArtDirection, type ApprovedMotionRecipeReceipt, type ArtDirectionEligibility } from '../core/art-direction/decision.ts';
+import { beatBudgetForRegister, canonicalArtDirectionReferences, exceedsCanonicalBeatBudget, NO_CURRENT_USER_BEAT_EXCEPTION_RECEIPT_SHA256, recipeDecisionProjectionSha256, resolveMarketingArtDirection, type ApprovedMotionRecipeReceipt, type ArtDirectionEligibility } from '../core/art-direction/decision.ts';
 import { validateActivationContext } from '../core/runtime/activation.ts';
 import { createLocalCliInvocation, requireCurrentIntentLedgerAuthorization, requireCurrentUserIntentEventAuthorization, requireEvaluatorAssessmentAuthorization, requireEvaluatorResultAuthorization, requireFinalEvidenceManifestAuthorization, requireFinalReviewerLaneAuthorization, requireStaticEvidenceResultAuthorization, requireStaticReviewReceiptAuthorization, validateCurrentProjectRun, type ProjectRunInvocation } from '../core/runtime/invocation.ts';
 import { acquireProjectLock, createExternalObservationDirectory, createProjectWriteAdapter, replaceProjectFileAtomically, writeContentAddressedProjectFile, writeExternalObservationFile, writeImmutableProjectFile, type ExternalObservationKind, type ProjectWriteAdapter } from '../core/runtime/project-write.ts';
@@ -94,6 +95,8 @@ interface Opts {
   site?: string;
   /** Similarity threshold for `omd figma diff` / `omd target diff` (0–1, default 0.97). */
   threshold?: string;
+  /** Route the emitted art-direction check payload targets (`omd art-direction check-input --route /`). */
+  route?: string;
   /** Force re-export even when a cached Figma export exists (`omd figma diff --fresh`). */
   fresh?: boolean;
   /** Named visual target to diff against (`omd target diff --target <name>`). */
@@ -2082,6 +2085,54 @@ async function cmdIntent(mode: string | undefined, opts: Opts): Promise<never> {
   process.exit(0);
 }
 
+/** Prints the canonical skeleton for an input a coordinator authors by hand. */
+async function cmdSchema(name: string | undefined, opts: Opts): Promise<never> {
+  const { INPUT_SKELETONS, inputSkeleton } = await import('../core/schema/inputs.ts');
+  if (name === undefined || name === 'list') {
+    if (opts.json) process.stdout.write(JSON.stringify(INPUT_SKELETONS.map((entry) => ({ name: entry.name, path: entry.path, command: entry.command }))));
+    else for (const entry of INPUT_SKELETONS) console.log(`  ${entry.name.padEnd(22)} ${entry.path.padEnd(38)} ${entry.command}`);
+    process.exit(0);
+  }
+  const entry = inputSkeleton(name);
+  if (opts.json) process.stdout.write(JSON.stringify(entry));
+  else {
+    console.log(`${entry.name} -> ${entry.path}`);
+    console.log(`validated by: ${entry.command}`);
+    console.log(JSON.stringify(entry.skeleton, null, 2));
+  }
+  process.exit(0);
+}
+
+type StageArtifact = { readonly stage: string; readonly path: string; readonly present: boolean };
+
+/**
+ * A resumed run must consume what earlier stages already produced. Without this, a coordinator
+ * that lost its session restarts from the domain brief and rewrites owned artifacts.
+ */
+function cmdStage(mode: string | undefined, opts: Opts): never {
+  if (mode !== 'status' || opts._.length > 0) throw new Error('usage: omd stage status [--json]');
+  const artifacts: StageArtifact[] = ([
+    ['domain', '.omd/domain-brief.json'],
+    ['depth', '.omd/depth.json'],
+    ['frame', '.omd/frame.md'],
+    ['acquisition', '.omd/acquisition-plan.json'],
+    ['scout', '.omd/scout.md'],
+    ['reference-board', '.omd/reference-board.json'],
+    ['reference-selection', '.omd/reference-pre-selection-v2.json'],
+    ['art-direction', '.omd/art-direction.json'],
+    ['copy', '.omd/copy-deck.md'],
+    ['type-proof', '.omd/type-proof.md'],
+    ['composition', '.omd/composition.md'],
+  ] as const).map(([stage, path]) => ({ stage, path, present: existsSync(join(process.cwd(), path)) }));
+  const next = artifacts.find((artifact) => !artifact.present);
+  const result = { completed: artifacts.filter((artifact) => artifact.present).map((artifact) => artifact.stage), next: next?.stage ?? null, artifacts };
+  if (opts.json) process.stdout.write(JSON.stringify(result));
+  else {
+    for (const artifact of artifacts) console.log(`  ${artifact.present ? 'have' : '    '}  ${artifact.stage.padEnd(20)} ${artifact.path}`);
+    console.log(next === undefined ? 'every recorded stage artifact exists; resume at the first unproven gate' : `next stage: ${next.stage} (${next.path})`);
+  }
+  process.exit(0);
+}
 async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<never> {
   if (mode === 'alternatives-sha') {
     if (!opts.input || opts._.length > 0) throw new Error('usage: omd art-direction alternatives-sha --input <alternatives.json> [--json]');
@@ -2096,14 +2147,27 @@ async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<ne
     console.log(opts.json ? JSON.stringify(result) : result.alternativesSha256);
     process.exit(0);
   }
+  if (mode === 'check-input') {
+    if (opts.input !== undefined || opts._.length > 0) throw new Error('usage: omd art-direction check-input [--route /] [--json]');
+    const { inputSkeleton } = await import('../core/schema/inputs.ts');
+    const selection = validatePreReferenceSelectionV2(process.cwd());
+    const skeleton = inputSkeleton('art-direction-check').skeleton as Record<string, unknown>;
+    const payload = {
+      ...skeleton,
+      route: opts.route ?? skeleton.route,
+      references: canonicalArtDirectionReferences(selection),
+    };
+    console.log(JSON.stringify(payload, null, opts.json ? 0 : 2));
+    process.exit(0);
+  }
   const localMode = mode === 'local-check';
   if ((mode !== 'check' && !localMode) || !opts.input || opts._.length > 0) {
-    throw new Error('usage: omd art-direction check|local-check|alternatives-sha --input <json> [--json]');
+    throw new Error('usage: omd art-direction check|local-check|alternatives-sha|check-input --input <json> [--json]');
   }
   const command = localMode ? 'omd art-direction local-check' : 'omd art-direction check';
   const payload = inputJson(opts.input, command);
   if (!isRecord(payload)) throw new Error(`${command} input must contain evaluator assessment and result payloads`);
-  const allowed = new Set(['alternatives', 'references', 'eligibility', 'evaluatorAssessment', 'evaluatorResult', 'beats', 'invocation', 'deliberation', 'route', 'implementationLane', 'fallbackPath', 'performanceAccessibilityBudget']);
+  const allowed = new Set<string>(ART_DIRECTION_CHECK_INPUT_KEYS);
   if (Object.keys(payload).some((key) => !allowed.has(key))) throw new Error('ART_DIRECTION_CALLER_DECISION_FORBIDDEN: evaluator choices, scores, and motion sources must remain inside the evaluator bytes');
   const { alternatives, references, eligibility, evaluatorAssessment, evaluatorResult, beats, invocation, deliberation, route, implementationLane, fallbackPath, performanceAccessibilityBudget } = payload;
   if (localMode && invocation !== undefined) throw new Error('ART_DIRECTION_LOCAL_INVOCATION_FORBIDDEN: local-check derives write authority from the running CLI');
@@ -2962,6 +3026,10 @@ function usage(): never {
     + '  evidence tasks-check [--json]               revalidate strict production task evidence\n'
     + '\n'
     + '  art-direction check|local-check --input decision-check.json [--json]  persist a host-authorized or moderator-bound local direction\n'
+    + '  art-direction alternatives-sha --input alternatives.json [--json]  canonical digest every perspective and receipt must bind\n'
+    + '  art-direction check-input [--route /] [--json]  emit the check payload skeleton with canonical references filled in\n'
+    + '  schema list | schema <name> [--json]        print the exact skeleton for a hand-authored input\n'
+    + '  stage status [--json]                       show which stage artifacts exist and where a resumed run continues\n'
     + '  intent append --input trusted-intent.json [--json]  append trusted intent and update its guarded current pointer\n'
     + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
     + '  craft-fidelity check --input pair.json [--json]  verify a generated part reproduced the reference craft\n'
@@ -3079,6 +3147,8 @@ async function main(): Promise<never> {
   if (cmd === 'design') return cmdDesign(parseArgs(args.slice(1)));
   if (cmd === 'copy') return cmdCopy(parseArgs(args.slice(1)));
   if (cmd === 'art-direction') return cmdArtDirection(sub, parseArgs(args.slice(2)));
+  if (cmd === 'schema') return cmdSchema(sub, parseArgs(args.slice(2)));
+  if (cmd === 'stage') return cmdStage(sub, parseArgs(args.slice(2)));
   if (cmd === 'preflight') return cmdPreflight(parseArgs(args.slice(1)));
   if (cmd === 'composition') return cmdComposition(parseArgs(args.slice(1)));
   if (cmd === 'source') return cmdSource(sub, parseArgs(args.slice(2)));

--- a/core/art-direction/decision.ts
+++ b/core/art-direction/decision.ts
@@ -184,14 +184,21 @@ function citedReferences(slotIds: readonly string[], references: readonly ArtDir
     return reference;
   });
 }
-function canonicalReferences(bindings: CanonicalReferenceBindings): readonly ArtDirectionReference[] {
-  return bindings.selection.slots.map((slot) => ({
+/**
+ * The references array a check payload must carry is a pure projection of the settled selection.
+ * Exported so the CLI can emit it instead of asking a coordinator to retype it byte-exactly.
+ */
+export function canonicalArtDirectionReferences(selection: ReferenceSelectionV2): readonly ArtDirectionReference[] {
+  return selection.slots.map((slot) => ({
     slotId: slot.slotId,
     signal: slot.signal,
     positive: slot.rights === 'lawful' && slot.signal !== 'anti-reference',
     lawful: slot.rights === 'lawful',
     motionObligation: 'none',
   }));
+}
+function canonicalReferences(bindings: CanonicalReferenceBindings): readonly ArtDirectionReference[] {
+  return canonicalArtDirectionReferences(bindings.selection);
 }
 
 function validateCanonicalSelectionSlots(selection: ReferenceSelectionV2): void {

--- a/core/art-direction/schema.ts
+++ b/core/art-direction/schema.ts
@@ -5,6 +5,11 @@ export const REGISTERS = ['quiet', 'confident', 'showpiece'] as const;
 export const MOTION_DECISIONS = ['none', 'one'] as const;
 export const ART_DIRECTION_RECORD_SCHEMA_VERSION = 'art-direction-record-v2' as const;
 export const ART_DIRECTION_POINTER_SCHEMA_VERSION = 'art-direction-current-v2' as const;
+/** Exactly the keys a caller may author in an `omd art-direction check|local-check` payload. */
+export const ART_DIRECTION_CHECK_INPUT_KEYS = [
+  'route', 'alternatives', 'references', 'eligibility', 'evaluatorAssessment', 'evaluatorResult',
+  'beats', 'invocation', 'deliberation', 'implementationLane', 'fallbackPath', 'performanceAccessibilityBudget',
+] as const;
 
 export type Register = (typeof REGISTERS)[number];
 export type MotionDecision = (typeof MOTION_DECISIONS)[number];

--- a/core/deliberation/depth.ts
+++ b/core/deliberation/depth.ts
@@ -15,6 +15,11 @@ export type DepthInput = {
   readonly webgl: boolean;
   readonly referenceZones: number;
 };
+export const DEPTH_INPUT_KEYS = [
+  'schema', 'scope', 'zoneCount', 'newPrimaryCta', 'newInformationArchitecture', 'multiScreenState',
+  'costlyError', 'brandDirectionChange', 'showpieceMotion', 'webgl', 'referenceZones',
+] as const;
+export const DEPTH_SCOPES = ['component-change', 'single-section', 'single-surface', 'multi-surface'] as const;
 export type DepthResult = {
   readonly level: DepthLevel;
   readonly reasons: readonly string[];
@@ -29,10 +34,36 @@ const BASE: Record<DepthLevel, readonly string[]> = {
   L4: ['domain', 'frame', 'scout', 'writer', 'typesetter', 'composer', 'design-deliberation', 'sketch', 'blind-selection', 'hand', 'render-observe', 'glance', 'constraint-deliberation', 'eye', 'red-green'],
 };
 
+/**
+ * One actionable shape error. A coordinator authors this file by hand, so a partial complaint
+ * about a single field sends it reverse-engineering the type instead of writing the input.
+ */
+export function validateDepthInput(input: DepthInput): void {
+  const value = input as unknown;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`depth input must be a ${DEPTH_INPUT_SCHEMA} object with keys: ${DEPTH_INPUT_KEYS.join(', ')}`);
+  }
+  const record = value as Record<string, unknown>;
+  const missing = DEPTH_INPUT_KEYS.filter((key) => !Object.hasOwn(record, key));
+  const unknown = Object.keys(record).filter((key) => !(DEPTH_INPUT_KEYS as readonly string[]).includes(key));
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new Error([
+      `depth input must contain exactly: ${DEPTH_INPUT_KEYS.join(', ')}`,
+      missing.length > 0 ? `missing: ${missing.join(', ')}` : '',
+      unknown.length > 0 ? `unknown: ${unknown.join(', ')}` : '',
+      'run `omd schema depth-input` for the exact skeleton',
+    ].filter((part) => part !== '').join('; '));
+  }
+  if (record.schema !== DEPTH_INPUT_SCHEMA) throw new Error(`depth schema must be ${DEPTH_INPUT_SCHEMA}`);
+  if (!(DEPTH_SCOPES as readonly unknown[]).includes(record.scope)) throw new Error(`scope must be one of ${DEPTH_SCOPES.join(', ')}`);
+  for (const key of ['newPrimaryCta', 'newInformationArchitecture', 'multiScreenState', 'costlyError', 'brandDirectionChange', 'showpieceMotion', 'webgl'] as const) {
+    if (typeof record[key] !== 'boolean') throw new Error(`${key} must be a boolean`);
+  }
+  if (!Number.isSafeInteger(record.zoneCount) || (record.zoneCount as number) < 1) throw new Error('zoneCount must be a positive integer');
+  if (!Number.isSafeInteger(record.referenceZones) || (record.referenceZones as number) < 0) throw new Error('referenceZones must be a non-negative integer');
+}
 export function classifyDepth(input: DepthInput): DepthResult {
-  if (input.schema !== DEPTH_INPUT_SCHEMA) throw new Error(`depth schema must be ${DEPTH_INPUT_SCHEMA}`);
-  if (!Number.isSafeInteger(input.zoneCount) || input.zoneCount < 1) throw new Error('zoneCount must be a positive integer');
-  if (!Number.isSafeInteger(input.referenceZones) || input.referenceZones < 0) throw new Error('referenceZones must be a non-negative integer');
+  validateDepthInput(input);
 
   let level: DepthLevel = input.scope === 'component-change' ? 'L1' : input.scope === 'single-section' ? 'L2' : 'L3';
   const reasons = [`scope:${input.scope}`];

--- a/core/schema/inputs.ts
+++ b/core/schema/inputs.ts
@@ -1,0 +1,95 @@
+// Canonical skeletons for the inputs a coordinator authors by hand.
+//
+// Every one of these files is written into `.omd/` (or `.omd/.cache/`) by a chat agent, then
+// validated by a CLI gate. Without a printable skeleton the agent reads `core/**` to recover the
+// key list, which costs a stage retry when it guesses wrong. `omd schema <name>` prints these.
+
+import { DEPTH_INPUT_KEYS, DEPTH_INPUT_SCHEMA, DEPTH_SCOPES } from '../deliberation/depth.ts';
+import { ART_DIRECTION_CHECK_INPUT_KEYS } from '../art-direction/schema.ts';
+
+export type InputSkeleton = {
+  readonly name: string;
+  /** Where the authored file belongs, so the printed skeleton is directly usable. */
+  readonly path: string;
+  readonly command: string;
+  readonly keys: readonly string[];
+  readonly skeleton: unknown;
+};
+
+const DEPTH_INPUT: InputSkeleton = {
+  name: 'depth-input',
+  path: '.omd/depth.json',
+  command: 'omd depth classify --input .omd/depth.json --json',
+  keys: DEPTH_INPUT_KEYS,
+  skeleton: {
+    schema: DEPTH_INPUT_SCHEMA,
+    scope: DEPTH_SCOPES[2],
+    zoneCount: 1,
+    newPrimaryCta: false,
+    newInformationArchitecture: false,
+    multiScreenState: false,
+    costlyError: false,
+    brandDirectionChange: false,
+    showpieceMotion: false,
+    webgl: false,
+    referenceZones: 0,
+  },
+};
+
+const ART_DIRECTION_ALTERNATIVE = {
+  register: '<quiet|confident|showpiece>',
+  subjectIdentityFit: '<why this register fits the subject, from permitted evidence>',
+  staticReferenceSlotIds: ['<slotId from the settled selection>'],
+  motionReferenceSlotIds: [],
+  conceptRole: '<the concept this direction carries>',
+  macroCompositionHypothesis: '<macro system; motion none requires a named template departure>',
+  motionHypothesis: '<none|one>',
+  uxAccessibilityPerformanceRisks: '<risks this direction accepts>',
+  lawfulImplementationPath: '<how it ships lawfully in the chosen stack>',
+  rejectionCondition: '<observable condition that would reject this direction>',
+};
+
+const ART_DIRECTION_CHECK: InputSkeleton = {
+  name: 'art-direction-check',
+  path: '.omd/.cache/art-direction-check.json',
+  command: 'omd art-direction local-check --input .omd/.cache/art-direction-check.json --json',
+  keys: ART_DIRECTION_CHECK_INPUT_KEYS,
+  skeleton: {
+    route: '/',
+    alternatives: [ART_DIRECTION_ALTERNATIVE],
+    references: '<run `omd art-direction check-input` to emit the canonical references array>',
+    eligibility: { sceneRoles: [], fallbackAttempted: true },
+    evaluatorAssessment: {
+      assessments: [{
+        register: '<quiet|confident|showpiece>',
+        score: 0,
+        subjectIdentityRationale: '<evaluator rationale>',
+        conceptRoleRationale: '<evaluator rationale>',
+        uxAccessibilityPerformanceRationale: '<evaluator rationale>',
+        lawfulFeasibilityRationale: '<evaluator rationale>',
+        referenceEvidenceRationale: '<evaluator rationale>',
+        rejectionRationale: '<evaluator rationale>',
+      }],
+    },
+    evaluatorResult: {
+      winner: '<highest-scoring register>',
+      alternativesSha256: '<omd art-direction alternatives-sha --input <alternatives.json> --json>',
+      motionResolution: { motionDecision: '<none|one>', slots: [] },
+    },
+    beats: ['B-1'],
+    deliberation: '.omd/deliberations/<moderator-receipt-id>.json',
+    implementationLane: '<how the selected direction is built>',
+    fallbackPath: '<lawful css/svg/static or reduced-motion fallback that was tried>',
+    performanceAccessibilityBudget: '<budget the build must hold>',
+  },
+};
+
+export const INPUT_SKELETONS: readonly InputSkeleton[] = [DEPTH_INPUT, ART_DIRECTION_CHECK];
+
+export function inputSkeleton(name: string): InputSkeleton {
+  const found = INPUT_SKELETONS.find((entry) => entry.name === name);
+  if (found === undefined) {
+    throw new Error(`unknown schema ${name}; known: ${INPUT_SKELETONS.map((entry) => entry.name).join(', ')}`);
+  }
+  return found;
+}

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -100,15 +100,24 @@ In particular, only `oh-my-design:hand` may write production source; neither the
 `worker` may substitute for it.
 
 Run `omd doctor`. Stop on a failed prerequisite. For interactive visual research or user-directed
-region capture, initialize `browser-rs` first. Only an observed initialization/capability failure
-permits headless, reduced-motion `omd render` or `omd probe` as the deterministic Playwright
-fallback; record the failure and do not add or try another provider. Pin the absolute working
-directory first. A Figma frame or exact visual target uses the single Figma structural-bypass route
-declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather than
-handing the run off or terminating this loop.
+region capture, verify the provider with `oh-my-design browser doctor` and stop there: the OMD CLI
+spawns `browser-rs` itself over stdio for each capture. Never start a long-lived `browser-rs`, pick a
+port, or debug a listening socket — an `Address already in use` reply means you started a second
+instance that the capture path never needed. Only an observed provider failure reported by
+`browser doctor` permits headless, reduced-motion `omd render` or `omd probe` as the deterministic
+Playwright fallback; record the failure and do not add or try another provider. Pin the absolute
+working directory first. A Figma frame or exact visual target uses the single Figma structural-bypass
+route declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather
+than handing the run off or terminating this loop.
+
+A resumed or restarted run does not begin again at the domain brief. Run `omd stage status` first and
+continue at the first stage whose artifact is missing; artifacts an earlier owner already wrote stay
+authoritative, and rewriting one yourself is the same ownership violation as writing it the first
+time.
 
 Before spawning an artifact owner, classify depth. The coordinator writes only the routing input
-`.omd/depth.json` as `design-depth-input-v1`, runs
+`.omd/depth.json` as `design-depth-input-v1` — print its exact skeleton with
+`omd schema depth-input` instead of inferring keys from `core/` — then runs
 `omd depth classify --input .omd/depth.json --json`, and follows that result. Scope cannot lower a
 risk-raised level. A new promotional surface establishes an art direction and is L4; an existing
 component-only change may be L1. L1/L2 omit only the stages listed by the classifier and still spawn
@@ -187,12 +196,23 @@ itself. Copy that JSON byte-for-byte, without its Markdown fence and without edi
 paraphrasing, to `.omd/.cache/art-direction-moderator.json`, then run
 `omd deliberate preserve --input .omd/.cache/art-direction-moderator.json`. This validated clerical
 persistence is not coordinator authorship. Its three `inputSha256` values must equal the alternatives
-hash and its resolution must equal the evaluator result. Run
+hash and its resolution must equal the evaluator result. Build the check payload with
+`omd art-direction check-input`, which emits the caller skeleton with the canonical `references`
+array already filled from the settled selection; fill in only the alternatives, evaluator bytes,
+beats, deliberation path, and lane/budget strings. `omd schema art-direction-check` prints the same
+skeleton without a project. Never retype the references array by hand. Then run
 `omd art-direction local-check --input <decision-check.json>` with that `deliberation` path and no
 `invocation` field. This derives only local project-write authority and cannot publish v2 evidence;
 it still creates the immutable art-direction, motion settlement, composer handoff, and hand handoff
 required to build. Never fabricate a host activation or downgrade to an unsigned handwritten
 `.omd/art-direction.json`.
+
+A rejected gate is only terminal when an owner role failed. A validator complaint about the
+coordinator's own payload — an unknown or missing key, a stale digest, a wrong path — is clerical:
+repair the bytes and rerun the same command. Reruns are safe because every receipt in this lane is
+content-addressed, so recomputing identical bytes is a no-op rather than an
+`immutable project artifact already exists` failure. Do not spend a role retry, do not restart the
+graph, and do not stop the run for a mistake you can fix in the file you wrote.
 
 ## 0.5 Domain analysis
 

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -100,15 +100,24 @@ In particular, only `omd-hand` may write production source; neither the coordina
 `worker` may substitute for it.
 
 Run `omd doctor`. Stop on a failed prerequisite. For interactive visual research or user-directed
-region capture, initialize `browser-rs` first. Only an observed initialization/capability failure
-permits headless, reduced-motion `omd render` or `omd probe` as the deterministic Playwright
-fallback; record the failure and do not add or try another provider. Pin the absolute working
-directory first. A Figma frame or exact visual target uses the single Figma structural-bypass route
-declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather than
-handing the run off or terminating this loop.
+region capture, verify the provider with `oh-my-design browser doctor` and stop there: the OMD CLI
+spawns `browser-rs` itself over stdio for each capture. Never start a long-lived `browser-rs`, pick a
+port, or debug a listening socket — an `Address already in use` reply means you started a second
+instance that the capture path never needed. Only an observed provider failure reported by
+`browser doctor` permits headless, reduced-motion `omd render` or `omd probe` as the deterministic
+Playwright fallback; record the failure and do not add or try another provider. Pin the absolute
+working directory first. A Figma frame or exact visual target uses the single Figma structural-bypass
+route declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather
+than handing the run off or terminating this loop.
+
+A resumed or restarted run does not begin again at the domain brief. Run `omd stage status` first and
+continue at the first stage whose artifact is missing; artifacts an earlier owner already wrote stay
+authoritative, and rewriting one yourself is the same ownership violation as writing it the first
+time.
 
 Before spawning an artifact owner, classify depth. The coordinator writes only the routing input
-`.omd/depth.json` as `design-depth-input-v1`, runs
+`.omd/depth.json` as `design-depth-input-v1` — print its exact skeleton with
+`omd schema depth-input` instead of inferring keys from `core/` — then runs
 `omd depth classify --input .omd/depth.json --json`, and follows that result. Scope cannot lower a
 risk-raised level. A new promotional surface establishes an art direction and is L4; an existing
 component-only change may be L1. L1/L2 omit only the stages listed by the classifier and still spawn
@@ -187,12 +196,23 @@ itself. Copy that JSON byte-for-byte, without its Markdown fence and without edi
 paraphrasing, to `.omd/.cache/art-direction-moderator.json`, then run
 `omd deliberate preserve --input .omd/.cache/art-direction-moderator.json`. This validated clerical
 persistence is not coordinator authorship. Its three `inputSha256` values must equal the alternatives
-hash and its resolution must equal the evaluator result. Run
+hash and its resolution must equal the evaluator result. Build the check payload with
+`omd art-direction check-input`, which emits the caller skeleton with the canonical `references`
+array already filled from the settled selection; fill in only the alternatives, evaluator bytes,
+beats, deliberation path, and lane/budget strings. `omd schema art-direction-check` prints the same
+skeleton without a project. Never retype the references array by hand. Then run
 `omd art-direction local-check --input <decision-check.json>` with that `deliberation` path and no
 `invocation` field. This derives only local project-write authority and cannot publish v2 evidence;
 it still creates the immutable art-direction, motion settlement, composer handoff, and hand handoff
 required to build. Never fabricate a host activation or downgrade to an unsigned handwritten
 `.omd/art-direction.json`.
+
+A rejected gate is only terminal when an owner role failed. A validator complaint about the
+coordinator's own payload — an unknown or missing key, a stale digest, a wrong path — is clerical:
+repair the bytes and rerun the same command. Reruns are safe because every receipt in this lane is
+content-addressed, so recomputing identical bytes is a no-op rather than an
+`immutable project artifact already exists` failure. Do not spend a role retry, do not restart the
+graph, and do not stop the run for a mistake you can fix in the file you wrote.
 
 ## 0.5 Domain analysis
 

--- a/test/omd-cli-wiring.test.ts
+++ b/test/omd-cli-wiring.test.ts
@@ -117,3 +117,82 @@ test('art-direction alternatives-sha accepts a decision-check payload and reject
   assert.notEqual(invalid.status, 0);
   assert.match(invalid.stderr, /ART_DIRECTION_ALTERNATIVES_INVALID/);
 });
+
+// ── schema / stage / check-input ────────────────────────────────────────────
+
+// Every skeleton the CLI prints must stay the exact key set its validator enforces; a drifted
+// skeleton is worse than none, because the coordinator trusts it and loses a stage to the gate.
+
+test('printed input skeletons carry exactly the keys their validators accept', async () => {
+  const { INPUT_SKELETONS, inputSkeleton } = await import('../core/schema/inputs.ts');
+  const { DEPTH_INPUT_KEYS } = await import('../core/deliberation/depth.ts');
+  const { ART_DIRECTION_CHECK_INPUT_KEYS } = await import('../core/art-direction/schema.ts');
+
+  const depth = inputSkeleton('depth-input');
+  assert.deepEqual(Object.keys(depth.skeleton as object).sort(), [...DEPTH_INPUT_KEYS].sort());
+  const check = inputSkeleton('art-direction-check');
+  const authored = Object.keys(check.skeleton as object);
+  assert.ok(authored.every((key) => (ART_DIRECTION_CHECK_INPUT_KEYS as readonly string[]).includes(key)), authored.join(','));
+  assert.ok(!authored.includes('invocation'), 'the local lane never authors an invocation');
+  assert.equal(INPUT_SKELETONS.length, 2);
+
+  const dir = project();
+  const printed = run(['schema', 'depth-input', '--json'], dir);
+  assert.equal(printed.status, 0, printed.stderr);
+  assert.deepEqual(JSON.parse(printed.stdout).skeleton, depth.skeleton);
+  const listed = run(['schema', 'list', '--json'], dir);
+  assert.deepEqual(JSON.parse(listed.stdout).map((entry: { name: string }) => entry.name), ['depth-input', 'art-direction-check']);
+});
+
+test('the printed depth skeleton classifies and a shapeless input names every missing key', () => {
+  const dir = project();
+  const skeleton = JSON.parse(run(['schema', 'depth-input', '--json'], dir).stdout).skeleton;
+  const good = writeFile(dir, 'depth.json', JSON.stringify(skeleton));
+  const classified = run(['depth', 'classify', '--input', good, '--json'], dir);
+  assert.equal(classified.status, 0, classified.stderr);
+  assert.equal(JSON.parse(classified.stdout).level, 'L3');
+
+  const bad = writeFile(dir, 'bad-depth.json', JSON.stringify({ schema: 'design-depth-input-v1', surface: 'marketing', costlyError: false, webgl: false }));
+  const rejected = run(['depth', 'classify', '--input', bad, '--json'], dir);
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /missing: scope, zoneCount/);
+  assert.match(rejected.stderr, /unknown: surface/);
+  assert.match(rejected.stderr, /omd schema depth-input/);
+});
+
+test('stage status names the first missing artifact so a resumed run does not restart', () => {
+  const dir = project();
+  const empty = run(['stage', 'status', '--json'], dir);
+  assert.equal(empty.status, 0, empty.stderr);
+  assert.equal(JSON.parse(empty.stdout).next, 'domain');
+  assert.deepEqual(JSON.parse(empty.stdout).completed, []);
+
+  writeFile(dir, '.omd/domain-brief.json', '{}');
+  writeFile(dir, '.omd/depth.json', '{}');
+  const resumed = JSON.parse(run(['stage', 'status', '--json'], dir).stdout);
+  assert.deepEqual(resumed.completed, ['domain', 'depth']);
+  assert.equal(resumed.next, 'frame');
+});
+
+// The check payload's `references` array must equal this projection byte-for-byte, so emitting it
+// is the only way a coordinator can stop retyping it. Rights and anti-reference signal decide
+// `positive`/`lawful`; motion obligations stay pending until the evaluator settles them.
+test('canonical check references project rights and signal from the settled selection', async () => {
+  const { canonicalArtDirectionReferences } = await import('../core/art-direction/decision.ts');
+  const slot = (slotId: string, signal: string, rights: string) => ({
+    slotId, signal, rights, staticAxis: 'available', motionAxis: 'absent',
+    obligationDisposition: 'not-applicable', obligationReason: 'static-only reference',
+  });
+  const references = canonicalArtDirectionReferences({
+    slots: [
+      slot('hero', 'high-visual-system', 'lawful'),
+      slot('avoid', 'anti-reference', 'lawful'),
+      slot('unlicensed', 'supporting-component', 'restricted'),
+    ],
+  } as never);
+  assert.deepEqual(references, [
+    { slotId: 'hero', signal: 'high-visual-system', positive: true, lawful: true, motionObligation: 'none' },
+    { slotId: 'avoid', signal: 'anti-reference', positive: false, lawful: true, motionObligation: 'none' },
+    { slotId: 'unlicensed', signal: 'supporting-component', positive: false, lawful: false, motionObligation: 'none' },
+  ]);
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -901,6 +901,14 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /`omd art-direction local-check --input <decision-check\.json>`/);
   assert.match(skill, /`omd art-direction alternatives-sha --input <alternatives\.json> --json`/);
   assert.match(skill, /never reimplement canonical JSON hashing in shell or ad-hoc JavaScript/);
+  assert.match(skill, /`omd art-direction check-input`/);
+  assert.match(skill, /Never retype the references array by hand/);
+  assert.match(skill, /A rejected gate is only terminal when an owner role failed/);
+  assert.match(skill, /repair the bytes and rerun the same command/);
+  assert.match(skill, /Run `omd stage status` first and continue at the first stage whose artifact is missing/);
+  assert.match(skill, /`omd schema depth-input` instead of inferring keys from `core\/`/);
+  assert.match(skill, /the OMD CLI spawns `browser-rs` itself over stdio for each capture/);
+  assert.match(skill, /Never start a long-lived `browser-rs`, pick a port, or debug a listening socket/);
   assert.match(skill, /do not attempt or claim v2 publication/);
   assert.match(skill, /`omd deliberate preserve --input/);
   assert.match(skill, /A read-only moderator response is the required success path/);


### PR DESCRIPTION
Real-use runs of the L4 loop kept spending stages on clerical work the CLI already knows how to do.

- `omd schema list|<name>` prints the exact skeleton for `.omd/depth.json` and the art-direction check payload, generated from the same constants the validators enforce. The depth validator now names every missing and unknown key in one error instead of one field at a time.
- `omd art-direction check-input` emits the check payload with the canonical `references` array already projected from the settled selection, so no coordinator retypes it.
- `omd stage status` reports which stage artifacts exist and where a resumed run continues, instead of restarting at the domain brief.
- The skill stops the coordinator from starting its own long-lived `browser-rs` on a chosen port; the CLI owns that process over stdio and `oh-my-design browser doctor` is the only capability check.
- The skill separates a terminal owner-role failure from a clerical validator complaint about the coordinator's own bytes, which must be repaired and rerun.

Evidence: replaying the exact payload that failed the third trial with `guarded project write rejected: immutable project artifact already exists: .omd/evaluator-results/sha256-b18b13e…json` now reaches the real design gate (`none requires a declared template-breaking macro departure`).

Verification: `npm test` 1753 pass / 0 fail / 1 skip, `npx tsc --noEmit` clean, `npm run build` succeeds.