### PR TITLE
Keep a long run disciplined and prove it did what the brief asked

### DIFF
--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -97,6 +97,24 @@ interface Opts {
   threshold?: string;
   /** Route the emitted art-direction check payload targets (`omd art-direction check-input --route /`). */
   route?: string;
+  /** Stage a contract is delivered to (`omd stage deliver --stage art-direction`). */
+  stage?: string;
+  /** Pack-relative contract path delivered to a stage (`--contract protocol/copy-deck.md`). */
+  contract?: string;
+  /** Per-stage token ceiling for `omd stage cost --max-stage-tokens`. */
+  maxStageTokens?: string;
+  /** Whole-run token ceiling for `omd stage cost --max-run-tokens`. */
+  maxRunTokens?: string;
+  /** Whole-run wall-clock ceiling in minutes for `omd stage cost --max-run-minutes`. */
+  maxRunMinutes?: string;
+  /** File path a cue is resolved for (`omd cue --path src/landing/Hero.tsx`). */
+  path?: string;
+  /** Code symbol a cue is resolved for (`omd cue --symbol Dialog`). */
+  symbol?: string;
+  /** Typed brief field a cue is resolved for (`omd cue --field surface=marketing`). */
+  field?: string;
+  /** Copy deck the locale gate binds against (`omd locale check --deck .omd/copy-deck.md`). */
+  deck?: string;
   /** Force re-export even when a cached Figma export exists (`omd figma diff --fresh`). */
   fresh?: boolean;
   /** Named visual target to diff against (`omd target diff --target <name>`). */
@@ -153,6 +171,9 @@ const ALIASES: Record<string, keyof Opts> = {
   'max-lcp': 'maxLcp',
   'max-tbt': 'maxTbt',
   'max-cls': 'maxCls',
+  'max-stage-tokens': 'maxStageTokens',
+  'max-run-tokens': 'maxRunTokens',
+  'max-run-minutes': 'maxRunMinutes',
   'dry-run': 'dryRun',
 };
 
@@ -2103,35 +2124,167 @@ async function cmdSchema(name: string | undefined, opts: Opts): Promise<never> {
   process.exit(0);
 }
 
-type StageArtifact = { readonly stage: string; readonly path: string; readonly present: boolean };
-
 /**
- * A resumed run must consume what earlier stages already produced. Without this, a coordinator
- * that lost its session restarts from the domain brief and rewrites owned artifacts.
+ * Stage state for a run. `status`/`resume` derive everything from artifacts on disk; `deliver`
+ * records the one fact that cannot be derived — that a contract's exact bytes reached the stage
+ * that must obey them — and `require` refuses to advance without both.
  */
-function cmdStage(mode: string | undefined, opts: Opts): never {
-  if (mode !== 'status' || opts._.length > 0) throw new Error('usage: omd stage status [--json]');
-  const artifacts: StageArtifact[] = ([
-    ['domain', '.omd/domain-brief.json'],
-    ['depth', '.omd/depth.json'],
-    ['frame', '.omd/frame.md'],
-    ['acquisition', '.omd/acquisition-plan.json'],
-    ['scout', '.omd/scout.md'],
-    ['reference-board', '.omd/reference-board.json'],
-    ['reference-selection', '.omd/reference-pre-selection-v2.json'],
-    ['art-direction', '.omd/art-direction.json'],
-    ['copy', '.omd/copy-deck.md'],
-    ['type-proof', '.omd/type-proof.md'],
-    ['composition', '.omd/composition.md'],
-  ] as const).map(([stage, path]) => ({ stage, path, present: existsSync(join(process.cwd(), path)) }));
-  const next = artifacts.find((artifact) => !artifact.present);
-  const result = { completed: artifacts.filter((artifact) => artifact.present).map((artifact) => artifact.stage), next: next?.stage ?? null, artifacts };
+async function cmdStage(mode: string | undefined, opts: Opts): Promise<never> {
+  const { STAGES, contractSha256, deliveryReceipt, DELIVERY_LOG, readDeliveryReceipts, requireStage, resolveRunState, serializeDeliveryLog, stageDefinition } = await import('../core/stage/contract.ts');
+  const packRoot = join(root, 'core');
+  const projectRoot = process.cwd();
+
+  if (mode === 'status' || mode === 'resume') {
+    if (opts._.length > 0) throw new Error(`usage: omd stage ${mode} [--json]`);
+    const state = resolveRunState(projectRoot, packRoot);
+    const blocked = state.current === null ? undefined : requireStage(projectRoot, packRoot, state.current);
+    const result = { ...state, blocked: blocked?.ok === false ? blocked : null };
+    if (opts.json) process.stdout.write(JSON.stringify(result));
+    else {
+      for (const stage of state.stages) {
+        const contracts = stage.undelivered.length === 0 ? '' : `  undelivered: ${stage.undelivered.join(', ')}`;
+        console.log(`  ${stage.present ? 'have' : '    '}  ${stage.stage.padEnd(20)} ${stage.artifact.padEnd(40)} ${stage.owner}${contracts}`);
+      }
+      if (state.current === null) console.log('every recorded stage artifact exists; resume at the first unproven gate');
+      else {
+        console.log(`current stage: ${state.current}`);
+        for (const contract of blocked?.undeliveredContracts ?? []) console.log(`  deliver first: omd stage deliver --stage ${state.current} --contract ${contract}`);
+      }
+    }
+    process.exit(0);
+  }
+
+  if (mode === 'deliver') {
+    const contract = opts.contract;
+    const stage = opts.stage;
+    if (contract === undefined || stage === undefined || opts._.length > 0) {
+      throw new Error('usage: omd stage deliver --stage <stage> --contract <pack-relative.md> [--json]');
+    }
+    const receipt = deliveryReceipt(stageDefinition(stage).id, contract, contractSha256(packRoot, contract), new Date().toISOString());
+    const adapter = projectWriterFromActivation(opts, 'omd stage deliver');
+    adapter.write(DELIVERY_LOG, serializeDeliveryLog([...readDeliveryReceipts(projectRoot), receipt]));
+    if (opts.json) process.stdout.write(JSON.stringify(receipt));
+    else console.log(`delivered ${contract} to ${receipt.stage} (${receipt.sha256.slice(0, 12)})`);
+    process.exit(0);
+  }
+
+  if (mode === 'require') {
+    const stage = opts.stage ?? opts._[0];
+    if (stage === undefined || opts._.length > 1) throw new Error('usage: omd stage require <stage> [--json]');
+    const requirement = requireStage(projectRoot, packRoot, stage);
+    if (opts.json) process.stdout.write(JSON.stringify(requirement));
+    else if (requirement.ok) console.log(`ok — ${requirement.stage} may run`);
+    else {
+      for (const artifact of requirement.missingArtifacts) console.error(`[blocked] ${requirement.stage} needs an earlier owner's artifact: ${artifact}`);
+      for (const contract of requirement.undeliveredContracts) console.error(`[blocked] ${requirement.stage} has no current delivery receipt for ${contract}; run: omd stage deliver --stage ${requirement.stage} --contract ${contract}`);
+    }
+    process.exit(requirement.ok ? 0 : 1);
+  }
+
+  if (mode === 'record' || mode === 'cost') {
+    const { evaluateStageBudget, readStageUsage, serializeStageUsage, STAGE_USAGE_LOG, STAGE_USAGE_SCHEMA, validateStageUsageSample } = await import('../core/stage/usage.ts');
+    if (mode === 'record') {
+      const stage = opts.stage ?? opts._[0];
+      if (stage === undefined || opts._.length > 1) throw new Error('usage: omd stage record --stage <stage> [--json]');
+      const { computeRunUsage } = await import('../core/usage/index.ts');
+      const current = computeRunUsage(projectRoot);
+      if (current === null) throw new Error('STAGE_USAGE_UNAVAILABLE: no host session log to attribute this stage to');
+      const sample = validateStageUsageSample({
+        schema: STAGE_USAGE_SCHEMA,
+        stage: stageDefinition(stage).id,
+        at: new Date().toISOString(),
+        totalTokens: current.totalTokens,
+        outputTokens: current.outputTokens,
+        elapsedMs: current.elapsedMs,
+        approximate: current.approximate === true,
+      });
+      const adapter = projectWriterFromActivation(opts, 'omd stage record');
+      adapter.write(STAGE_USAGE_LOG, serializeStageUsage([...readStageUsage(projectRoot), sample]));
+      if (opts.json) process.stdout.write(JSON.stringify(sample));
+      else console.log(`recorded ${sample.stage}: ${sample.totalTokens} tokens, ${Math.round(sample.elapsedMs / 1000)}s cumulative`);
+      process.exit(0);
+    }
+    const budget = {
+      ...(opts.maxStageTokens === undefined ? {} : { maxStageTokens: Number(opts.maxStageTokens) }),
+      ...(opts.maxRunTokens === undefined ? {} : { maxRunTokens: Number(opts.maxRunTokens) }),
+      ...(opts.maxRunMinutes === undefined ? {} : { maxRunElapsedMs: Number(opts.maxRunMinutes) * 60_000 }),
+    };
+    const report = evaluateStageBudget(readStageUsage(projectRoot), budget);
+    if (opts.json) process.stdout.write(JSON.stringify(report));
+    else {
+      for (const cost of report.costs) console.log(`  ${cost.stage.padEnd(20)} ${String(cost.totalTokens).padStart(10)} tokens  ${String(Math.round(cost.elapsedMs / 1000)).padStart(6)}s${cost.approximate ? '  (approx)' : ''}`);
+      console.log(`  ${'run total'.padEnd(20)} ${String(report.runTokens).padStart(10)} tokens  ${String(Math.round(report.runElapsedMs / 1000)).padStart(6)}s`);
+      for (const finding of report.findings) console.error(`[over budget] ${finding}`);
+    }
+    process.exit(report.ok ? 0 : 1);
+  }
+  if (mode === 'list') {
+    if (opts.json) process.stdout.write(JSON.stringify(STAGES));
+    else for (const stage of STAGES) console.log(`  ${stage.id.padEnd(20)} ${stage.owner.padEnd(16)} ${stage.artifact.padEnd(40)} ${stage.requiredContracts.join(', ')}`);
+    process.exit(0);
+  }
+
+  throw new Error('usage: omd stage status|resume|list [--json] | deliver --stage <s> --contract <c> | require <stage> | record --stage <s> | cost [--max-stage-tokens N] [--max-run-tokens N] [--max-run-minutes N]');
+}
+/**
+ * Resolves the contracts a piece of work binds, from inputs a machine evaluates identically twice:
+ * file paths, code symbols, and typed brief fields. Never from free-text intent.
+ */
+async function cmdCue(opts: Opts): Promise<never> {
+  const { resolveCues, cueContracts, stageContractsWithCues } = await import('../core/stage/cues.ts');
+  const fields: Record<string, string> = {};
+  for (const pair of opts.field === undefined ? [] : [opts.field]) {
+    const [key, ...rest] = pair.split('=');
+    if (key === undefined || rest.length === 0) throw new Error('usage: omd cue --field <name>=<value>');
+    fields[key] = rest.join('=');
+  }
+  const cues = resolveCues({
+    ...(opts.path === undefined ? {} : { paths: [opts.path] }),
+    ...(opts.symbol === undefined ? {} : { symbols: [opts.symbol] }),
+    fields,
+  });
+  const contracts = opts.stage === undefined ? cueContracts(cues) : stageContractsWithCues(opts.stage, cues);
+  const result = { contracts, cues: cues.map((cue) => ({ source: cue.rule.source, matched: cue.matched, contracts: cue.rule.contracts, reason: cue.rule.reason })) };
   if (opts.json) process.stdout.write(JSON.stringify(result));
   else {
-    for (const artifact of artifacts) console.log(`  ${artifact.present ? 'have' : '    '}  ${artifact.stage.padEnd(20)} ${artifact.path}`);
-    console.log(next === undefined ? 'every recorded stage artifact exists; resume at the first unproven gate' : `next stage: ${next.stage} (${next.path})`);
+    for (const cue of result.cues) console.log(`  ${cue.source.padEnd(7)} ${cue.matched.padEnd(28)} ${cue.contracts.join(', ')}  — ${cue.reason}`);
+    console.log(contracts.length === 0 ? 'no contract is bound by these cues' : `deliver: ${contracts.join(', ')}`);
   }
   process.exit(0);
+}
+/** Validates the declared locale contract and that every Beat carries copy in every locale. */
+async function cmdLocale(mode: string | undefined, opts: Opts): Promise<never> {
+  if (mode !== 'check' || opts._.length > 0) throw new Error('usage: omd locale check [--input .omd/locale.json] [--deck .omd/copy-deck.md] [--json]');
+  const { checkLocaleCopyBinding, validateLocaleContract } = await import('../core/locale/contract.ts');
+  const contractPath = opts.input ?? join(process.cwd(), '.omd', 'locale.json');
+  const contract = validateLocaleContract(inputJson(contractPath, 'omd locale check'));
+  const deckPath = opts.deck ?? join(process.cwd(), '.omd', 'copy-deck.md');
+  const findings = existsSync(deckPath)
+    ? checkLocaleCopyBinding(contract, readFileSync(deckPath, 'utf8'))
+    : [{ id: 'LOCALE-DECK-MISSING', message: `No copy deck at ${relative(process.cwd(), deckPath)} to bind locales against.` }];
+  if (opts.json) process.stdout.write(JSON.stringify({ contract, findings }));
+  else {
+    for (const finding of findings) console.error(`[error] ${finding.id}: ${finding.message}`);
+    if (findings.length === 0) console.log(`ok — ${contract.mode} contract covers ${contract.locales.join(', ')} with primary ${contract.primary}`);
+  }
+  process.exit(findings.length > 0 ? 1 : 0);
+}
+/** Correlates the brief's stated requirements with the built page; it adds no style rule. */
+async function cmdComplete(mode: string | undefined, opts: Opts): Promise<never> {
+  const target = opts._[0];
+  if (mode !== 'check' || target === undefined || opts._.length > 1) {
+    throw new Error('usage: omd complete check <page> [--input .omd/functional-requirements.json] [--json]');
+  }
+  const { checkFunctionalCompleteness, validateFunctionalRequirements } = await import('../core/completeness/index.ts');
+  const requirements = validateFunctionalRequirements(inputJson(opts.input ?? join(process.cwd(), '.omd', 'functional-requirements.json'), 'omd complete check'));
+  const raw = await rawIrFor(opts, target);
+  const findings = checkFunctionalCompleteness(requirements, raw.nodes);
+  if (opts.json) process.stdout.write(JSON.stringify({ requirements: requirements.requirements.length, findings }));
+  else {
+    for (const finding of findings) console.error(`[error] ${finding.id} ${finding.requirement}: ${finding.message}`);
+    if (findings.length === 0) console.log(`ok — all ${requirements.requirements.length} declared requirements are present, operable, and reachable`);
+  }
+  process.exit(findings.length > 0 ? 1 : 0);
 }
 async function cmdArtDirection(mode: string | undefined, opts: Opts): Promise<never> {
   if (mode === 'alternatives-sha') {
@@ -3029,7 +3182,13 @@ function usage(): never {
     + '  art-direction alternatives-sha --input alternatives.json [--json]  canonical digest every perspective and receipt must bind\n'
     + '  art-direction check-input [--route /] [--json]  emit the check payload skeleton with canonical references filled in\n'
     + '  schema list | schema <name> [--json]        print the exact skeleton for a hand-authored input\n'
-    + '  stage status [--json]                       show which stage artifacts exist and where a resumed run continues\n'
+    + '  stage list|status|resume [--json]           stage owners, artifacts, and where a resumed run continues\n'
+    + '  stage deliver --stage <s> --contract <pack-relative.md>  record that a contract reached its stage\n'
+    + '  stage require <stage> [--json]              block until earlier artifacts exist and contracts are delivered\n'
+    + '  stage record --stage <s> | stage cost [--max-stage-tokens N] [--max-run-tokens N] [--max-run-minutes N]  per-stage cost and budget\n'
+    + '  cue [--path p] [--symbol s] [--field k=v] [--stage s] [--json]  contracts this work binds, from deterministic inputs only\n'
+    + '  locale check [--input .omd/locale.json] [--deck .omd/copy-deck.md] [--json]  validate declared locales and their Beat copy\n'
+    + '  complete check <page> [--input .omd/functional-requirements.json] [--json]  every declared requirement is present, operable, reachable\n'
     + '  intent append --input trusted-intent.json [--json]  append trusted intent and update its guarded current pointer\n'
     + '  domain check [--input domain-brief.json] [--json]  validate the domain-analysis brief\n'
     + '  craft-fidelity check --input pair.json [--json]  verify a generated part reproduced the reference craft\n'
@@ -3146,9 +3305,12 @@ async function main(): Promise<never> {
 
   if (cmd === 'design') return cmdDesign(parseArgs(args.slice(1)));
   if (cmd === 'copy') return cmdCopy(parseArgs(args.slice(1)));
+  if (cmd === 'locale') return cmdLocale(sub, parseArgs(args.slice(2)));
+  if (cmd === 'complete') return cmdComplete(sub, parseArgs(args.slice(2)));
   if (cmd === 'art-direction') return cmdArtDirection(sub, parseArgs(args.slice(2)));
   if (cmd === 'schema') return cmdSchema(sub, parseArgs(args.slice(2)));
   if (cmd === 'stage') return cmdStage(sub, parseArgs(args.slice(2)));
+  if (cmd === 'cue') return cmdCue(parseArgs(args.slice(1)));
   if (cmd === 'preflight') return cmdPreflight(parseArgs(args.slice(1)));
   if (cmd === 'composition') return cmdComposition(parseArgs(args.slice(1)));
   if (cmd === 'source') return cmdSource(sub, parseArgs(args.slice(2)));

--- a/core/completeness/index.ts
+++ b/core/completeness/index.ts
@@ -1,0 +1,132 @@
+// Functional completeness.
+//
+// The loop measures craft, hierarchy, and slop, but nothing correlated the brief's stated
+// requirements with the built page: a landing that looks right and never links to the repository
+// still passes every visual gate. This module is that correlation and nothing else — it reuses the
+// IR every other check already extracts, and adds no new style rule.
+
+import type { RawNode } from '../types.ts';
+
+export const FUNCTIONAL_REQUIREMENTS_SCHEMA = 'functional-requirements-v1' as const;
+export const REQUIREMENT_KINDS = ['action', 'preference', 'form', 'content'] as const;
+
+export type RequirementKind = (typeof REQUIREMENT_KINDS)[number];
+
+export type FunctionalRequirement = {
+  readonly id: string;
+  readonly kind: RequirementKind;
+  /** What the visitor must be able to do, in the brief's words. */
+  readonly statement: string;
+  /** Visible text that proves the affordance exists on the page. */
+  readonly label: string;
+};
+
+export type FunctionalRequirements = {
+  readonly schema: typeof FUNCTIONAL_REQUIREMENTS_SCHEMA;
+  readonly requirements: readonly FunctionalRequirement[];
+};
+
+export type CompletenessFinding = {
+  readonly id: string;
+  readonly requirement: string;
+  readonly message: string;
+};
+
+const REQUIREMENT_KEYS = ['id', 'kind', 'statement', 'label'] as const;
+
+export function validateFunctionalRequirements(value: unknown): FunctionalRequirements {
+  const fail = (message: string): never => { throw new Error(`FUNCTIONAL_REQUIREMENTS_INVALID: ${message}`); };
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return fail('requirements must be an object with schema and requirements');
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).sort().join(',') !== 'requirements,schema') return fail('requirements must contain exactly schema, requirements');
+  if (record.schema !== FUNCTIONAL_REQUIREMENTS_SCHEMA) return fail(`schema must be ${FUNCTIONAL_REQUIREMENTS_SCHEMA}`);
+  if (!Array.isArray(record.requirements) || record.requirements.length === 0) return fail('at least one requirement is required');
+  const seen = new Set<string>();
+  const requirements = record.requirements.map((entry) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return fail('each requirement must be an object');
+    const item = entry as Record<string, unknown>;
+    if (Object.keys(item).sort().join(',') !== [...REQUIREMENT_KEYS].sort().join(',')) return fail(`each requirement must contain exactly ${REQUIREMENT_KEYS.join(', ')}`);
+    if (typeof item.id !== 'string' || !/^R-\d+$/.test(item.id)) return fail('requirement id must be R-<number>');
+    if (seen.has(item.id)) return fail(`duplicate requirement ${item.id}`);
+    seen.add(item.id);
+    if (!(REQUIREMENT_KINDS as readonly unknown[]).includes(item.kind)) return fail(`requirement ${item.id} kind must be one of ${REQUIREMENT_KINDS.join(', ')}`);
+    for (const key of ['statement', 'label'] as const) {
+      if (typeof item[key] !== 'string' || (item[key] as string).trim() === '') return fail(`requirement ${item.id} needs a non-empty ${key}`);
+    }
+    return { id: item.id, kind: item.kind as RequirementKind, statement: item.statement as string, label: item.label as string };
+  });
+  return { schema: FUNCTIONAL_REQUIREMENTS_SCHEMA, requirements: Object.freeze(requirements) };
+}
+
+const normalize = (value: string): string => value.replace(/\s+/g, ' ').trim().toLowerCase();
+
+function matches(node: RawNode, label: string): boolean {
+  const text = normalize(node.text ?? '');
+  if (text === '') return false;
+  const wanted = normalize(label);
+  return text === wanted || text.includes(wanted);
+}
+
+function descendants(nodes: readonly RawNode[], root: RawNode): readonly RawNode[] {
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const out: RawNode[] = [];
+  const queue = [...root.children];
+  while (queue.length > 0) {
+    const node = byId.get(queue.shift()!);
+    if (node === undefined) continue;
+    out.push(node);
+    queue.push(...node.children);
+  }
+  return out;
+}
+
+function ancestors(nodes: readonly RawNode[], node: RawNode): readonly RawNode[] {
+  const byId = new Map(nodes.map((entry) => [entry.id, entry]));
+  const out: RawNode[] = [];
+  let current = node.parent === null ? undefined : byId.get(node.parent);
+  while (current !== undefined) {
+    out.push(current);
+    current = current.parent === null ? undefined : byId.get(current.parent);
+  }
+  return out;
+}
+
+/**
+ * A requirement is satisfied when its affordance exists, is operable, and is reachable by keyboard.
+ * `action` and `preference` need an interactive, focusable carrier; `form` needs a labelled field
+ * inside a control group; `content` only needs to be present and legible to a reader.
+ */
+export function checkFunctionalCompleteness(
+  requirements: FunctionalRequirements,
+  nodes: readonly RawNode[],
+): readonly CompletenessFinding[] {
+  const findings: CompletenessFinding[] = [];
+  for (const requirement of requirements.requirements) {
+    const carriers = nodes.filter((node) => matches(node, requirement.label));
+    if (carriers.length === 0) {
+      findings.push({ id: 'FUNC-MISSING', requirement: requirement.id, message: `${requirement.statement} — no element carries the text "${requirement.label}".` });
+      continue;
+    }
+    if (requirement.kind === 'content') continue;
+
+    if (requirement.kind === 'form') {
+      const fielded = carriers.some((carrier) => {
+        const group = [...descendants(nodes, carrier), ...ancestors(nodes, carrier).flatMap((parent) => descendants(nodes, parent))];
+        return group.some((node) => node.interactive === true);
+      });
+      if (!fielded) findings.push({ id: 'FUNC-FORM-INERT', requirement: requirement.id, message: `${requirement.statement} — "${requirement.label}" labels no interactive field.` });
+      continue;
+    }
+
+    const operable = carriers.filter((carrier) => carrier.interactive === true || descendants(nodes, carrier).some((node) => node.interactive === true) || ancestors(nodes, carrier).some((node) => node.interactive === true));
+    if (operable.length === 0) {
+      findings.push({ id: 'FUNC-INERT', requirement: requirement.id, message: `${requirement.statement} — "${requirement.label}" is text, not an operable control.` });
+      continue;
+    }
+    const reachable = operable.some((carrier) => [carrier, ...ancestors(nodes, carrier)].some((node) => node.focusable === true));
+    if (!reachable) {
+      findings.push({ id: 'FUNC-UNREACHABLE', requirement: requirement.id, message: `${requirement.statement} — "${requirement.label}" is not reachable by keyboard.` });
+    }
+  }
+  return findings;
+}

--- a/core/locale/contract.ts
+++ b/core/locale/contract.ts
@@ -1,0 +1,109 @@
+// Locale contract and its copy binding.
+//
+// A second locale is not a second string table: it changes line length, control width, and what a
+// visitor already believes. `protocol/locale-contract.md` states the obligations; this module
+// validates the two that are mechanically checkable before a browser exists — that the declared
+// contract is coherent, and that every Beat the page argues has real copy in every declared locale.
+
+export const LOCALE_CONTRACT_SCHEMA = 'locale-contract-v1' as const;
+export const LOCALE_MODES = ['language-only', 'regional', 'market-specific'] as const;
+export const LOCALE_CONTRACT_KEYS = ['schema', 'mode', 'locales', 'primary'] as const;
+
+export type LocaleMode = (typeof LOCALE_MODES)[number];
+
+export type LocaleContract = {
+  readonly schema: typeof LOCALE_CONTRACT_SCHEMA;
+  readonly mode: LocaleMode;
+  readonly locales: readonly string[];
+  readonly primary: string;
+};
+
+export type LocaleFinding = { readonly id: string; readonly message: string };
+
+const TAG = /^[a-z]{2,3}(-[A-Z][a-z]{3})?(-([A-Z]{2}|\d{3}))?$/;
+const PLACEHOLDER = /^(tbd|todo|n\/a|-{1,3}|\.\.\.|…)$/i;
+
+export function validateLocaleContract(value: unknown): LocaleContract {
+  const fail = (message: string): never => { throw new Error(`LOCALE_CONTRACT_INVALID: ${message}`); };
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return fail(`contract must be an object with keys: ${LOCALE_CONTRACT_KEYS.join(', ')}`);
+  const record = value as Record<string, unknown>;
+  const missing = LOCALE_CONTRACT_KEYS.filter((key) => !Object.hasOwn(record, key));
+  const unknown = Object.keys(record).filter((key) => !(LOCALE_CONTRACT_KEYS as readonly string[]).includes(key));
+  if (missing.length > 0 || unknown.length > 0) {
+    return fail(`contract must contain exactly ${LOCALE_CONTRACT_KEYS.join(', ')}${missing.length > 0 ? `; missing: ${missing.join(', ')}` : ''}${unknown.length > 0 ? `; unknown: ${unknown.join(', ')}` : ''}`);
+  }
+  if (record.schema !== LOCALE_CONTRACT_SCHEMA) return fail(`schema must be ${LOCALE_CONTRACT_SCHEMA}`);
+  if (!(LOCALE_MODES as readonly unknown[]).includes(record.mode)) return fail(`mode must be one of ${LOCALE_MODES.join(', ')}`);
+  const locales = record.locales;
+  if (!Array.isArray(locales) || locales.length < 2 || locales.some((locale) => typeof locale !== 'string' || !TAG.test(locale))) {
+    return fail('locales must be two or more BCP-47 tags such as ko-KR, en-US');
+  }
+  if (new Set(locales as string[]).size !== locales.length) return fail('locales must be unique');
+  if (typeof record.primary !== 'string' || !(locales as string[]).includes(record.primary)) return fail('primary must be one of the declared locales');
+  return { schema: LOCALE_CONTRACT_SCHEMA, mode: record.mode as LocaleMode, locales: Object.freeze([...(locales as string[])]), primary: record.primary };
+}
+
+type Table = { readonly header: readonly string[]; readonly rows: readonly (readonly string[])[] };
+
+function parseTable(markdown: string, requiredColumn: string): Table | undefined {
+  const rows = markdown.split('\n')
+    .filter((line) => line.trim().startsWith('|'))
+    .map((line) => line.trim().replace(/^\||\|$/g, '').split('|').map((cell) => cell.trim()));
+  const headerIndex = rows.findIndex((cells) => cells.includes(requiredColumn));
+  if (headerIndex === -1) return undefined;
+  return {
+    header: rows[headerIndex]!,
+    rows: rows.slice(headerIndex + 1).filter((cells) => !cells.every((cell) => /^:?-{3,}:?$/.test(cell))),
+  };
+}
+
+function section(deck: string, title: string): string | undefined {
+  const pattern = new RegExp(`^##\\s+${title}\\s*$`, 'im');
+  const match = pattern.exec(deck);
+  if (match === null) return undefined;
+  const rest = deck.slice(match.index + match[0].length);
+  const next = /^##\s+/m.exec(rest);
+  return next === null ? rest : rest.slice(0, next.index);
+}
+
+/**
+ * Beats are locale-independent; their wording is not. Every Beat the art-direction contract names
+ * must carry real copy for every declared locale — a blank or placeholder cell is a hole in the
+ * page for that visitor, never a silent fallback to another language.
+ */
+export function checkLocaleCopyBinding(contract: LocaleContract, deck: string): readonly LocaleFinding[] {
+  const findings: LocaleFinding[] = [];
+  const artDirection = section(deck, 'Art direction contract');
+  const localeCopy = section(deck, 'Locale copy');
+  if (artDirection === undefined) return [{ id: 'LOCALE-DECK-SECTION', message: 'Copy deck has no `## Art direction contract` section to read Beat IDs from.' }];
+  if (localeCopy === undefined) return [{ id: 'LOCALE-DECK-SECTION', message: 'A multi-locale deck needs a `## Locale copy` section with one column per declared locale.' }];
+
+  const beats = parseTable(artDirection, 'Beat ID');
+  const copy = parseTable(localeCopy, 'Beat ID');
+  if (beats === undefined) return [{ id: 'LOCALE-DECK-SECTION', message: 'Art direction contract has no Beat ID table.' }];
+  if (copy === undefined) return [{ id: 'LOCALE-DECK-SECTION', message: 'Locale copy section has no Beat ID table.' }];
+
+  const beatColumn = copy.header.indexOf('Beat ID');
+  const declared = new Set(beats.rows.map((cells) => cells[beats.header.indexOf('Beat ID')] ?? '').filter((id) => id !== ''));
+  for (const locale of contract.locales) {
+    if (!copy.header.includes(locale)) findings.push({ id: 'LOCALE-COLUMN-MISSING', message: `Locale copy table has no ${locale} column.` });
+  }
+  const covered = new Set<string>();
+  for (const cells of copy.rows) {
+    const beat = cells[beatColumn] ?? '';
+    if (beat === '') continue;
+    covered.add(beat);
+    if (!declared.has(beat)) findings.push({ id: 'LOCALE-BEAT-UNKNOWN', message: `Locale copy row ${beat} is not a Beat the art-direction contract declares.` });
+    for (const locale of contract.locales) {
+      const column = copy.header.indexOf(locale);
+      if (column === -1) continue;
+      const text = cells[column] ?? '';
+      if (text === '') findings.push({ id: 'LOCALE-COPY-MISSING', message: `Beat ${beat} has no ${locale} copy.` });
+      else if (PLACEHOLDER.test(text)) findings.push({ id: 'LOCALE-COPY-PLACEHOLDER', message: `Beat ${beat} has placeholder ${locale} copy (${text}).` });
+    }
+  }
+  for (const beat of declared) {
+    if (!covered.has(beat)) findings.push({ id: 'LOCALE-BEAT-UNCOVERED', message: `Beat ${beat} has no row in the locale copy table.` });
+  }
+  return findings;
+}

--- a/core/protocol/locale-contract.md
+++ b/core/protocol/locale-contract.md
@@ -1,0 +1,68 @@
+# Locale contract
+
+More than one locale is not a translation task. The same page in another language changes line
+length, control width, reading order emphasis, and what a visitor already believes before the first
+sentence. This contract states what a multi-locale run owes, and what it may not claim.
+
+## Modes
+
+- `language-only` — same market, same offer, same proof. Only the language changes. Copy is
+  rewritten for the language, never machine-translated, but the message ladder is shared.
+- `regional` — same product, different operating conditions: currency, address, phone, date, and
+  legal notices differ. The message ladder may reorder; it may not gain claims.
+- `market-specific` — different offer or audience per market. Each locale gets its own frame and
+  its own copy deck, and shares only the design system.
+
+A run declares exactly one mode. Escalating mode mid-run invalidates the copy deck, because the
+lower mode's deck was written under an assumption the higher mode removes.
+
+## Beat binding
+
+Beats are locale-independent. A Beat is the argument the page makes at that point; its wording is
+not. Every locale carries the same Beat IDs in the same order, and each Beat has one entry per
+declared locale. A missing entry is a hole in the page for that visitor, not a fallback: never let
+one locale silently render another's string.
+
+The primary locale is the source of truth for fact IDs. A non-primary locale may not introduce a
+fact the primary deck does not carry, because a fact that exists in only one language cannot be
+verified by the same evidence.
+
+## Layout expansion
+
+Language changes physical length. The build must hold at the widest declared locale, not the one it
+was designed in. Korean to English typically expands; German and Finnish expand further; Japanese
+and Chinese contract in character count but need different line-breaking.
+
+The obligations are measurable and belong to the build, not to copy review:
+
+- No fixed-height control may clip its longest declared label.
+- No single-line heading may overflow its container at the narrowest declared viewport.
+- A control that wraps in one locale must wrap legibly in all of them; a locale-specific hack that
+  fixes one language by breaking another is a defect.
+
+## Control state
+
+A locale switch is a preference control, not navigation. It must:
+
+- carry an accessible name that states what it switches, in the language currently rendered;
+- expose the active locale by something other than colour alone;
+- be reachable and operable by keyboard;
+- persist across reload, and survive a hard refresh without resetting to the default locale.
+
+The same applies to a theme control when the run declares one. Preference controls are grouped and
+independently reachable; neither may be the only way to reach the other.
+
+## Document signals
+
+Every rendered locale sets the document language on the root element, and each localized route
+declares its own title and description. In `regional` and `market-specific` modes the run also owes
+alternate-language links between the equivalent routes, and locale-appropriate formats for date,
+currency, address, and phone number.
+
+## What a locale run may not claim
+
+- It may not claim a market it has no evidence about. Audience evidence is per locale; a Korean
+  audience study does not license a claim about a Japanese buyer.
+- It may not present machine translation as authored copy.
+- It may not use a flag to denote a language.
+- It may not treat the primary locale as complete while another declared locale is a stub.

--- a/core/schema/inputs.ts
+++ b/core/schema/inputs.ts
@@ -6,6 +6,8 @@
 
 import { DEPTH_INPUT_KEYS, DEPTH_INPUT_SCHEMA, DEPTH_SCOPES } from '../deliberation/depth.ts';
 import { ART_DIRECTION_CHECK_INPUT_KEYS } from '../art-direction/schema.ts';
+import { LOCALE_CONTRACT_KEYS, LOCALE_CONTRACT_SCHEMA, LOCALE_MODES } from '../locale/contract.ts';
+import { FUNCTIONAL_REQUIREMENTS_SCHEMA, REQUIREMENT_KINDS } from '../completeness/index.ts';
 
 export type InputSkeleton = {
   readonly name: string;
@@ -84,7 +86,36 @@ const ART_DIRECTION_CHECK: InputSkeleton = {
   },
 };
 
-export const INPUT_SKELETONS: readonly InputSkeleton[] = [DEPTH_INPUT, ART_DIRECTION_CHECK];
+const LOCALE_CONTRACT: InputSkeleton = {
+  name: 'locale-contract',
+  path: '.omd/locale.json',
+  command: 'omd locale check --json',
+  keys: LOCALE_CONTRACT_KEYS,
+  skeleton: {
+    schema: LOCALE_CONTRACT_SCHEMA,
+    mode: LOCALE_MODES[0],
+    locales: ['ko-KR', 'en-US'],
+    primary: 'ko-KR',
+  },
+};
+
+const FUNCTIONAL_REQUIREMENTS: InputSkeleton = {
+  name: 'functional-requirements',
+  path: '.omd/functional-requirements.json',
+  command: 'omd complete check <page> --json',
+  keys: ['schema', 'requirements'],
+  skeleton: {
+    schema: FUNCTIONAL_REQUIREMENTS_SCHEMA,
+    requirements: [{
+      id: 'R-1',
+      kind: REQUIREMENT_KINDS[0],
+      statement: "<what the visitor must be able to do, in the brief's words>",
+      label: '<the visible text that proves the affordance exists>',
+    }],
+  },
+};
+
+export const INPUT_SKELETONS: readonly InputSkeleton[] = [DEPTH_INPUT, ART_DIRECTION_CHECK, LOCALE_CONTRACT, FUNCTIONAL_REQUIREMENTS];
 
 export function inputSkeleton(name: string): InputSkeleton {
   const found = INPUT_SKELETONS.find((entry) => entry.name === name);

--- a/core/stage/contract.ts
+++ b/core/stage/contract.ts
@@ -1,0 +1,178 @@
+// Stage state for a design run.
+//
+// The loop already owns each durable artifact; what it lacked was a machine-readable answer to
+// "which stage am I in, what did an earlier owner already produce, and which contracts were
+// actually handed to the role that needs them". A long run that compacts its context, or a run
+// that died mid-stage, otherwise restarts at the domain brief and rewrites owned artifacts.
+//
+// State is derived from the artifacts on disk. The one fact that cannot be derived is delivery:
+// whether a contract's exact bytes reached the stage that must obey them. That is the only thing
+// this module persists, append-only, in `.omd/delivery.jsonl`.
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const DELIVERY_RECEIPT_SCHEMA = 'stage-delivery-v1' as const;
+export const DELIVERY_LOG = '.omd/delivery.jsonl';
+
+export type StageId =
+  | 'domain' | 'depth' | 'frame' | 'acquisition' | 'scout' | 'reference-board'
+  | 'reference-selection' | 'art-direction' | 'copy' | 'type-proof' | 'composition';
+
+export type StageDefinition = {
+  readonly id: StageId;
+  /** The role that writes the artifact; the coordinator never substitutes for a named owner. */
+  readonly owner: string;
+  /** Project-relative artifact whose existence proves the stage produced its output. */
+  readonly artifact: string;
+  /** Pack-relative contracts this stage's owner must receive before it runs. */
+  readonly requiredContracts: readonly string[];
+};
+
+export const STAGES: readonly StageDefinition[] = Object.freeze([
+  { id: 'domain', owner: 'coordinator', artifact: '.omd/domain-brief.json', requiredContracts: ['protocol/domain-analysis.md'] },
+  { id: 'depth', owner: 'coordinator', artifact: '.omd/depth.json', requiredContracts: ['protocol/design-deliberation.md'] },
+  { id: 'frame', owner: 'omd-framer', artifact: '.omd/frame.md', requiredContracts: ['protocol/human-design-loop.md', 'theory/ux.md'] },
+  { id: 'acquisition', owner: 'omd-framer', artifact: '.omd/acquisition-plan.json', requiredContracts: ['protocol/reference-assembly.md'] },
+  { id: 'scout', owner: 'omd-scout', artifact: '.omd/scout.md', requiredContracts: ['protocol/reference-assembly.md'] },
+  { id: 'reference-board', owner: 'omd-scout', artifact: '.omd/reference-board.json', requiredContracts: ['protocol/reference-assembly.md'] },
+  { id: 'reference-selection', owner: 'coordinator', artifact: '.omd/reference-pre-selection-v2.json', requiredContracts: ['protocol/reference-assembly.md'] },
+  { id: 'art-direction', owner: 'coordinator', artifact: '.omd/art-direction.json', requiredContracts: ['protocol/design-deliberation.md'] },
+  { id: 'copy', owner: 'omd-writer', artifact: '.omd/copy-deck.md', requiredContracts: ['protocol/copy-deck.md', 'theory/voice.md'] },
+  { id: 'type-proof', owner: 'omd-typesetter', artifact: '.omd/type-proof.md', requiredContracts: ['theory/typography.md'] },
+  { id: 'composition', owner: 'omd-composer', artifact: '.omd/composition.md', requiredContracts: ['protocol/composition-contract.md', 'theory/layout.md'] },
+].map((stage) => Object.freeze({ ...stage, requiredContracts: Object.freeze(stage.requiredContracts) })) as StageDefinition[]);
+
+export type DeliveryReceipt = {
+  readonly schema: typeof DELIVERY_RECEIPT_SCHEMA;
+  readonly stage: StageId;
+  readonly contract: string;
+  readonly sha256: string;
+  readonly at: string;
+};
+
+export type StageState = {
+  readonly stage: StageId;
+  readonly owner: string;
+  readonly artifact: string;
+  readonly present: boolean;
+  /** Contracts whose exact current bytes have a receipt for this stage. */
+  readonly delivered: readonly string[];
+  readonly undelivered: readonly string[];
+};
+
+export type RunState = {
+  readonly completed: readonly StageId[];
+  readonly current: StageId | null;
+  readonly stages: readonly StageState[];
+};
+
+export class StageError extends Error {}
+
+const digest = (bytes: Buffer): string => createHash('sha256').update(bytes).digest('hex');
+
+export function stageDefinition(id: string): StageDefinition {
+  const found = STAGES.find((stage) => stage.id === id);
+  if (found === undefined) throw new StageError(`unknown stage ${id}; known: ${STAGES.map((stage) => stage.id).join(', ')}`);
+  return found;
+}
+
+/** Strict lookup for delivery: handing over a contract that does not exist is a caller error. */
+export function contractSha256(packRoot: string, contract: string): string {
+  const current = currentContractSha256(packRoot, contract);
+  if (current === undefined) throw new StageError(`contract ${contract} does not exist under the knowledge pack`);
+  return current;
+}
+
+/**
+ * State resolution must survive a missing contract: an absent file leaves its stage blocked with a
+ * named reason instead of collapsing the whole run state.
+ */
+function currentContractSha256(packRoot: string, contract: string): string | undefined {
+  const path = join(packRoot, contract);
+  return existsSync(path) ? digest(readFileSync(path)) : undefined;
+}
+
+export function readDeliveryReceipts(projectRoot: string): readonly DeliveryReceipt[] {
+  const path = join(projectRoot, DELIVERY_LOG);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line, index) => {
+      let value: unknown;
+      try { value = JSON.parse(line); } catch { throw new StageError(`delivery log line ${index + 1} is not JSON`); }
+      return validateDeliveryReceipt(value);
+    });
+}
+
+export function validateDeliveryReceipt(value: unknown): DeliveryReceipt {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new StageError('delivery receipt must be an object');
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).sort().join(',') !== 'at,contract,schema,sha256,stage') throw new StageError('delivery receipt has unknown or missing keys');
+  if (record.schema !== DELIVERY_RECEIPT_SCHEMA) throw new StageError(`delivery receipt schema must be ${DELIVERY_RECEIPT_SCHEMA}`);
+  if (typeof record.contract !== 'string' || record.contract === '') throw new StageError('delivery receipt needs a contract path');
+  if (typeof record.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(record.sha256)) throw new StageError('delivery receipt needs a SHA-256 digest');
+  if (typeof record.at !== 'string' || !Number.isFinite(Date.parse(record.at))) throw new StageError('delivery receipt needs an ISO timestamp');
+  return { schema: DELIVERY_RECEIPT_SCHEMA, stage: stageDefinition(String(record.stage)).id, contract: record.contract, sha256: record.sha256, at: record.at };
+}
+
+/**
+ * A receipt only counts while the contract's bytes still match: an edited protocol invalidates the
+ * handoff that quoted the old text, exactly like every other digest-bound record in the loop.
+ */
+export function resolveRunState(projectRoot: string, packRoot: string): RunState {
+  const receipts = readDeliveryReceipts(projectRoot);
+  const stages = STAGES.map((stage) => {
+    const delivered: string[] = [];
+    const undelivered: string[] = [];
+    for (const contract of stage.requiredContracts) {
+      const current = currentContractSha256(packRoot, contract);
+      const fresh = current !== undefined && receipts.some((receipt) => receipt.stage === stage.id && receipt.contract === contract && receipt.sha256 === current);
+      (fresh ? delivered : undelivered).push(contract);
+    }
+    return {
+      stage: stage.id,
+      owner: stage.owner,
+      artifact: stage.artifact,
+      present: existsSync(join(projectRoot, stage.artifact)),
+      delivered,
+      undelivered,
+    };
+  });
+  const completed = stages.filter((stage) => stage.present).map((stage) => stage.stage);
+  return { completed, current: stages.find((stage) => !stage.present)?.stage ?? null, stages };
+}
+
+export function deliveryReceipt(stage: StageId, contract: string, sha256: string, at: string): DeliveryReceipt {
+  return { schema: DELIVERY_RECEIPT_SCHEMA, stage: stageDefinition(stage).id, contract, sha256, at };
+}
+
+export function serializeDeliveryLog(receipts: readonly DeliveryReceipt[]): string {
+  return `${receipts.map((receipt) => JSON.stringify(receipt)).join('\n')}\n`;
+}
+
+export type StageRequirement = {
+  readonly stage: StageId;
+  readonly ok: boolean;
+  readonly missingArtifacts: readonly string[];
+  readonly undeliveredContracts: readonly string[];
+};
+
+/**
+ * The gate a stage runs before its owner is spawned. It fails on the two conditions a long run
+ * cannot detect for itself: an earlier owner never produced its artifact, and a contract this
+ * stage must obey was never delivered with its current bytes.
+ */
+export function requireStage(projectRoot: string, packRoot: string, id: string): StageRequirement {
+  const definition = stageDefinition(id);
+  const state = resolveRunState(projectRoot, packRoot);
+  const index = STAGES.findIndex((stage) => stage.id === definition.id);
+  const missingArtifacts = state.stages
+    .slice(0, index)
+    .filter((stage) => !stage.present)
+    .map((stage) => stage.artifact);
+  const undeliveredContracts = state.stages[index]!.undelivered;
+  return { stage: definition.id, ok: missingArtifacts.length === 0 && undeliveredContracts.length === 0, missingArtifacts, undeliveredContracts };
+}

--- a/core/stage/cues.ts
+++ b/core/stage/cues.ts
@@ -1,0 +1,99 @@
+// Deterministic contract cues.
+//
+// Storing a rule and delivering it at the moment it binds are different things: a long run reads
+// the pack once and then works for an hour without re-reading it. Cues close that gap, but only
+// from inputs a machine can evaluate the same way twice — a file path, a code symbol, and typed
+// fields the frame and domain brief already carry.
+//
+// Free-text intent is deliberately not a cue source. A trigger the agent interprets is exactly the
+// discipline this module exists to replace.
+
+import { STAGES, StageError, stageDefinition, type StageId } from './contract.ts';
+
+export type CueSource = 'path' | 'symbol' | 'field';
+
+export type CueRule = {
+  readonly source: CueSource;
+  /** Path glob (`**\/landing\/**`), exact symbol name, or `field:value` for a typed brief field. */
+  readonly match: string;
+  /** Pack-relative contracts this cue requires before the work continues. */
+  readonly contracts: readonly string[];
+  readonly reason: string;
+};
+
+export const CUE_RULES: readonly CueRule[] = Object.freeze([
+  { source: 'path', match: '**/landing/**', contracts: ['theory/craft.md', 'protocol/copy-deck.md'], reason: 'a landing surface is judged on persuasion craft and copy, not component correctness' },
+  { source: 'path', match: '**/dashboard/**', contracts: ['theory/ux.md'], reason: 'a dashboard is a product surface whose risk is task completion' },
+  { source: 'path', match: '**/*.stories.*', contracts: ['theory/components.md'], reason: 'a story file states component states that must match the component contract' },
+  { source: 'symbol', match: 'Dialog', contracts: ['theory/components.md', 'theory/ux.md'], reason: 'a dialog owns focus, escape, and return-focus behaviour' },
+  { source: 'symbol', match: 'form', contracts: ['theory/ux.md'], reason: 'a form owns validation, error, and recovery states' },
+  { source: 'symbol', match: 'canvas', contracts: ['theory/motion.md'], reason: 'canvas work carries motion and performance obligations' },
+  { source: 'field', match: 'surface:marketing', contracts: ['theory/craft.md'], reason: 'a marketing surface must earn a signature moment' },
+  { source: 'field', match: 'surface:product', contracts: ['theory/ux.md'], reason: 'a product surface is judged on task completion' },
+  { source: 'field', match: 'motionDecision:one', contracts: ['theory/motion.md'], reason: 'a selected motion carries the reduced-motion and trigger contract' },
+  { source: 'field', match: 'motionDecision:none', contracts: ['theory/layout.md'], reason: 'a static direction still owes a designed template departure' },
+  { source: 'field', match: 'localization:multi-locale', contracts: ['protocol/locale-contract.md'], reason: 'more than one locale changes copy, layout width, and control state' },
+].map((rule) => Object.freeze({ ...rule, contracts: Object.freeze(rule.contracts) })) as CueRule[]);
+
+export type CueInput = {
+  readonly paths?: readonly string[];
+  readonly symbols?: readonly string[];
+  /** Typed fields already validated elsewhere: `{ surface: 'marketing', motionDecision: 'none' }`. */
+  readonly fields?: Readonly<Record<string, string>>;
+};
+
+export type Cue = {
+  readonly rule: CueRule;
+  readonly matched: string;
+};
+
+/** Minimal glob: `**` spans separators, `*` stops at one, everything else is literal. */
+function globMatches(glob: string, path: string): boolean {
+  const pattern = glob
+    .split(/(\*\*|\*)/)
+    .map((part) => (part === '**' ? '.*' : part === '*' ? '[^/]*' : part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    .join('');
+  return new RegExp(`^${pattern}$`).test(path);
+}
+
+export function resolveCues(input: CueInput): readonly Cue[] {
+  const cues: Cue[] = [];
+  for (const rule of CUE_RULES) {
+    if (rule.source === 'path') {
+      for (const path of input.paths ?? []) if (globMatches(rule.match, path)) cues.push({ rule, matched: path });
+    } else if (rule.source === 'symbol') {
+      for (const symbol of input.symbols ?? []) if (symbol === rule.match) cues.push({ rule, matched: symbol });
+    } else {
+      const [field, value] = rule.match.split(':');
+      const actual = (input.fields ?? {})[field ?? ''];
+      if (actual !== undefined && actual === value) cues.push({ rule, matched: rule.match });
+    }
+  }
+  return cues;
+}
+
+export function cueContracts(cues: readonly Cue[]): readonly string[] {
+  return [...new Set(cues.flatMap((cue) => cue.rule.contracts))].sort();
+}
+
+/**
+ * Contracts a stage must hold: its own declared set plus everything the current cues add. The
+ * caller delivers the union, so a cue can only ever widen the obligation.
+ */
+export function stageContractsWithCues(stage: StageId | string, cues: readonly Cue[]): readonly string[] {
+  const definition = stageDefinition(String(stage));
+  return [...new Set([...definition.requiredContracts, ...cueContracts(cues)])].sort();
+}
+
+export function validateCueRules(rules: readonly CueRule[] = CUE_RULES): void {
+  const seen = new Set<string>();
+  for (const rule of rules) {
+    const key = `${rule.source}:${rule.match}`;
+    if (seen.has(key)) throw new StageError(`duplicate cue rule ${key}`);
+    seen.add(key);
+    if (rule.contracts.length === 0) throw new StageError(`cue ${key} delivers no contract`);
+    if (rule.reason.trim() === '') throw new StageError(`cue ${key} has no reason`);
+    if (rule.source === 'field' && rule.match.split(':').length !== 2) throw new StageError(`field cue ${key} must be field:value`);
+  }
+  if (STAGES.length === 0) throw new StageError('cue rules require a stage table');
+}

--- a/core/stage/usage.ts
+++ b/core/stage/usage.ts
@@ -1,0 +1,119 @@
+// Per-stage cost accounting.
+//
+// A full L4 run costs about an hour of wall clock and a large share of a weekly model quota. When
+// one dies the run reports nothing about where the budget went, so nobody can tell an expensive
+// stage from a runaway one. Host logs only expose a cumulative total, so a stage's cost is the
+// delta between the snapshot taken when it ended and the previous one.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { stageDefinition, StageError, type StageId } from './contract.ts';
+
+export const STAGE_USAGE_SCHEMA = 'stage-usage-v1' as const;
+export const STAGE_USAGE_LOG = '.omd/stage-usage.jsonl';
+
+export type StageUsageSample = {
+  readonly schema: typeof STAGE_USAGE_SCHEMA;
+  readonly stage: StageId;
+  readonly at: string;
+  /** Cumulative run totals at the moment the stage ended, as reported by the host session log. */
+  readonly totalTokens: number;
+  readonly outputTokens: number;
+  readonly elapsedMs: number;
+  readonly approximate: boolean;
+};
+
+export type StageCost = {
+  readonly stage: StageId;
+  readonly totalTokens: number;
+  readonly outputTokens: number;
+  readonly elapsedMs: number;
+  /** True when the host total moved backwards or the source declared itself partial. */
+  readonly approximate: boolean;
+};
+
+export type StageBudget = {
+  readonly maxStageTokens?: number;
+  readonly maxRunTokens?: number;
+  readonly maxRunElapsedMs?: number;
+};
+
+export type StageBudgetReport = {
+  readonly ok: boolean;
+  readonly costs: readonly StageCost[];
+  readonly runTokens: number;
+  readonly runElapsedMs: number;
+  readonly findings: readonly string[];
+};
+
+export function validateStageUsageSample(value: unknown): StageUsageSample {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new StageError('stage usage sample must be an object');
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).sort().join(',') !== 'approximate,at,elapsedMs,outputTokens,schema,stage,totalTokens') throw new StageError('stage usage sample has unknown or missing keys');
+  if (record.schema !== STAGE_USAGE_SCHEMA) throw new StageError(`stage usage schema must be ${STAGE_USAGE_SCHEMA}`);
+  if (typeof record.at !== 'string' || !Number.isFinite(Date.parse(record.at))) throw new StageError('stage usage sample needs an ISO timestamp');
+  if (typeof record.approximate !== 'boolean') throw new StageError('stage usage sample needs an approximate flag');
+  for (const key of ['totalTokens', 'outputTokens', 'elapsedMs'] as const) {
+    if (!Number.isFinite(record[key]) || (record[key] as number) < 0) throw new StageError(`stage usage ${key} must be a non-negative number`);
+  }
+  return {
+    schema: STAGE_USAGE_SCHEMA,
+    stage: stageDefinition(String(record.stage)).id,
+    at: record.at,
+    totalTokens: record.totalTokens as number,
+    outputTokens: record.outputTokens as number,
+    elapsedMs: record.elapsedMs as number,
+    approximate: record.approximate,
+  };
+}
+
+export function readStageUsage(projectRoot: string): readonly StageUsageSample[] {
+  const path = join(projectRoot, STAGE_USAGE_LOG);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line, index) => {
+      let value: unknown;
+      try { value = JSON.parse(line); } catch { throw new StageError(`stage usage log line ${index + 1} is not JSON`); }
+      return validateStageUsageSample(value);
+    });
+}
+
+export function serializeStageUsage(samples: readonly StageUsageSample[]): string {
+  return `${samples.map((sample) => JSON.stringify(sample)).join('\n')}\n`;
+}
+
+/** Deltas between consecutive snapshots. A backwards total means the host log rotated: clamp and flag. */
+export function stageCosts(samples: readonly StageUsageSample[]): readonly StageCost[] {
+  let previous: StageUsageSample | undefined;
+  return samples.map((sample) => {
+    const delta = (current: number, before: number): number => (current >= before ? current - before : current);
+    const rolled = previous !== undefined && (sample.totalTokens < previous.totalTokens || sample.elapsedMs < previous.elapsedMs);
+    const cost: StageCost = {
+      stage: sample.stage,
+      totalTokens: previous === undefined ? sample.totalTokens : delta(sample.totalTokens, previous.totalTokens),
+      outputTokens: previous === undefined ? sample.outputTokens : delta(sample.outputTokens, previous.outputTokens),
+      elapsedMs: previous === undefined ? sample.elapsedMs : delta(sample.elapsedMs, previous.elapsedMs),
+      approximate: sample.approximate || rolled,
+    };
+    previous = sample;
+    return cost;
+  });
+}
+
+export function evaluateStageBudget(samples: readonly StageUsageSample[], budget: StageBudget): StageBudgetReport {
+  const costs = stageCosts(samples);
+  const last = samples[samples.length - 1];
+  const runTokens = last?.totalTokens ?? 0;
+  const runElapsedMs = last?.elapsedMs ?? 0;
+  const findings: string[] = [];
+  if (budget.maxStageTokens !== undefined) {
+    for (const cost of costs) {
+      if (cost.totalTokens > budget.maxStageTokens) findings.push(`stage ${cost.stage} used ${cost.totalTokens} tokens over the ${budget.maxStageTokens} stage budget`);
+    }
+  }
+  if (budget.maxRunTokens !== undefined && runTokens > budget.maxRunTokens) findings.push(`run used ${runTokens} tokens over the ${budget.maxRunTokens} run budget`);
+  if (budget.maxRunElapsedMs !== undefined && runElapsedMs > budget.maxRunElapsedMs) findings.push(`run took ${Math.round(runElapsedMs / 60000)} minutes over the ${Math.round(budget.maxRunElapsedMs / 60000)} minute budget`);
+  return { ok: findings.length === 0, costs, runTokens, runElapsedMs, findings };
+}

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -110,10 +110,29 @@ working directory first. A Figma frame or exact visual target uses the single Fi
 route declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather
 than handing the run off or terminating this loop.
 
-A resumed or restarted run does not begin again at the domain brief. Run `omd stage status` first and
-continue at the first stage whose artifact is missing; artifacts an earlier owner already wrote stay
-authoritative, and rewriting one yourself is the same ownership violation as writing it the first
-time.
+A resumed or restarted run does not begin again at the domain brief. Run `omd stage resume` first
+and continue at the stage it names; artifacts an earlier owner already wrote stay authoritative, and
+rewriting one yourself is the same ownership violation as writing it the first time. The same
+command is the recovery step after a context compaction: it reports the current stage, the owner of
+every artifact, and the contracts that stage still needs.
+
+Before spawning a stage's owner, hand it its contracts and record that handoff:
+`omd stage deliver --stage <stage> --contract <pack-relative.md>` for each contract
+`omd stage list` names, then `omd stage require <stage>`. `require` exits non-zero while an earlier
+owner's artifact is missing or a contract has no receipt for its current bytes; that is a hard stop,
+not a warning. Editing a contract invalidates its receipt, so a mid-run protocol change forces a
+fresh delivery rather than a silent divergence between what the role read and what the loop
+requires. Never claim a role received a contract without its receipt.
+
+Contracts are also bound by the work itself, not only by the stage. Before handing a role its task,
+run `omd cue --path <file> --symbol <symbol> --field <name>=<value>` for the paths, symbols, and
+typed frame fields that task touches, and deliver everything it returns alongside the stage's own
+contracts. Cues resolve only from those deterministic inputs; a rule that needed the coordinator to
+interpret intent would be the same undelivered-knowledge failure in a new costume.
+
+Record cost at each stage boundary with `omd stage record --stage <stage>` and read it back with
+`omd stage cost`. A run that dies with no cost record cannot tell an expensive stage from a runaway
+one, and the next run repeats the same spend.
 
 Before spawning an artifact owner, classify depth. The coordinator writes only the routing input
 `.omd/depth.json` as `design-depth-input-v1` — print its exact skeleton with
@@ -715,6 +734,16 @@ selected frame. Source-candidate triage has no untriaged or needs-render items a
   persists `.omd/reference-report.md`; paste the pure formatter's exact Korean-first bilingual
   Markdown unchanged into the final chat. Everything is clean or has an evidence-backed deliberate
   overrule.
+A declared requirement is not shipped because the page looks finished. Write the brief's stated
+requirements to `.omd/functional-requirements.json` as `functional-requirements-v1` — print its
+shape with `omd schema functional-requirements` — and run `omd complete check <page>`. It fails
+when a declared affordance is absent, is text rather than an operable control, or cannot be reached
+by keyboard. It adds no style rule; it only proves the page does what the brief said it would.
+
+When the run declares more than one locale, `.omd/locale.json` is `locale-contract-v1` and
+`omd locale check` must pass before ship: every Beat carries real copy in every declared locale,
+and no locale silently falls back to another. Read `protocol/locale-contract.md` for the layout,
+control-state, and document-signal obligations that go with it.
 Regardless of whether reference assembly applied, close the final chat response with this run's usage: run `omd usage` and include its elapsed-time and token total in your final message to the user. It reads the host session log (Claude Code or Codex); if no log is found it prints a short unavailable note, which you simply omit rather than fabricating a number.
 When the run is an iteration with a before/after pair, form the pairwise blind-choose verdict:
 blind-choose is the visual distinction signal only; applicable task probes, accessibility checks, and

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -110,10 +110,29 @@ working directory first. A Figma frame or exact visual target uses the single Fi
 route declared above; it retains content, craft, glance, probe, critique, and all UX evidence rather
 than handing the run off or terminating this loop.
 
-A resumed or restarted run does not begin again at the domain brief. Run `omd stage status` first and
-continue at the first stage whose artifact is missing; artifacts an earlier owner already wrote stay
-authoritative, and rewriting one yourself is the same ownership violation as writing it the first
-time.
+A resumed or restarted run does not begin again at the domain brief. Run `omd stage resume` first
+and continue at the stage it names; artifacts an earlier owner already wrote stay authoritative, and
+rewriting one yourself is the same ownership violation as writing it the first time. The same
+command is the recovery step after a context compaction: it reports the current stage, the owner of
+every artifact, and the contracts that stage still needs.
+
+Before spawning a stage's owner, hand it its contracts and record that handoff:
+`omd stage deliver --stage <stage> --contract <pack-relative.md>` for each contract
+`omd stage list` names, then `omd stage require <stage>`. `require` exits non-zero while an earlier
+owner's artifact is missing or a contract has no receipt for its current bytes; that is a hard stop,
+not a warning. Editing a contract invalidates its receipt, so a mid-run protocol change forces a
+fresh delivery rather than a silent divergence between what the role read and what the loop
+requires. Never claim a role received a contract without its receipt.
+
+Contracts are also bound by the work itself, not only by the stage. Before handing a role its task,
+run `omd cue --path <file> --symbol <symbol> --field <name>=<value>` for the paths, symbols, and
+typed frame fields that task touches, and deliver everything it returns alongside the stage's own
+contracts. Cues resolve only from those deterministic inputs; a rule that needed the coordinator to
+interpret intent would be the same undelivered-knowledge failure in a new costume.
+
+Record cost at each stage boundary with `omd stage record --stage <stage>` and read it back with
+`omd stage cost`. A run that dies with no cost record cannot tell an expensive stage from a runaway
+one, and the next run repeats the same spend.
 
 Before spawning an artifact owner, classify depth. The coordinator writes only the routing input
 `.omd/depth.json` as `design-depth-input-v1` — print its exact skeleton with
@@ -715,6 +734,16 @@ selected frame. Source-candidate triage has no untriaged or needs-render items a
   persists `.omd/reference-report.md`; paste the pure formatter's exact Korean-first bilingual
   Markdown unchanged into the final chat. Everything is clean or has an evidence-backed deliberate
   overrule.
+A declared requirement is not shipped because the page looks finished. Write the brief's stated
+requirements to `.omd/functional-requirements.json` as `functional-requirements-v1` — print its
+shape with `omd schema functional-requirements` — and run `omd complete check <page>`. It fails
+when a declared affordance is absent, is text rather than an operable control, or cannot be reached
+by keyboard. It adds no style rule; it only proves the page does what the brief said it would.
+
+When the run declares more than one locale, `.omd/locale.json` is `locale-contract-v1` and
+`omd locale check` must pass before ship: every Beat carries real copy in every declared locale,
+and no locale silently falls back to another. Read `protocol/locale-contract.md` for the layout,
+control-state, and document-signal obligations that go with it.
 Regardless of whether reference assembly applied, close the final chat response with this run's usage: run `omd usage` and include its elapsed-time and token total in your final message to the user. It reads the host session log (Claude Code or Codex); if no log is found it prints a short unavailable note, which you simply omit rather than fabricating a number.
 When the run is an iteration with a before/after pair, form the pairwise blind-choose verdict:
 blind-choose is the visual distinction signal only; applicable task probes, accessibility checks, and

--- a/test/completeness.test.ts
+++ b/test/completeness.test.ts
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkFunctionalCompleteness, validateFunctionalRequirements } from '../core/completeness/index.ts';
+import type { RawNode } from '../core/types.ts';
+
+// The visual gates cannot tell a landing that links to the repository from one that only says it
+// does. This gate correlates the brief's stated requirements with the built page and adds no style
+// rule of its own: present, operable, reachable.
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+const FIXTURE = fileURLToPath(new URL('./fixtures/completeness.html', import.meta.url));
+const run = (args: string[], cwd: string) => spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', cwd });
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-complete-'));
+
+const requirements = (...entries: Record<string, unknown>[]) => ({ schema: 'functional-requirements-v1', requirements: entries });
+
+const node = (overrides: Partial<RawNode> & { id: string }): RawNode => ({
+  name: overrides.id, type: 'TEXT', path: `body > ${overrides.id}`, parent: null, children: [],
+  box: { x: 0, y: 0, w: 100, h: 40 }, ...overrides,
+} as RawNode);
+
+test('a requirement schema rejects duplicate, unlabelled, and unknown-kind entries', () => {
+  assert.equal(validateFunctionalRequirements(requirements({ id: 'R-1', kind: 'action', statement: 'open', label: 'Open' })).requirements.length, 1);
+  assert.throws(() => validateFunctionalRequirements(requirements({ id: 'R-1', kind: 'action', statement: 'a', label: 'A' }, { id: 'R-1', kind: 'action', statement: 'b', label: 'B' })), /duplicate requirement R-1/);
+  assert.throws(() => validateFunctionalRequirements(requirements({ id: 'R-1', kind: 'guess', statement: 'a', label: 'A' })), /kind must be one of/);
+  assert.throws(() => validateFunctionalRequirements(requirements({ id: 'R-1', kind: 'action', statement: 'a', label: '  ' })), /needs a non-empty label/);
+  assert.throws(() => validateFunctionalRequirements(requirements({ id: '1', kind: 'action', statement: 'a', label: 'A' })), /id must be R-<number>/);
+});
+
+test('an action is satisfied only when its carrier is operable and keyboard-reachable', () => {
+  const declared = validateFunctionalRequirements(requirements({ id: 'R-1', kind: 'action', statement: 'Visitor opens the repository', label: '저장소 열기' }));
+
+  assert.deepEqual(checkFunctionalCompleteness(declared, [node({ id: 'a', text: '저장소 열기', interactive: true, focusable: true })]), []);
+
+  const inert = checkFunctionalCompleteness(declared, [node({ id: 'a', text: '저장소 열기' })]);
+  assert.deepEqual(inert.map((finding) => finding.id), ['FUNC-INERT']);
+
+  const unreachable = checkFunctionalCompleteness(declared, [node({ id: 'a', text: '저장소 열기', interactive: true, focusable: false })]);
+  assert.deepEqual(unreachable.map((finding) => finding.id), ['FUNC-UNREACHABLE']);
+
+  const absent = checkFunctionalCompleteness(declared, [node({ id: 'a', text: '다른 문구' })]);
+  assert.deepEqual(absent.map((finding) => finding.id), ['FUNC-MISSING']);
+});
+
+test('a label inside an interactive ancestor still counts, and content needs only presence', () => {
+  const declared = validateFunctionalRequirements(requirements(
+    { id: 'R-1', kind: 'preference', statement: 'Visitor switches language', label: 'English' },
+    { id: 'R-2', kind: 'content', statement: 'Scope is stated', label: '지원 범위' },
+  ));
+  const nodes = [
+    node({ id: 'btn', text: '', interactive: true, focusable: true, children: ['label'] }),
+    node({ id: 'label', text: 'English', parent: 'btn' }),
+    node({ id: 'scope', text: '지원 범위는 다음과 같습니다' }),
+  ];
+  assert.deepEqual(checkFunctionalCompleteness(declared, nodes), []);
+});
+
+test('a form label with no interactive field nearby is reported as inert', () => {
+  const declared = validateFunctionalRequirements(requirements({ id: 'R-1', kind: 'form', statement: 'Visitor submits an email', label: '이메일' }));
+  const wired = [
+    node({ id: 'row', children: ['label', 'input'] }),
+    node({ id: 'label', text: '이메일', parent: 'row' }),
+    node({ id: 'input', parent: 'row', interactive: true, focusable: true }),
+  ];
+  assert.deepEqual(checkFunctionalCompleteness(declared, wired), []);
+
+  const orphan = [node({ id: 'label', text: '이메일' })];
+  assert.deepEqual(checkFunctionalCompleteness(declared, orphan).map((finding) => finding.id), ['FUNC-FORM-INERT']);
+});
+
+test('the gate runs against a real page and separates satisfied from unsatisfied requirements', () => {
+  const dir = project();
+  const write = (relative: string, content: string): string => {
+    const path = join(dir, relative);
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, content);
+    return path;
+  };
+
+  const satisfied = write('satisfied.json', JSON.stringify(requirements(
+    { id: 'R-1', kind: 'action', statement: 'Visitor opens the repository', label: '저장소 열기' },
+    { id: 'R-2', kind: 'preference', statement: 'Visitor switches language', label: 'English' },
+    { id: 'R-3', kind: 'form', statement: 'Visitor submits an email', label: '이메일' },
+  )));
+  const passing = run(['complete', 'check', FIXTURE, '--input', satisfied, '--json'], dir);
+  assert.equal(passing.status, 0, passing.stdout || passing.stderr);
+  assert.deepEqual(JSON.parse(passing.stdout).findings, []);
+
+  const unmet = write('unmet.json', JSON.stringify(requirements(
+    { id: 'R-1', kind: 'action', statement: 'Visitor starts a trial', label: '무료로 시작' },
+    { id: 'R-2', kind: 'action', statement: 'Visitor triggers the hidden action', label: '숨은 동작' },
+  )));
+  const blocked = run(['complete', 'check', FIXTURE, '--input', unmet, '--json'], dir);
+  assert.equal(blocked.status, 1, blocked.stdout);
+  assert.deepEqual(JSON.parse(blocked.stdout).findings.map((finding: { id: string }) => finding.id), ['FUNC-MISSING', 'FUNC-UNREACHABLE']);
+});

--- a/test/fixtures/completeness.html
+++ b/test/fixtures/completeness.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <title>완성도 게이트 픽스처</title>
+  </head>
+  <body>
+    <header>
+      <button type="button">English</button>
+      <span>다크 모드</span>
+    </header>
+    <main>
+      <h1>근거를 남기는 디자인 루프</h1>
+      <p>모든 결정은 기록으로 남습니다.</p>
+      <a href="https://example.com/repo">저장소 열기</a>
+      <label for="email">이메일</label>
+      <input id="email" type="email" />
+      <div tabindex="-1" onclick="void 0">숨은 동작</div>
+    </main>
+  </body>
+</html>

--- a/test/locale-contract.test.ts
+++ b/test/locale-contract.test.ts
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkLocaleCopyBinding, validateLocaleContract } from '../core/locale/contract.ts';
+
+// A second locale is a second audience, not a second string table. The two obligations that can be
+// checked before a browser exists are a coherent contract and real copy for every declared locale;
+// a blank cell is a hole in the page for that visitor, never a silent fallback.
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+const run = (args: string[], cwd: string) => spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', cwd });
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-locale-'));
+
+const contract = (overrides: Record<string, unknown> = {}) => ({
+  schema: 'locale-contract-v1', mode: 'language-only', locales: ['ko-KR', 'en-US'], primary: 'ko-KR', ...overrides,
+});
+
+const deck = (rows: string): string => [
+  '# Copy', '',
+  '## Art direction contract', '',
+  '| Beat ID | Evidence IDs |',
+  '| --- | --- |',
+  '| B-1 | F-001 |',
+  '| B-2 | F-002 |', '',
+  '## Locale copy', '',
+  '| Beat ID | ko-KR | en-US |',
+  '| --- | --- | --- |',
+  rows, '',
+].join('\n');
+
+function write(dir: string, relative: string, content: string): string {
+  const path = join(dir, relative);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+  return path;
+}
+
+test('a locale contract needs two unique tags, a known mode, and a primary among them', () => {
+  assert.equal(validateLocaleContract(contract()).primary, 'ko-KR');
+  assert.throws(() => validateLocaleContract(contract({ locales: ['ko-KR'] })), /two or more BCP-47 tags/);
+  assert.throws(() => validateLocaleContract(contract({ locales: ['ko-KR', 'ko-KR'] })), /locales must be unique/);
+  assert.throws(() => validateLocaleContract(contract({ primary: 'ja-JP' })), /primary must be one of the declared locales/);
+  assert.throws(() => validateLocaleContract(contract({ mode: 'translated' })), /mode must be one of/);
+  assert.throws(() => validateLocaleContract(contract({ locales: ['korean', 'english'] })), /BCP-47/);
+  assert.throws(() => validateLocaleContract({ ...contract(), extra: 1 }), /unknown: extra/);
+});
+
+test('every declared Beat needs real copy in every declared locale', () => {
+  const complete = checkLocaleCopyBinding(validateLocaleContract(contract()), deck([
+    '| B-1 | 소스에서 근거를 수집합니다 | Collects evidence from the source |',
+    '| B-2 | 결정을 기록으로 남깁니다 | Records each decision |',
+  ].join('\n')));
+  assert.deepEqual(complete, []);
+
+  const holes = checkLocaleCopyBinding(validateLocaleContract(contract()), deck([
+    '| B-1 | 소스에서 근거를 수집합니다 |  |',
+    '| B-2 | TBD | Records each decision |',
+  ].join('\n')));
+  assert.deepEqual(holes.map((finding) => finding.id), ['LOCALE-COPY-MISSING', 'LOCALE-COPY-PLACEHOLDER']);
+  assert.match(holes[0]!.message, /Beat B-1 has no en-US copy/);
+});
+
+test('locale copy may not invent or skip a Beat the art direction declares', () => {
+  const invented = checkLocaleCopyBinding(validateLocaleContract(contract()), deck([
+    '| B-1 | 한국어 | English |',
+    '| B-2 | 한국어 | English |',
+    '| B-9 | 한국어 | English |',
+  ].join('\n')));
+  assert.deepEqual(invented.map((finding) => finding.id), ['LOCALE-BEAT-UNKNOWN']);
+
+  const skipped = checkLocaleCopyBinding(validateLocaleContract(contract()), deck('| B-1 | 한국어 | English |'));
+  assert.deepEqual(skipped.map((finding) => finding.id), ['LOCALE-BEAT-UNCOVERED']);
+  assert.match(skipped[0]!.message, /Beat B-2 has no row/);
+});
+
+test('a missing locale column and a missing section both fail with a named reason', () => {
+  const missingColumn = checkLocaleCopyBinding(
+    validateLocaleContract(contract({ locales: ['ko-KR', 'en-US', 'ja-JP'], mode: 'market-specific' })),
+    deck(['| B-1 | 한국어 | English |', '| B-2 | 한국어 | English |'].join('\n')),
+  );
+  assert.equal(missingColumn[0]!.id, 'LOCALE-COLUMN-MISSING');
+  assert.match(missingColumn[0]!.message, /no ja-JP column/);
+
+  const noSection = checkLocaleCopyBinding(validateLocaleContract(contract()), '# Copy\n\n## Art direction contract\n\n| Beat ID | Evidence IDs |\n| --- | --- |\n| B-1 | F-001 |\n');
+  assert.deepEqual(noSection.map((finding) => finding.id), ['LOCALE-DECK-SECTION']);
+});
+
+test('the locale gate exits non-zero on a hole and zero on a complete deck', () => {
+  const dir = project();
+  write(dir, '.omd/locale.json', JSON.stringify(contract()));
+  write(dir, '.omd/copy-deck.md', deck('| B-1 | 한국어 | English |'));
+  const blocked = run(['locale', 'check', '--json'], dir);
+  assert.equal(blocked.status, 1, blocked.stdout);
+  assert.deepEqual(JSON.parse(blocked.stdout).findings.map((finding: { id: string }) => finding.id), ['LOCALE-BEAT-UNCOVERED']);
+
+  write(dir, '.omd/copy-deck.md', deck(['| B-1 | 한국어 | English |', '| B-2 | 한국어 | English |'].join('\n')));
+  const passing = run(['locale', 'check'], dir);
+  assert.equal(passing.status, 0, passing.stderr);
+  assert.match(passing.stdout, /ok — language-only contract covers ko-KR, en-US with primary ko-KR/);
+});

--- a/test/omd-cli-wiring.test.ts
+++ b/test/omd-cli-wiring.test.ts
@@ -134,14 +134,20 @@ test('printed input skeletons carry exactly the keys their validators accept', a
   const authored = Object.keys(check.skeleton as object);
   assert.ok(authored.every((key) => (ART_DIRECTION_CHECK_INPUT_KEYS as readonly string[]).includes(key)), authored.join(','));
   assert.ok(!authored.includes('invocation'), 'the local lane never authors an invocation');
-  assert.equal(INPUT_SKELETONS.length, 2);
+  assert.equal(INPUT_SKELETONS.length, 4);
+
+  const locale = inputSkeleton('locale-contract');
+  const { LOCALE_CONTRACT_KEYS } = await import('../core/locale/contract.ts');
+  assert.deepEqual(Object.keys(locale.skeleton as object).sort(), [...LOCALE_CONTRACT_KEYS].sort());
+  const functional = inputSkeleton('functional-requirements');
+  assert.deepEqual(Object.keys(functional.skeleton as object).sort(), ['requirements', 'schema']);
 
   const dir = project();
   const printed = run(['schema', 'depth-input', '--json'], dir);
   assert.equal(printed.status, 0, printed.stderr);
   assert.deepEqual(JSON.parse(printed.stdout).skeleton, depth.skeleton);
   const listed = run(['schema', 'list', '--json'], dir);
-  assert.deepEqual(JSON.parse(listed.stdout).map((entry: { name: string }) => entry.name), ['depth-input', 'art-direction-check']);
+  assert.deepEqual(JSON.parse(listed.stdout).map((entry: { name: string }) => entry.name), ['depth-input', 'art-direction-check', 'locale-contract', 'functional-requirements']);
 });
 
 test('the printed depth skeleton classifies and a shapeless input names every missing key', () => {
@@ -160,18 +166,19 @@ test('the printed depth skeleton classifies and a shapeless input names every mi
   assert.match(rejected.stderr, /omd schema depth-input/);
 });
 
-test('stage status names the first missing artifact so a resumed run does not restart', () => {
+// Stage state itself is covered by test/stage-state.test.ts; this only locks the CLI surface.
+test('stage status reports the derived run state through the CLI', () => {
   const dir = project();
   const empty = run(['stage', 'status', '--json'], dir);
   assert.equal(empty.status, 0, empty.stderr);
-  assert.equal(JSON.parse(empty.stdout).next, 'domain');
+  assert.equal(JSON.parse(empty.stdout).current, 'domain');
   assert.deepEqual(JSON.parse(empty.stdout).completed, []);
 
   writeFile(dir, '.omd/domain-brief.json', '{}');
   writeFile(dir, '.omd/depth.json', '{}');
   const resumed = JSON.parse(run(['stage', 'status', '--json'], dir).stdout);
   assert.deepEqual(resumed.completed, ['domain', 'depth']);
-  assert.equal(resumed.next, 'frame');
+  assert.equal(resumed.current, 'frame');
 });
 
 // The check payload's `references` array must equal this projection byte-for-byte, so emitting it

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -905,7 +905,16 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /Never retype the references array by hand/);
   assert.match(skill, /A rejected gate is only terminal when an owner role failed/);
   assert.match(skill, /repair the bytes and rerun the same command/);
-  assert.match(skill, /Run `omd stage status` first and continue at the first stage whose artifact is missing/);
+  assert.match(skill, /Run `omd stage resume` first and continue at the stage it names/);
+  assert.match(skill, /`omd stage deliver --stage <stage> --contract <pack-relative\.md>`/);
+  assert.match(skill, /`require` exits non-zero while an earlier owner's artifact is missing or a contract has no receipt/);
+  assert.match(skill, /Never claim a role received a contract without its receipt/);
+  assert.match(skill, /`omd cue --path <file> --symbol <symbol> --field <name>=<value>`/);
+  assert.match(skill, /Cues resolve only from those deterministic inputs/);
+  assert.match(skill, /Record cost at each stage boundary with `omd stage record --stage <stage>`/);
+  assert.match(skill, /`omd complete check <page>`/);
+  assert.match(skill, /It adds no style rule; it only proves the page does what the brief said it would/);
+  assert.match(skill, /`omd locale check` must pass before ship/);
   assert.match(skill, /`omd schema depth-input` instead of inferring keys from `core\/`/);
   assert.match(skill, /the OMD CLI spawns `browser-rs` itself over stdio for each capture/);
   assert.match(skill, /Never start a long-lived `browser-rs`, pick a port, or debug a listening socket/);

--- a/test/stage-state.test.ts
+++ b/test/stage-state.test.ts
@@ -1,0 +1,211 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { STAGES, readDeliveryReceipts, requireStage, resolveRunState } from '../core/stage/contract.ts';
+import { evaluateStageBudget, readStageUsage, serializeStageUsage, STAGE_USAGE_LOG, STAGE_USAGE_SCHEMA, stageCosts } from '../core/stage/usage.ts';
+
+// Stage state is the loop's answer to a run that died mid-stage or lost its context to compaction.
+// Artifact presence is derived from disk; delivery is the single persisted fact, and a receipt
+// stops counting the moment the contract's bytes change.
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+const PACK = fileURLToPath(new URL('../core', import.meta.url));
+const run = (args: string[], cwd: string) => spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', cwd });
+const project = (): string => mkdtempSync(join(tmpdir(), 'omd-stage-'));
+
+function write(dir: string, relative: string, content: string): void {
+  const path = join(dir, relative);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+}
+
+test('every stage names a real owner, artifact, and existing pack contract', () => {
+  assert.ok(STAGES.length >= 10);
+  assert.equal(new Set(STAGES.map((stage) => stage.id)).size, STAGES.length);
+  for (const stage of STAGES) {
+    assert.match(stage.artifact, /^\.omd\//);
+    assert.ok(stage.requiredContracts.length > 0, `${stage.id} declares no contract`);
+    for (const contract of stage.requiredContracts) {
+      assert.doesNotThrow(() => readFileSync(join(PACK, contract)), `${stage.id} cites missing ${contract}`);
+    }
+  }
+});
+
+test('a stage is blocked until an earlier owner produced its artifact', () => {
+  const dir = project();
+  const blocked = run(['stage', 'require', 'frame', '--json'], dir);
+  assert.equal(blocked.status, 1, blocked.stdout);
+  const requirement = JSON.parse(blocked.stdout);
+  assert.deepEqual(requirement.missingArtifacts, ['.omd/domain-brief.json', '.omd/depth.json']);
+
+  write(dir, '.omd/domain-brief.json', '{}');
+  write(dir, '.omd/depth.json', '{}');
+  const stillBlocked = JSON.parse(run(['stage', 'require', 'frame', '--json'], dir).stdout);
+  assert.deepEqual(stillBlocked.missingArtifacts, []);
+  assert.deepEqual(stillBlocked.undeliveredContracts, ['protocol/human-design-loop.md', 'theory/ux.md']);
+});
+
+test('delivery unblocks a stage and an edited contract invalidates its receipt', () => {
+  const dir = project();
+  write(dir, '.omd/domain-brief.json', '{}');
+  write(dir, '.omd/depth.json', '{}');
+  for (const contract of ['protocol/human-design-loop.md', 'theory/ux.md']) {
+    const delivered = run(['stage', 'deliver', '--stage', 'frame', '--contract', contract, '--json'], dir);
+    assert.equal(delivered.status, 0, delivered.stderr);
+    assert.equal(JSON.parse(delivered.stdout).stage, 'frame');
+  }
+  assert.equal(run(['stage', 'require', 'frame'], dir).status, 0);
+
+  const receipts = readDeliveryReceipts(dir);
+  assert.equal(receipts.length, 2);
+  assert.ok(receipts.every((receipt) => /^[a-f0-9]{64}$/.test(receipt.sha256)));
+
+  // A receipt binds exact bytes: pointing the pack at different content leaves the stage blocked.
+  const stalePack = mkdtempSync(join(tmpdir(), 'omd-stage-pack-'));
+  mkdirSync(join(stalePack, 'protocol'), { recursive: true });
+  mkdirSync(join(stalePack, 'theory'), { recursive: true });
+  writeFileSync(join(stalePack, 'protocol', 'human-design-loop.md'), 'edited protocol');
+  writeFileSync(join(stalePack, 'theory', 'ux.md'), 'edited theory');
+  const stale = requireStage(dir, stalePack, 'frame');
+  assert.equal(stale.ok, false);
+  assert.deepEqual(stale.undeliveredContracts, ['protocol/human-design-loop.md', 'theory/ux.md']);
+});
+
+test('run state names the current stage and its blocking contracts after a partial run', () => {
+  const dir = project();
+  for (const [relative, body] of [
+    ['.omd/domain-brief.json', '{}'],
+    ['.omd/depth.json', '{}'],
+    ['.omd/frame.md', '# frame'],
+    ['.omd/acquisition-plan.json', '{}'],
+    ['.omd/scout.md', '# scout'],
+  ] as const) write(dir, relative, body);
+
+  const state = resolveRunState(dir, PACK);
+  assert.deepEqual(state.completed, ['domain', 'depth', 'frame', 'acquisition', 'scout']);
+  assert.equal(state.current, 'reference-board');
+
+  const resumed = JSON.parse(run(['stage', 'resume', '--json'], dir).stdout);
+  assert.equal(resumed.current, 'reference-board');
+  assert.deepEqual(resumed.blocked.undeliveredContracts, ['protocol/reference-assembly.md']);
+});
+
+test('the delivery log stays append-only across separate deliveries and rejects corrupt lines', () => {
+  const dir = project();
+  run(['stage', 'deliver', '--stage', 'domain', '--contract', 'protocol/domain-analysis.md'], dir);
+  run(['stage', 'deliver', '--stage', 'depth', '--contract', 'protocol/design-deliberation.md'], dir);
+  const log = readFileSync(join(dir, '.omd/delivery.jsonl'), 'utf8').trim().split('\n');
+  assert.equal(log.length, 2);
+  assert.deepEqual(readDeliveryReceipts(dir).map((receipt) => receipt.stage), ['domain', 'depth']);
+
+  writeFileSync(join(dir, '.omd/delivery.jsonl'), `${log[0]}\nnot json\n`);
+  assert.throws(() => readDeliveryReceipts(dir), /delivery log line 2 is not JSON/);
+});
+
+test('an unknown stage names the known stages instead of failing silently', () => {
+  const dir = project();
+  const unknown = run(['stage', 'require', 'polish'], dir);
+  assert.equal(unknown.status, 1);
+  assert.match(unknown.stderr, /unknown stage polish; known: domain, depth, frame/);
+});
+
+// Host logs only report a cumulative run total, so a stage's cost is the delta between the
+// snapshot taken when it ended and the previous one. A rotated log moves the total backwards;
+// that must degrade to an approximate figure rather than a negative one.
+
+const sample = (stage: string, totalTokens: number, elapsedMs: number, approximate = false) => ({
+  schema: STAGE_USAGE_SCHEMA, stage, at: new Date(elapsedMs).toISOString(),
+  totalTokens, outputTokens: Math.round(totalTokens / 10), elapsedMs, approximate,
+});
+
+test('stage cost is the delta between cumulative snapshots', () => {
+  const costs = stageCosts([
+    sample('domain', 1_000, 60_000),
+    sample('frame', 4_000, 300_000),
+    sample('scout', 9_000, 900_000),
+  ] as never);
+  assert.deepEqual(costs.map((cost) => cost.totalTokens), [1_000, 3_000, 5_000]);
+  assert.deepEqual(costs.map((cost) => cost.elapsedMs), [60_000, 240_000, 600_000]);
+  assert.ok(costs.every((cost) => !cost.approximate));
+});
+
+test('a rotated host log yields an approximate cost instead of a negative one', () => {
+  const costs = stageCosts([sample('domain', 9_000, 900_000), sample('frame', 500, 30_000)] as never);
+  assert.equal(costs[1]!.totalTokens, 500);
+  assert.equal(costs[1]!.approximate, true);
+});
+
+test('the budget names the stage that blew it and the run totals that did not', () => {
+  const samples = [sample('domain', 1_000, 60_000), sample('frame', 400_000, 3_600_000)] as never;
+  const overStage = evaluateStageBudget(samples, { maxStageTokens: 100_000 });
+  assert.equal(overStage.ok, false);
+  assert.match(overStage.findings[0]!, /stage frame used 399000 tokens over the 100000 stage budget/);
+
+  const overRun = evaluateStageBudget(samples, { maxRunTokens: 200_000, maxRunElapsedMs: 30 * 60_000 });
+  assert.equal(overRun.ok, false);
+  assert.equal(overRun.findings.length, 2);
+  assert.equal(evaluateStageBudget(samples, { maxRunTokens: 1_000_000 }).ok, true);
+});
+
+test('stage cost reads its log through the CLI and fails only over budget', () => {
+  const dir = project();
+  write(dir, STAGE_USAGE_LOG, serializeStageUsage([sample('domain', 1_000, 60_000), sample('frame', 50_000, 600_000)] as never));
+  assert.equal(readStageUsage(dir).length, 2);
+
+  const within = run(['stage', 'cost', '--json'], dir);
+  assert.equal(within.status, 0, within.stderr);
+  assert.equal(JSON.parse(within.stdout).runTokens, 50_000);
+
+  const over = run(['stage', 'cost', '--max-stage-tokens', '10000', '--json'], dir);
+  assert.equal(over.status, 1);
+  assert.match(JSON.parse(over.stdout).findings[0], /stage frame used 49000 tokens/);
+});
+
+// Cues answer "which contract does this piece of work bind" from inputs a machine evaluates the
+// same way twice. A cue that required interpretation would reintroduce the discipline gap it
+// exists to close, so free-text intent is not a source.
+
+test('every cue rule is unique, reasoned, and cites a contract that exists', async () => {
+  const { CUE_RULES, validateCueRules } = await import('../core/stage/cues.ts');
+  assert.doesNotThrow(() => validateCueRules());
+  for (const rule of CUE_RULES) {
+    for (const contract of rule.contracts) {
+      assert.doesNotThrow(() => readFileSync(join(PACK, contract)), `${rule.match} cites missing ${contract}`);
+    }
+  }
+  assert.ok(CUE_RULES.every((rule) => ['path', 'symbol', 'field'].includes(rule.source)), 'cue sources stay deterministic');
+});
+
+test('cues resolve from paths, symbols, and typed fields, and widen a stage obligation', async () => {
+  const { resolveCues, cueContracts, stageContractsWithCues } = await import('../core/stage/cues.ts');
+  const landing = resolveCues({ paths: ['src/landing/Hero.tsx'] });
+  assert.deepEqual(cueContracts(landing), ['protocol/copy-deck.md', 'theory/craft.md']);
+  assert.deepEqual(resolveCues({ paths: ['src/components/Hero.tsx'] }), []);
+
+  assert.deepEqual(cueContracts(resolveCues({ symbols: ['Dialog'] })), ['theory/components.md', 'theory/ux.md']);
+  assert.deepEqual(resolveCues({ symbols: ['DialogTrigger'] }), [], 'symbol cues match exactly, never by substring');
+
+  const multi = resolveCues({ fields: { localization: 'multi-locale', motionDecision: 'none' } });
+  assert.deepEqual(cueContracts(multi), ['protocol/locale-contract.md', 'theory/layout.md']);
+  assert.deepEqual(resolveCues({ fields: { localization: 'single' } }), []);
+
+  const widened = stageContractsWithCues('copy', multi);
+  assert.deepEqual(widened, ['protocol/copy-deck.md', 'protocol/locale-contract.md', 'theory/layout.md', 'theory/voice.md']);
+});
+
+test('the cue CLI reports the bound contracts and their reasons', () => {
+  const dir = project();
+  const resolved = run(['cue', '--path', 'app/dashboard/page.tsx', '--symbol', 'form', '--json'], dir);
+  assert.equal(resolved.status, 0, resolved.stderr);
+  const result = JSON.parse(resolved.stdout);
+  assert.deepEqual(result.contracts, ['theory/ux.md']);
+  assert.equal(result.cues.length, 2);
+  assert.ok(result.cues.every((cue: { reason: string }) => cue.reason.length > 0));
+
+  const staged = JSON.parse(run(['cue', '--field', 'surface=marketing', '--stage', 'frame', '--json'], dir).stdout);
+  assert.deepEqual(staged.contracts, ['protocol/human-design-loop.md', 'theory/craft.md', 'theory/ux.md']);
+});


### PR DESCRIPTION
Three real-use runs died before writing production source, and none of them died from missing design knowledge. This adds the machinery a long run needs to survive itself, plus the two gates that check a page against its brief rather than against taste.

**Stage state (`omd stage`)** — `list`/`status`/`resume` derive the run's position from artifacts on disk; `deliver` records the one fact that cannot be derived, that a contract's exact bytes reached the stage that must obey them; `require` blocks while an earlier owner's artifact is missing or a contract has no current receipt. Editing a contract invalidates its receipt, so a mid-run protocol change forces a fresh delivery instead of silent divergence. `resume` is also the recovery step after context compaction.

**Stage cost (`omd stage record|cost`)** — host logs expose only a cumulative total, so a stage's cost is the delta between snapshots. Budgets fail per stage or per run; a rotated log degrades to an approximate figure instead of a negative one.

**Cues (`omd cue`)** — contracts bound by the work itself, resolved only from deterministic inputs: path globs, exact symbols, and typed brief fields. Free-text intent is deliberately not a cue source.

**Locale (`omd locale check`, `protocol/locale-contract.md`)** — a declared multi-locale run must carry real copy for every Beat in every locale. Blank and placeholder cells fail; a Beat may not be invented or skipped.

**Functional completeness (`omd complete check`)** — correlates the brief's stated requirements with the built page: present, operable, keyboard-reachable. It reuses the existing IR and adds no style rule.

`omd schema` now prints all four hand-authored inputs, and the depth validator reports every missing and unknown key at once.

Verification: `npm test` 1776 pass / 0 fail / 1 skip, `npx tsc --noEmit` clean, `npm run build` succeeds, `git diff --check` clean.