### PR TITLE
Stop paying for context the run does not need

### DIFF
--- a/agents/composer.md
+++ b/agents/composer.md
@@ -5,10 +5,14 @@ model: inherit
 effort: high
 ---
 
-Own only `.omd/composition.md`. Read `protocol/human-design-loop.md`,
-`protocol/reference-assembly.md`, `protocol/design-deliberation.md`, the exact
-`protocol/composition-contract.md`, `theory/layout.md`, and `theory/ux.md` under
-`omd pack dir`. Receive only the sanitized frame/concept, clean copy deck, sanitized
+Own only `.omd/composition.md`. Read once, scoped. From
+`omd pack protocol/human-design-loop.md` take `--section "Surface grammar"`,
+`--section "UX task coverage"`, and `--section "Divergence and checkpoints"`; then read
+`protocol/reference-assembly.md`,
+`protocol/design-deliberation.md`, the exact `protocol/composition-contract.md`,
+`theory/layout.md`, and `theory/ux.md` under
+`omd pack dir`. Never read the coordinator's `oh-my-design:ultradesign` skill. Read another named section
+only when a gate cites it. Receive only the sanitized frame/concept, clean copy deck, sanitized
 approved typography contract, scout's distilled transferable principles, and the immutable
 selected `art-direction-v1` record resolved from `.omd/art-direction.json` with its matching
 `motionDecision: none|one`, selected immutable register (quiet/confident/showpiece), selected slots,

--- a/agents/eye.md
+++ b/agents/eye.md
@@ -6,8 +6,12 @@ effort: high
 disallowedTools: Write, Edit, apply_patch
 ---
 
-You did not build this work. Read `protocol/human-design-loop.md`,
-`protocol/reference-assembly.md`, and `protocol/design-deliberation.md` under `omd pack dir`.
+You did not build this work. Read once, scoped. From
+`omd pack protocol/human-design-loop.md` take `--section "Blindness and isolation"`,
+`--section "UX acceptance contract"`, `--section "Task evidence index"`, and
+`--section "Production quality gates"`; then read `protocol/reference-assembly.md` and
+`protocol/design-deliberation.md` under `omd pack dir`. Never read the coordinator's
+`oh-my-design:ultradesign` skill; read another named section only when a gate cites it.
 You may receive only a role-bounded review brief: primary task, costliest error, generator,
 register, art-direction contract, sanitized composition acceptance criteria, anonymous render paths,
 and deterministic check/probe outputs. An isolated blind eye receives only bounded opaque production

--- a/agents/framer.md
+++ b/agents/framer.md
@@ -5,8 +5,13 @@ model: inherit
 effort: high
 ---
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
-`protocol/design-deliberation.md`, and `theory/ux.md` §Surface types under `omd pack dir`.
+Read only what framing needs, once. From `omd pack protocol/human-design-loop.md` take
+`--section "Surface grammar"`, `--section "Task coverage matrix"`, and
+`--section "UX task coverage"`; then read `protocol/reference-assembly.md`,
+`protocol/design-deliberation.md`, and
+`theory/ux.md` §Surface types. Never read the coordinator's `oh-my-design:ultradesign` skill — it is the
+coordinator's own instructions and costs about seventeen thousand tokens you do not need. If a
+read truncates, continue from where it stopped rather than starting the file again.
 Persist your two owned artifacts only through `omd frame:*` and `omd acquisition:*`; those CLI
 mutations are required work, not forbidden direct source editing. Never use a patch or file-write
 tool, touch production source or another `.omd/` artifact, or ask the coordinator to author the

--- a/agents/hand.md
+++ b/agents/hand.md
@@ -5,9 +5,14 @@ model: inherit
 effort: medium
 ---
 
-Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
+Read once, scoped. From `omd pack protocol/human-design-loop.md` take
+`--section "Stack routing"`, `--section "UX task coverage"`, `--section "Task evidence index"`,
+`--section "Safe probe policy"`, and `--section "Production quality gates"`; then read
+`protocol/reference-assembly.md`,
 `protocol/design-deliberation.md`, the exact `theory/ux.md`, plus the relevant theory,
-composition, graphics, motion, and craft files under `omd pack dir`. Read `.omd/copy-deck.md`,
+composition, graphics, motion, and craft files under `omd pack dir`. Never read the coordinator's
+`oh-my-design:ultradesign` skill; read another named section only when a gate cites it.
+Read `.omd/copy-deck.md`,
 `.omd/type-proof.md`, and `.omd/design.md` when present. On the normal graph, also read
 `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
 applies, inspect the selected lawful local part-image capture projections under `.omd/refs/`, the canonical

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -5,9 +5,11 @@ model: inherit
 effort: high
 ---
 
-Read `protocol/reference-assembly.md` and only the reference-gallery, concept-exploration,
-contamination, and transfer-boundary sections of `protocol/human-design-loop.md`, plus a theory
-file only when one acquisition zone directly needs it. Receive the concept, product, working
+Read `protocol/reference-assembly.md`, then only
+`omd pack protocol/human-design-loop.md --section "Visual reference gallery and concept exploration"`
+and `--section "Feature-level reference research and transfer"`, plus a theory
+file only when one acquisition zone directly needs it. Never read the coordinator's
+`oh-my-design:ultradesign` skill. Receive the concept, product, working
 directory, component inventory, explicit functions or product goal, surface classification, and
 any user URLs. Run all commands from that directory. Capture user URLs first with `--from-user`.
 Acquisition comes before exhaustive reading. A host may require one initial read of the installed

--- a/agents/sketch.md
+++ b/agents/sketch.md
@@ -5,7 +5,9 @@ model: inherit
 effort: medium
 ---
 
-Read `protocol/human-design-loop.md` under `omd pack dir` and obey its isolation boundary.
+Read `omd pack protocol/human-design-loop.md --section "Blindness and isolation"` and
+`--section "Divergence and checkpoints"`, once, and obey that isolation boundary. Never read the
+coordinator's `oh-my-design:ultradesign` skill or the rest of the loop protocol.
 You receive only a sanitized frame/concept, `.omd/copy-deck.md`, approved typography and
 composition contracts, an anonymous candidate id, and one axis assigned from the
 composition contract's Candidate axes section. The contracts contain approved dependency,

--- a/agents/typesetter.md
+++ b/agents/typesetter.md
@@ -5,9 +5,10 @@ model: inherit
 effort: high
 ---
 
-Own typography proof, not page design. Read `protocol/human-design-loop.md`,
+Own typography proof, not page design. Read once, scoped:
+`omd pack protocol/human-design-loop.md --section "Blindness and isolation"`, then
 `protocol/design-deliberation.md`, the exact `theory/typography.md`, `.omd/copy-deck.md`, and
-the scout's cited typography evidence.
+the scout's cited typography evidence. Never read the coordinator's `oh-my-design:ultradesign` skill.
 Create layout-neutral specimens under `.omd/.cache/type-proof/`, render them at exactly
 1280x900 and 390x844, and write the durable record `.omd/type-proof.md`.
 

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -2997,6 +2997,11 @@ async function cmdTargetList(): Promise<never> {
  */
 function cmdPack(sub: string | undefined, ...rest: string[]): never {
   const packsRoot = join(root, 'core');
+  // `--section "<heading>"` prints one `##` section. A role that needs the framing rules should not
+  // pay for the whole protocol: the loop file alone costs about sixteen thousand tokens to read.
+  const sectionIndex = rest.indexOf('--section');
+  const section = sectionIndex === -1 ? undefined : rest[sectionIndex + 1];
+  const parts = sectionIndex === -1 ? rest : rest.slice(0, sectionIndex);
 
   if (sub === 'dir') {
     console.log(packsRoot);
@@ -3021,16 +3026,29 @@ function cmdPack(sub: string | undefined, ...rest: string[]): never {
 
   if (sub) {
     // `omd pack <relpath>` — treat `sub` as a relative path under the pack root.
-    const target = join(packsRoot, sub, ...rest);
+    const target = join(packsRoot, sub, ...parts);
     if (!existsSync(target)) {
       console.error(`pack file not found: ${target}`);
       process.exit(1);
     }
-    process.stdout.write(readFileSync(target, 'utf8'));
+    const body = readFileSync(target, 'utf8');
+    if (section === undefined) {
+      process.stdout.write(body);
+      process.exit(0);
+    }
+    const heading = new RegExp(`^##\\s+${section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'im');
+    const match = heading.exec(body);
+    if (match === null) {
+      console.error(`pack section not found: ${section}\nsections in ${sub}:\n${(body.match(/^##\s+.+$/gm) ?? []).join('\n')}`);
+      process.exit(1);
+    }
+    const tail = body.slice(match.index);
+    const next = /^##\s+/m.exec(tail.slice(match[0].length));
+    process.stdout.write(next === null ? tail : tail.slice(0, match[0].length + next.index));
     process.exit(0);
   }
 
-  console.error('usage: omd pack dir | list | <relpath>');
+  console.error('usage: omd pack dir | list | <relpath> [--section "<heading>"]');
   process.exit(1);
 }
 

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -62,6 +62,19 @@ response. Call `wait` again for the same retained child thread IDs until the too
 as `completed`, then quote only the child's returned handback. Never invent the expected response,
 treat the child's display name or `Started` event as its result, or advance because one poll returned
 no completed agents.
+**Every poll is a full turn.** A coordinator waiting on a role re-sends its whole context to ask
+"is it done", so a 60-second wait on a twenty-minute stage spends twenty turns learning nothing.
+Always request the longest wait the host supports — on Codex pass the maximum `timeout_ms` the tool
+accepts rather than a minute — and never poll a capture, render, or build stage more often than
+every five minutes. Waiting longer is free; polling is not.
+
+**Read once, read what you were given.** This skill is the coordinator's own instructions; a spawned
+role must never read it. Each role reads its own agent instructions plus exactly the contracts
+delivered to its stage, once, whole — not the same file again in overlapping slices because an
+earlier read was truncated. The knowledge pack costs roughly seventeen thousand tokens for this
+skill and sixteen thousand for the human-design loop, so a role that reloads both has spent a third
+of a context window before it looks at the brief. When output truncates, read the remaining range
+once, not the whole file again.
 For the scout specifically, acquisition and browser work can be quiet while a batch is active.
 Allow at least fifteen minutes for its first final state, and never retry or cancel it while its
 child state or a capture/browser tool is active. Six empty chat polls are not a timeout. Inspecting
@@ -145,6 +158,21 @@ component-only change may be L1. L1/L2 omit only the stages listed by the classi
 the owner of every retained artifact. L3 runs the full owner-separated graph. L4 adds the independent
 three-perspective deliberation and moderator. Never call a direct coordinator build an adaptive
 route.
+
+**Answer the depth input honestly; every field is a cost lever.** `brandDirectionChange` is true only
+when this run establishes a visual identity that does not exist yet. A surface built inside a
+project that already ships tokens, a type system, and a wordmark is an iteration, not a new
+direction, and marking it true buys a three-perspective deliberation the run does not need. The
+same discipline applies to `costlyError`, `showpieceMotion`, and `webgl`: each raises the level to
+L4 on its own. Inflating them is not caution, it is an hour of wall clock and a deliberation round
+spent proving something the project already decided. Under-reporting a genuinely new direction is
+the opposite failure and is worse; state what is true.
+
+Effort follows depth. At L3 and L4 every judgment role runs at its declared `high` tier. At L1 and
+L2 the retained judgment roles run at `medium` — the depth classifier already found that this
+change carries no new direction, and paying deep reasoning to confirm a component swap is the same
+waste as an inflated depth input. The production hand stays `medium` at every level. Effort changes
+depth of thought, never model identity, and never artifact ownership.
 
 `.omd/locale.json` is the other coordinator-owned routing input, written only when the brief names
 more than one language. It is `locale-contract-v1` (`omd schema locale-contract`), and declaring it

--- a/src/agents/composer.agent.yaml
+++ b/src/agents/composer.agent.yaml
@@ -12,10 +12,14 @@ allow:
   - Bash(shasum:*)
 deny: []
 instructions: |
-  Own only `.omd/composition.md`. Read `protocol/human-design-loop.md`,
-  `protocol/reference-assembly.md`, `protocol/design-deliberation.md`, the exact
-  `protocol/composition-contract.md`, `theory/layout.md`, and `theory/ux.md` under
-  `omd pack dir`. Receive only the sanitized frame/concept, clean copy deck, sanitized
+  Own only `.omd/composition.md`. Read once, scoped. From
+  `omd pack protocol/human-design-loop.md` take `--section "Surface grammar"`,
+  `--section "UX task coverage"`, and `--section "Divergence and checkpoints"`; then read
+  `protocol/reference-assembly.md`,
+  `protocol/design-deliberation.md`, the exact `protocol/composition-contract.md`,
+  `theory/layout.md`, and `theory/ux.md` under
+  `omd pack dir`. Never read the coordinator's `omd-ultradesign` skill. Read another named section
+  only when a gate cites it. Receive only the sanitized frame/concept, clean copy deck, sanitized
   approved typography contract, scout's distilled transferable principles, and the immutable
   selected `art-direction-v1` record resolved from `.omd/art-direction.json` with its matching
   `motionDecision: none|one`, selected immutable register (quiet/confident/showpiece), selected slots,

--- a/src/agents/eye.agent.yaml
+++ b/src/agents/eye.agent.yaml
@@ -11,8 +11,12 @@ deny:
   - Edit
   - apply_patch
 instructions: |
-  You did not build this work. Read `protocol/human-design-loop.md`,
-  `protocol/reference-assembly.md`, and `protocol/design-deliberation.md` under `omd pack dir`.
+  You did not build this work. Read once, scoped. From
+  `omd pack protocol/human-design-loop.md` take `--section "Blindness and isolation"`,
+  `--section "UX acceptance contract"`, `--section "Task evidence index"`, and
+  `--section "Production quality gates"`; then read `protocol/reference-assembly.md` and
+  `protocol/design-deliberation.md` under `omd pack dir`. Never read the coordinator's
+  `omd-ultradesign` skill; read another named section only when a gate cites it.
   You may receive only a role-bounded review brief: primary task, costliest error, generator,
   register, art-direction contract, sanitized composition acceptance criteria, anonymous render paths,
   and deterministic check/probe outputs. An isolated blind eye receives only bounded opaque production

--- a/src/agents/framer.agent.yaml
+++ b/src/agents/framer.agent.yaml
@@ -11,8 +11,13 @@ allow:
   - Bash(omd pack:*)
 deny: []
 instructions: |
-  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
-  `protocol/design-deliberation.md`, and `theory/ux.md` §Surface types under `omd pack dir`.
+  Read only what framing needs, once. From `omd pack protocol/human-design-loop.md` take
+  `--section "Surface grammar"`, `--section "Task coverage matrix"`, and
+  `--section "UX task coverage"`; then read `protocol/reference-assembly.md`,
+  `protocol/design-deliberation.md`, and
+  `theory/ux.md` §Surface types. Never read the coordinator's `omd-ultradesign` skill — it is the
+  coordinator's own instructions and costs about seventeen thousand tokens you do not need. If a
+  read truncates, continue from where it stopped rather than starting the file again.
   Persist your two owned artifacts only through `omd frame:*` and `omd acquisition:*`; those CLI
   mutations are required work, not forbidden direct source editing. Never use a patch or file-write
   tool, touch production source or another `.omd/` artifact, or ask the coordinator to author the

--- a/src/agents/hand.agent.yaml
+++ b/src/agents/hand.agent.yaml
@@ -13,9 +13,14 @@ allow:
   - Bash(omd source:*)
 deny: []
 instructions: |
-  Read `protocol/human-design-loop.md`, `protocol/reference-assembly.md`,
+  Read once, scoped. From `omd pack protocol/human-design-loop.md` take
+  `--section "Stack routing"`, `--section "UX task coverage"`, `--section "Task evidence index"`,
+  `--section "Safe probe policy"`, and `--section "Production quality gates"`; then read
+  `protocol/reference-assembly.md`,
   `protocol/design-deliberation.md`, the exact `theory/ux.md`, plus the relevant theory,
-  composition, graphics, motion, and craft files under `omd pack dir`. Read `.omd/copy-deck.md`,
+  composition, graphics, motion, and craft files under `omd pack dir`. Never read the coordinator's
+  `omd-ultradesign` skill; read another named section only when a gate cites it.
+  Read `.omd/copy-deck.md`,
   `.omd/type-proof.md`, and `.omd/design.md` when present. On the normal graph, also read
   `.omd/composition.md` and receive accepted sanitized transfer criteria. When reference assembly
   applies, inspect the selected lawful local part-image capture projections under `.omd/refs/`, the canonical

--- a/src/agents/scout.agent.yaml
+++ b/src/agents/scout.agent.yaml
@@ -13,9 +13,11 @@ allow:
   - apply_patch
 deny: []
 instructions: |
-  Read `protocol/reference-assembly.md` and only the reference-gallery, concept-exploration,
-  contamination, and transfer-boundary sections of `protocol/human-design-loop.md`, plus a theory
-  file only when one acquisition zone directly needs it. Receive the concept, product, working
+  Read `protocol/reference-assembly.md`, then only
+  `omd pack protocol/human-design-loop.md --section "Visual reference gallery and concept exploration"`
+  and `--section "Feature-level reference research and transfer"`, plus a theory
+  file only when one acquisition zone directly needs it. Never read the coordinator's
+  `omd-ultradesign` skill. Receive the concept, product, working
   directory, component inventory, explicit functions or product goal, surface classification, and
   any user URLs. Run all commands from that directory. Capture user URLs first with `--from-user`.
   Acquisition comes before exhaustive reading. A host may require one initial read of the installed

--- a/src/agents/sketch.agent.yaml
+++ b/src/agents/sketch.agent.yaml
@@ -10,7 +10,9 @@ allow:
   - Bash(omd pack:*)
 deny: []
 instructions: |
-  Read `protocol/human-design-loop.md` under `omd pack dir` and obey its isolation boundary.
+  Read `omd pack protocol/human-design-loop.md --section "Blindness and isolation"` and
+  `--section "Divergence and checkpoints"`, once, and obey that isolation boundary. Never read the
+  coordinator's `omd-ultradesign` skill or the rest of the loop protocol.
   You receive only a sanitized frame/concept, `.omd/copy-deck.md`, approved typography and
   composition contracts, an anonymous candidate id, and one axis assigned from the
   composition contract's Candidate axes section. The contracts contain approved dependency,

--- a/src/agents/typesetter.agent.yaml
+++ b/src/agents/typesetter.agent.yaml
@@ -11,9 +11,10 @@ allow:
   - Bash(omd pack:*)
 deny: []
 instructions: |
-  Own typography proof, not page design. Read `protocol/human-design-loop.md`,
+  Own typography proof, not page design. Read once, scoped:
+  `omd pack protocol/human-design-loop.md --section "Blindness and isolation"`, then
   `protocol/design-deliberation.md`, the exact `theory/typography.md`, `.omd/copy-deck.md`, and
-  the scout's cited typography evidence.
+  the scout's cited typography evidence. Never read the coordinator's `omd-ultradesign` skill.
   Create layout-neutral specimens under `.omd/.cache/type-proof/`, render them at exactly
   1280x900 and 390x844, and write the durable record `.omd/type-proof.md`.
 

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -62,6 +62,19 @@ response. Call `wait` again for the same retained child thread IDs until the too
 as `completed`, then quote only the child's returned handback. Never invent the expected response,
 treat the child's display name or `Started` event as its result, or advance because one poll returned
 no completed agents.
+**Every poll is a full turn.** A coordinator waiting on a role re-sends its whole context to ask
+"is it done", so a 60-second wait on a twenty-minute stage spends twenty turns learning nothing.
+Always request the longest wait the host supports — on Codex pass the maximum `timeout_ms` the tool
+accepts rather than a minute — and never poll a capture, render, or build stage more often than
+every five minutes. Waiting longer is free; polling is not.
+
+**Read once, read what you were given.** This skill is the coordinator's own instructions; a spawned
+role must never read it. Each role reads its own agent instructions plus exactly the contracts
+delivered to its stage, once, whole — not the same file again in overlapping slices because an
+earlier read was truncated. The knowledge pack costs roughly seventeen thousand tokens for this
+skill and sixteen thousand for the human-design loop, so a role that reloads both has spent a third
+of a context window before it looks at the brief. When output truncates, read the remaining range
+once, not the whole file again.
 For the scout specifically, acquisition and browser work can be quiet while a batch is active.
 Allow at least fifteen minutes for its first final state, and never retry or cancel it while its
 child state or a capture/browser tool is active. Six empty chat polls are not a timeout. Inspecting
@@ -145,6 +158,21 @@ component-only change may be L1. L1/L2 omit only the stages listed by the classi
 the owner of every retained artifact. L3 runs the full owner-separated graph. L4 adds the independent
 three-perspective deliberation and moderator. Never call a direct coordinator build an adaptive
 route.
+
+**Answer the depth input honestly; every field is a cost lever.** `brandDirectionChange` is true only
+when this run establishes a visual identity that does not exist yet. A surface built inside a
+project that already ships tokens, a type system, and a wordmark is an iteration, not a new
+direction, and marking it true buys a three-perspective deliberation the run does not need. The
+same discipline applies to `costlyError`, `showpieceMotion`, and `webgl`: each raises the level to
+L4 on its own. Inflating them is not caution, it is an hour of wall clock and a deliberation round
+spent proving something the project already decided. Under-reporting a genuinely new direction is
+the opposite failure and is worse; state what is true.
+
+Effort follows depth. At L3 and L4 every judgment role runs at its declared `high` tier. At L1 and
+L2 the retained judgment roles run at `medium` — the depth classifier already found that this
+change carries no new direction, and paying deep reasoning to confirm a component swap is the same
+waste as an inflated depth input. The production hand stays `medium` at every level. Effort changes
+depth of thought, never model identity, and never artifact ownership.
 
 `.omd/locale.json` is the other coordinator-owned routing input, written only when the brief names
 more than one language. It is `locale-contract-v1` (`omd schema locale-contract`), and declaring it

--- a/test/pack-sections.test.ts
+++ b/test/pack-sections.test.ts
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Reading the whole pack is what made a run expensive: the loop protocol alone is ~16k tokens and
+// every role reloaded it, some in overlapping slices after truncation. Roles now cite the sections
+// they need. A renamed heading would silently send them back to reading everything, so every cited
+// section is checked against the file it names.
+
+const CLI = fileURLToPath(new URL('../bin/omd.ts', import.meta.url));
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const PACK = join(ROOT, 'core');
+const run = (args: string[]) => spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', cwd: ROOT });
+
+const SOURCES = [
+  ...readdirSync(join(ROOT, 'src', 'agents')).map((file) => join('src', 'agents', file)),
+  join('src', 'skills', 'omd-ultradesign', 'SKILL.md'),
+];
+
+/** `omd pack <file> --section "<heading>"` and bare `--section "<heading>"` continuations. */
+function citedSections(body: string): readonly { readonly file: string; readonly section: string }[] {
+  const cited: { file: string; section: string }[] = [];
+  let file: string | undefined;
+  const pattern = /(?:omd pack\s+(\S+\.md)[^\n]*?)?--section\s+"([^"]+)"/g;
+  for (const match of body.replace(/\n\s*/g, ' ').matchAll(pattern)) {
+    if (match[1] !== undefined) file = match[1];
+    if (file !== undefined && match[2] !== undefined) cited.push({ file, section: match[2] });
+  }
+  return cited;
+}
+
+test('every pack section a role cites exists in the file it names', () => {
+  const checked: string[] = [];
+  for (const source of SOURCES) {
+    for (const { file, section } of citedSections(readFileSync(join(ROOT, source), 'utf8'))) {
+      const body = readFileSync(join(PACK, file), 'utf8');
+      const headings = body.match(/^##\s+.+$/gm) ?? [];
+      assert.ok(
+        headings.some((heading) => heading.replace(/^##\s+/, '').trim() === section),
+        `${source} cites "${section}" which is not a heading in ${file}: ${headings.join(' | ')}`,
+      );
+      checked.push(`${file}#${section}`);
+    }
+  }
+  assert.ok(checked.length >= 12, `expected the roles to cite scoped sections, found ${checked.length}`);
+});
+
+test('a scoped read returns one section and costs a fraction of the whole file', () => {
+  const whole = run(['pack', 'protocol/human-design-loop.md']);
+  const scoped = run(['pack', 'protocol/human-design-loop.md', '--section', 'Surface grammar']);
+  assert.equal(scoped.status, 0, scoped.stderr);
+  assert.match(scoped.stdout, /^## Surface grammar\n/);
+  assert.doesNotMatch(scoped.stdout, /^## Stack routing/m);
+  assert.ok(scoped.stdout.length * 10 < whole.stdout.length, `scoped ${scoped.stdout.length} vs whole ${whole.stdout.length}`);
+});
+
+test('an unknown section names the available headings instead of printing the file', () => {
+  const missing = run(['pack', 'protocol/human-design-loop.md', '--section', 'Nope']);
+  assert.equal(missing.status, 1);
+  assert.equal(missing.stdout, '');
+  assert.match(missing.stderr, /pack section not found: Nope/);
+  assert.match(missing.stderr, /## Surface grammar/);
+});
+
+test('no spawned role is told to read the coordinator skill', () => {
+  for (const file of readdirSync(join(ROOT, 'src', 'agents'))) {
+    const body = readFileSync(join(ROOT, 'src', 'agents', file), 'utf8').replace(/\s+/g, ' ');
+    assert.doesNotMatch(body, /Read [^.]*omd-ultradesign/, `${file} sends a role into the coordinator skill`);
+  }
+  const scoped = ['composer', 'eye', 'framer', 'hand', 'scout', 'sketch', 'typesetter'];
+  for (const role of scoped) {
+    const body = readFileSync(join(ROOT, 'src', 'agents', `${role}.agent.yaml`), 'utf8').replace(/\s+/g, ' ');
+    assert.match(body, /Never read the coordinator's `omd-ultradesign` skill/, `${role} may still reload the coordinator skill`);
+  }
+});

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -915,6 +915,12 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /`omd complete check <page>`/);
   assert.match(skill, /It adds no style rule; it only proves the page does what the brief said it would/);
   assert.match(skill, /`omd locale check` must pass before ship/);
+  assert.match(skill, /Every poll is a full turn/);
+  assert.match(skill, /never poll a capture, render, or build stage more often than every five minutes/);
+  assert.match(skill, /Read once, read what you were given/);
+  assert.match(skill, /Answer the depth input honestly; every field is a cost lever/);
+  assert.match(skill, /At L1 and L2 the retained judgment roles run at `medium`/);
+  assert.match(skill, /Effort changes depth of thought, never model identity/);
   assert.match(skill, /`omd schema depth-input` instead of inferring keys from `core\/`/);
   assert.match(skill, /the OMD CLI spawns `browser-rs` itself over stdio for each capture/);
   assert.match(skill, /Never start a long-lived `browser-rs`, pick a port, or debug a listening socket/);


### PR DESCRIPTION
perf: stop paying for context the run does not need

A trial run cost about an hour and re-sent its whole context sixty times. The
spend was not design work.

- Polling. A coordinator waiting on a role re-sends its entire context to ask
  whether the child is done, so a 60-second wait on a twenty-minute stage buys
  twenty turns of nothing. The loop now requires the longest wait the host
  supports and never polls a capture, render, or build stage more than once
  every five minutes.
- Re-reading. `protocol/human-design-loop.md` is about sixteen thousand tokens
  and the coordinator skill about seventeen; a framer in the last trial read
  both, the skill in three slices and the protocol twice with overlapping
  ranges. `omd pack <file> --section "<heading>"` prints one section — 62KB down
  to 924 bytes for `Surface grammar` — and every role now cites the sections it
  needs, once, and is told never to read the coordinator's own skill.
- Depth inflation. `brandDirectionChange` is true only when the run establishes
  an identity that does not exist yet; a surface inside a project that already
  ships tokens, type, and a wordmark is an iteration. Each inflated flag buys an
  L4 deliberation the project already decided.
- Effort. L1 and L2 run their retained judgment roles at `medium`; L3 and L4
  keep `high`. Effort still changes depth of thought, never model identity.

A drift test asserts every section a role cites exists in the file it names, so
a renamed heading cannot silently send roles back to reading everything.
