### PR TITLE
Give the new artifacts an owner and a CLI persistence path

### DIFF
--- a/agents/framer.md
+++ b/agents/framer.md
@@ -63,6 +63,12 @@ required unless it is purely connective chrome that needs no external evidence. 
 scout's acquisition list and later the assembly coverage obligation; omitting hero, process,
 proof, install/CTA, navigation, or a required product state because another zone seems similar
 leaves the build inventing it from nothing.
+You also own `.omd/functional-requirements.json` as `functional-requirements-v1`; print its shape
+with `omd schema functional-requirements`. One entry per thing the brief says the visitor must be
+able to do, each carrying the visible label that will prove the affordance exists. A requirement
+is a promise the build owes, so state only what the brief actually asked for — never a feature you
+find attractive — and keep the label the words a visitor will read. `omd complete check` later
+fails the ship when a declared affordance is absent, inert, or unreachable by keyboard.
 When the brief names a real, existing subject — a product, project, company, repository, or brand,
 or supplies its link — record it in the frame as a research target: the exact name and any source
 link, plus any brand fact the source already ships (an existing wordmark, palette, or motif) kept
@@ -89,7 +95,9 @@ Finish by running `omd frame set --problem ... --reframe ... --why ... --task ..
 `mixed`, append `--task-matrix "T1 ..."` with every frame-owned matrix row; it is
 the sole durable persistence path. For `marketing` or `editorial`, omit
 `--task-matrix` entirely. Then persist the internal composition targets with
-`omd acquisition set --zones '<JSON array of {id,kind,job,required}>'`. English under
+`omd acquisition set --zones '<JSON array of {id,kind,job,required}>'`, and persist the visitor's
+declared affordances with `omd complete set --input <functional-requirements.json>`. Those three
+CLI mutations are the sole durable persistence path for your artifacts. English under
 `.omd/`; user-facing prose stays in the user's language. Nothing waits for approval.
 End with the prose handback.
 

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -2271,11 +2271,20 @@ async function cmdLocale(mode: string | undefined, opts: Opts): Promise<never> {
 }
 /** Correlates the brief's stated requirements with the built page; it adds no style rule. */
 async function cmdComplete(mode: string | undefined, opts: Opts): Promise<never> {
+  const { checkFunctionalCompleteness, validateFunctionalRequirements } = await import('../core/completeness/index.ts');
+  if (mode === 'set') {
+    if (!opts.input || opts._.length > 0) throw new Error('usage: omd complete set --input <functional-requirements.json> [--json]');
+    const requirements = validateFunctionalRequirements(inputJson(opts.input, 'omd complete set'));
+    const path = projectWriterFromActivation(opts, 'omd complete set')
+      .write('.omd/functional-requirements.json', `${JSON.stringify(requirements, null, 2)}\n`);
+    if (opts.json) process.stdout.write(JSON.stringify({ path, requirements: requirements.requirements.length }));
+    else console.log(path);
+    process.exit(0);
+  }
   const target = opts._[0];
   if (mode !== 'check' || target === undefined || opts._.length > 1) {
-    throw new Error('usage: omd complete check <page> [--input .omd/functional-requirements.json] [--json]');
+    throw new Error('usage: omd complete set --input <functional-requirements.json> | check <page> [--input <requirements.json>] [--json]');
   }
-  const { checkFunctionalCompleteness, validateFunctionalRequirements } = await import('../core/completeness/index.ts');
   const requirements = validateFunctionalRequirements(inputJson(opts.input ?? join(process.cwd(), '.omd', 'functional-requirements.json'), 'omd complete check'));
   const raw = await rawIrFor(opts, target);
   const findings = checkFunctionalCompleteness(requirements, raw.nodes);

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -77,6 +77,7 @@ artifact exists to provide, and every downstream check that reads it is then ver
 |---|---|---|
 | `.omd/frame.md` | `oh-my-design:framer` | §1 |
 | `.omd/acquisition-plan.json` | `oh-my-design:framer` | §1 |
+| `.omd/functional-requirements.json` | `oh-my-design:framer` | §1 |
 | `.omd/scout.md`, `.omd/refs/*` | `oh-my-design:scout` | §2 |
 | `.omd/copy-deck.md` | `oh-my-design:writer` | §2 |
 | `.omd/type-proof.md` | `oh-my-design:typesetter` | §3 |
@@ -87,6 +88,7 @@ artifact exists to provide, and every downstream check that reads it is then ver
 | production source (every file the site ships) | `oh-my-design:hand` | §6 |
 | `.omd/observations/*`, `.omd/assembly-coverage.json` | `oh-my-design:hand` | §6–§8 |
 | every review verdict | `oh-my-design:eye` / `oh-my-design:glance` | §5, §7, §8 |
+| `.omd/delivery.jsonl`, `.omd/stage-usage.jsonl` | the `omd stage` CLI (never hand-edited) | §0–§9 |
 
 If a stage looks skippable because the answer seems clear, that is the failure mode this table
 exists to stop: a run that writes its own composition contract and its own production source has
@@ -143,6 +145,12 @@ component-only change may be L1. L1/L2 omit only the stages listed by the classi
 the owner of every retained artifact. L3 runs the full owner-separated graph. L4 adds the independent
 three-perspective deliberation and moderator. Never call a direct coordinator build an adaptive
 route.
+
+`.omd/locale.json` is the other coordinator-owned routing input, written only when the brief names
+more than one language. It is `locale-contract-v1` (`omd schema locale-contract`), and declaring it
+binds the writer to per-locale Beat copy and the hand to the layout, control-state, and
+document-signal obligations in `protocol/locale-contract.md`. A single-language run does not write
+the file at all; a bilingual one that omits it has left its second audience to chance.
 
 There is exactly one structural-skip route: the Figma structural-bypass above. A full multi-feature
 app, an ERP/dashboard/console/CRUD/admin/editor, a data-dense internal tool, or a quiet/product

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -6,6 +6,8 @@ allow:
   - WebSearch
   - Bash(omd frame:*)
   - Bash(omd acquisition:*)
+  - Bash(omd complete:*)
+  - Bash(omd schema:*)
   - Bash(omd pack:*)
 deny: []
 instructions: |
@@ -67,6 +69,12 @@ instructions: |
   scout's acquisition list and later the assembly coverage obligation; omitting hero, process,
   proof, install/CTA, navigation, or a required product state because another zone seems similar
   leaves the build inventing it from nothing.
+  You also own `.omd/functional-requirements.json` as `functional-requirements-v1`; print its shape
+  with `omd schema functional-requirements`. One entry per thing the brief says the visitor must be
+  able to do, each carrying the visible label that will prove the affordance exists. A requirement
+  is a promise the build owes, so state only what the brief actually asked for — never a feature you
+  find attractive — and keep the label the words a visitor will read. `omd complete check` later
+  fails the ship when a declared affordance is absent, inert, or unreachable by keyboard.
   When the brief names a real, existing subject — a product, project, company, repository, or brand,
   or supplies its link — record it in the frame as a research target: the exact name and any source
   link, plus any brand fact the source already ships (an existing wordmark, palette, or motif) kept
@@ -93,7 +101,9 @@ instructions: |
   `mixed`, append `--task-matrix "T1 ..."` with every frame-owned matrix row; it is
   the sole durable persistence path. For `marketing` or `editorial`, omit
   `--task-matrix` entirely. Then persist the internal composition targets with
-  `omd acquisition set --zones '<JSON array of {id,kind,job,required}>'`. English under
+  `omd acquisition set --zones '<JSON array of {id,kind,job,required}>'`, and persist the visitor's
+  declared affordances with `omd complete set --input <functional-requirements.json>`. Those three
+  CLI mutations are the sole durable persistence path for your artifacts. English under
   `.omd/`; user-facing prose stays in the user's language. Nothing waits for approval.
   End with the prose handback.
 

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -77,6 +77,7 @@ artifact exists to provide, and every downstream check that reads it is then ver
 |---|---|---|
 | `.omd/frame.md` | `omd-framer` | §1 |
 | `.omd/acquisition-plan.json` | `omd-framer` | §1 |
+| `.omd/functional-requirements.json` | `omd-framer` | §1 |
 | `.omd/scout.md`, `.omd/refs/*` | `omd-scout` | §2 |
 | `.omd/copy-deck.md` | `omd-writer` | §2 |
 | `.omd/type-proof.md` | `omd-typesetter` | §3 |
@@ -87,6 +88,7 @@ artifact exists to provide, and every downstream check that reads it is then ver
 | production source (every file the site ships) | `omd-hand` | §6 |
 | `.omd/observations/*`, `.omd/assembly-coverage.json` | `omd-hand` | §6–§8 |
 | every review verdict | `omd-eye` / `omd-glance` | §5, §7, §8 |
+| `.omd/delivery.jsonl`, `.omd/stage-usage.jsonl` | the `omd stage` CLI (never hand-edited) | §0–§9 |
 
 If a stage looks skippable because the answer seems clear, that is the failure mode this table
 exists to stop: a run that writes its own composition contract and its own production source has
@@ -143,6 +145,12 @@ component-only change may be L1. L1/L2 omit only the stages listed by the classi
 the owner of every retained artifact. L3 runs the full owner-separated graph. L4 adds the independent
 three-perspective deliberation and moderator. Never call a direct coordinator build an adaptive
 route.
+
+`.omd/locale.json` is the other coordinator-owned routing input, written only when the brief names
+more than one language. It is `locale-contract-v1` (`omd schema locale-contract`), and declaring it
+binds the writer to per-locale Beat copy and the hand to the layout, control-state, and
+document-signal obligations in `protocol/locale-contract.md`. A single-language run does not write
+the file at all; a bilingual one that omits it has left its second audience to chance.
 
 There is exactly one structural-skip route: the Figma structural-bypass above. A full multi-feature
 app, an ERP/dashboard/console/CRUD/admin/editor, a data-dense internal tool, or a quiet/product

--- a/test/completeness.test.ts
+++ b/test/completeness.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -98,4 +98,35 @@ test('the gate runs against a real page and separates satisfied from unsatisfied
   const blocked = run(['complete', 'check', FIXTURE, '--input', unmet, '--json'], dir);
   assert.equal(blocked.status, 1, blocked.stdout);
   assert.deepEqual(JSON.parse(blocked.stdout).findings.map((finding: { id: string }) => finding.id), ['FUNC-MISSING', 'FUNC-UNREACHABLE']);
+});
+
+// The framer owns the requirement list because it is the role that interrogates the brief, and it
+// persists through the CLI like its other artifacts rather than writing the file directly.
+
+test('the framer owns and persists functional requirements through the CLI', () => {
+  const framer = readFileSync(fileURLToPath(new URL('../src/agents/framer.agent.yaml', import.meta.url)), 'utf8').replace(/\s+/g, ' ');
+  assert.match(framer, /Bash\(omd complete:\*\)/);
+  assert.match(framer, /You also own `\.omd\/functional-requirements\.json` as `functional-requirements-v1`/);
+  assert.match(framer, /persist the visitor's declared affordances with `omd complete set --input <functional-requirements\.json>`/);
+
+  const skill = readFileSync(fileURLToPath(new URL('../src/skills/omd-ultradesign/SKILL.md', import.meta.url)), 'utf8');
+  assert.match(skill, /\| `\.omd\/functional-requirements\.json` \| `omd-framer` \| §1 \|/);
+  assert.match(skill, /\| `\.omd\/delivery\.jsonl`, `\.omd\/stage-usage\.jsonl` \| the `omd stage` CLI \(never hand-edited\) \| §0–§9 \|/);
+  assert.match(skill, /`\.omd\/locale\.json` is the other coordinator-owned routing input/);
+});
+
+test('complete set validates before persisting and rejects an invalid list', () => {
+  const dir = project();
+  const path = join(dir, 'requirements.json');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(requirements({ id: 'R-1', kind: 'action', statement: 'Visitor opens the repository', label: '저장소 열기' })));
+  const stored = run(['complete', 'set', '--input', path, '--json'], dir);
+  assert.equal(stored.status, 0, stored.stderr);
+  assert.equal(JSON.parse(stored.stdout).requirements, 1);
+  assert.match(readFileSync(join(dir, '.omd/functional-requirements.json'), 'utf8'), /"id": "R-1"/);
+
+  writeFileSync(path, JSON.stringify(requirements({ id: 'R-1', kind: 'wish', statement: 'a', label: 'A' })));
+  const rejected = run(['complete', 'set', '--input', path], dir);
+  assert.equal(rejected.status, 1);
+  assert.match(rejected.stderr, /FUNCTIONAL_REQUIREMENTS_INVALID/);
 });


### PR DESCRIPTION
fix: give the new artifacts an owner and a CLI persistence path

The previous change shipped `.omd/functional-requirements.json`,
`.omd/locale.json`, and the two stage logs without saying who writes them. That
is exactly the ownership hole the artifact table exists to prevent.

- The framer owns the requirement list, because it is the role that interrogates
  the brief for what a visitor must be able to do, and persists it with
  `omd complete set` alongside `omd frame set` and `omd acquisition set`. It
  still writes no file directly.
- `.omd/locale.json` is named as the coordinator-owned routing input beside
  `.omd/depth.json`, written only when the brief names more than one language.
- `.omd/delivery.jsonl` and `.omd/stage-usage.jsonl` are declared CLI-owned and
  never hand-edited.
