### PR TITLE
Unblock the run at its last two stops

### DIFF
--- a/agents/sketch.md
+++ b/agents/sketch.md
@@ -7,7 +7,7 @@ effort: medium
 
 Read `omd pack protocol/human-design-loop.md --section "Blindness and isolation"` and
 `--section "Divergence and checkpoints"`, once, and obey that isolation boundary. Never read the
-coordinator's `oh-my-design:ultradesign` skill or the rest of the loop protocol.
+coordinator's `oh-my-design:ultradesign` skill, and do not read the rest of the loop protocol.
 You receive only a sanitized frame/concept, `.omd/copy-deck.md`, approved typography and
 composition contracts, an anonymous candidate id, and one axis assigned from the
 composition contract's Candidate axes section. The contracts contain approved dependency,

--- a/bin/omd.ts
+++ b/bin/omd.ts
@@ -2175,8 +2175,8 @@ async function cmdStage(mode: string | undefined, opts: Opts): Promise<never> {
     if (opts.json) process.stdout.write(JSON.stringify(requirement));
     else if (requirement.ok) console.log(`ok — ${requirement.stage} may run`);
     else {
-      for (const artifact of requirement.missingArtifacts) console.error(`[blocked] ${requirement.stage} needs an earlier owner's artifact: ${artifact}`);
-      for (const contract of requirement.undeliveredContracts) console.error(`[blocked] ${requirement.stage} has no current delivery receipt for ${contract}; run: omd stage deliver --stage ${requirement.stage} --contract ${contract}`);
+      for (const artifact of requirement.missingArtifacts) console.error(`[owner-blocked] ${requirement.stage} needs an earlier owner's artifact: ${artifact} — spawn that owner; only its failure stops the run`);
+      for (const contract of requirement.undeliveredContracts) console.error(`[deliver-then-retry] ${requirement.stage} has no current receipt for ${contract}. This is your own next step, not a run failure: run \`omd stage deliver --stage ${requirement.stage} --contract ${contract}\`, then require again`);
     }
     process.exit(requirement.ok ? 0 : 1);
   }
@@ -2997,11 +2997,21 @@ async function cmdTargetList(): Promise<never> {
  */
 function cmdPack(sub: string | undefined, ...rest: string[]): never {
   const packsRoot = join(root, 'core');
-  // `--section "<heading>"` prints one `##` section. A role that needs the framing rules should not
-  // pay for the whole protocol: the loop file alone costs about sixteen thousand tokens to read.
-  const sectionIndex = rest.indexOf('--section');
-  const section = sectionIndex === -1 ? undefined : rest[sectionIndex + 1];
-  const parts = sectionIndex === -1 ? rest : rest.slice(0, sectionIndex);
+  // `--section "<heading>"` prints one `##` section, and repeats to print several in file order. A
+  // role that needs the framing rules should not pay for the whole protocol: the loop file alone
+  // costs about sixteen thousand tokens to read.
+  const sections: string[] = [];
+  const parts: string[] = [];
+  for (let index = 0; index < rest.length; index++) {
+    if (rest[index] === '--section') {
+      const value = rest[++index];
+      if (value === undefined) {
+        console.error('usage: omd pack <relpath> --section "<heading>" [--section "<heading>"]');
+        process.exit(1);
+      }
+      sections.push(value);
+    } else parts.push(rest[index]!);
+  }
 
   if (sub === 'dir') {
     console.log(packsRoot);
@@ -3032,19 +3042,24 @@ function cmdPack(sub: string | undefined, ...rest: string[]): never {
       process.exit(1);
     }
     const body = readFileSync(target, 'utf8');
-    if (section === undefined) {
+    if (sections.length === 0) {
       process.stdout.write(body);
       process.exit(0);
     }
-    const heading = new RegExp(`^##\\s+${section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'im');
-    const match = heading.exec(body);
-    if (match === null) {
-      console.error(`pack section not found: ${section}\nsections in ${sub}:\n${(body.match(/^##\s+.+$/gm) ?? []).join('\n')}`);
-      process.exit(1);
+    const headings = body.match(/^##\s+.+$/gm) ?? [];
+    const printed: string[] = [];
+    for (const section of sections) {
+      const heading = new RegExp(`^##\\s+${section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'im');
+      const match = heading.exec(body);
+      if (match === null) {
+        console.error(`pack section not found: ${section}\nsections in ${sub}:\n${headings.join('\n')}`);
+        process.exit(1);
+      }
+      const tail = body.slice(match.index);
+      const next = /^##\s+/m.exec(tail.slice(match[0].length));
+      printed.push(next === null ? tail : tail.slice(0, match[0].length + next.index));
     }
-    const tail = body.slice(match.index);
-    const next = /^##\s+/m.exec(tail.slice(match[0].length));
-    process.stdout.write(next === null ? tail : tail.slice(0, match[0].length + next.index));
+    process.stdout.write(printed.join('\n'));
     process.exit(0);
   }
 

--- a/core/schema/inputs.ts
+++ b/core/schema/inputs.ts
@@ -8,6 +8,8 @@ import { DEPTH_INPUT_KEYS, DEPTH_INPUT_SCHEMA, DEPTH_SCOPES } from '../deliberat
 import { ART_DIRECTION_CHECK_INPUT_KEYS } from '../art-direction/schema.ts';
 import { LOCALE_CONTRACT_KEYS, LOCALE_CONTRACT_SCHEMA, LOCALE_MODES } from '../locale/contract.ts';
 import { FUNCTIONAL_REQUIREMENTS_SCHEMA, REQUIREMENT_KINDS } from '../completeness/index.ts';
+import { DOMAIN_BRIEF_SCHEMA } from '../domain/domain-brief.ts';
+import { DECISION_GRAPH_SCHEMA } from '../deliberation/contracts.ts';
 
 export type InputSkeleton = {
   readonly name: string;
@@ -115,7 +117,64 @@ const FUNCTIONAL_REQUIREMENTS: InputSkeleton = {
   },
 };
 
-export const INPUT_SKELETONS: readonly InputSkeleton[] = [DEPTH_INPUT, ART_DIRECTION_CHECK, LOCALE_CONTRACT, FUNCTIONAL_REQUIREMENTS];
+const DOMAIN_BRIEF: InputSkeleton = {
+  name: 'domain-brief',
+  path: '.omd/domain-brief.json',
+  command: 'omd domain check --input .omd/domain-brief.json --json',
+  keys: ['schema', 'request', 'domain', 'summary', 'surfaces', 'coreObjects', 'audience', 'referenceQueries', 'researched'],
+  skeleton: {
+    schema: DOMAIN_BRIEF_SCHEMA,
+    request: '<the raw request, normalized>',
+    domain: '<the domain in a few words>',
+    summary: '<one line: what this domain is and does>',
+    surfaces: [{ name: '<canonical page or screen>', purpose: '<the task it serves, one clause>' }],
+    coreObjects: ['<the real nouns the domain manipulates>'],
+    audience: '<who the work is for>',
+    referenceQueries: {
+      component: ['<detailed component or section design query>'],
+      craft: ['<motion, scroll, or sculptural craft query>'],
+    },
+    researched: false,
+  },
+};
+
+const DECISION_GRAPH: InputSkeleton = {
+  name: 'decision-graph',
+  path: '.omd/decision-graph.json',
+  command: 'omd deliberate check --json',
+  keys: ['schema', 'decisions'],
+  skeleton: {
+    schema: DECISION_GRAPH_SCHEMA,
+    decisions: [{
+      id: '<kebab-case-decision-id>',
+      stage: '<frame|copy|type|composition|structure|production|refinement>',
+      risk: '<low|medium|high|critical>',
+      owner: '<the role that owns that stage, never the coordinator>',
+      question: '<the consequential question this decision answered>',
+      alternatives: [
+        { id: '<kebab-id>', label: '<what this alternative was>' },
+        { id: '<kebab-id>', label: '<the other real option>' },
+      ],
+      selected: '<the chosen alternative id>',
+      evidence: ['<path or record that supports the choice>'],
+      constraints: ['<what the choice had to hold>'],
+      rejected: [{ id: '<kebab-id>', reason: '<why it lost, from evidence>' }],
+      affects: ['<downstream artifact or decision>'],
+      dependsOn: ['<upstream decision id>'],
+      reversible: true,
+      tradeoffs: [{
+        goal: '<what was wanted>',
+        constraint: '<what stopped it>',
+        attempt: '<what was actually tried>',
+        failureEvidence: ['<observed failure>'],
+        compromise: '<what shipped instead>',
+        resultEvidence: ['<observed result>'],
+      }],
+    }],
+  },
+};
+
+export const INPUT_SKELETONS: readonly InputSkeleton[] = [DOMAIN_BRIEF, DEPTH_INPUT, ART_DIRECTION_CHECK, LOCALE_CONTRACT, FUNCTIONAL_REQUIREMENTS, DECISION_GRAPH];
 
 export function inputSkeleton(name: string): InputSkeleton {
   const found = INPUT_SKELETONS.find((entry) => entry.name === name);

--- a/core/usage/index.ts
+++ b/core/usage/index.ts
@@ -19,6 +19,8 @@ export interface RunUsage {
   outputTokens: number;
   /** Wall-clock milliseconds from first to last logged event. */
   elapsedMs: number;
+  /** Epoch ms of the last logged event, used to tell a live run's log from a stale one. */
+  lastEventMs: number;
   /** Tool invocations, when the log records them. */
   toolUses: number;
   /** True when the figure is known to be partial (e.g. Codex subagent rollouts not found). */
@@ -109,6 +111,7 @@ export function parseClaudeSession(lines: string[]): RunUsage | null {
     totalTokens,
     outputTokens,
     elapsedMs,
+    lastEventMs: Number.isFinite(last) ? last : 0,
     toolUses,
     approximate: false,
     note: subUsage.size > 0 ? 'claude 세션 로그 (서브에이전트 포함)' : 'claude 세션 로그',
@@ -200,6 +203,7 @@ export function combineCodexRollouts(main: CodexRollout, children: CodexRollout[
     totalTokens,
     outputTokens,
     elapsedMs,
+    lastEventMs: Number.isFinite(last) ? last : 0,
     toolUses: 0,
     approximate: false,
     note: children.length > 0
@@ -305,9 +309,20 @@ function readCodexUsage(cwd: string, home: string): RunUsage | null {
  * Compute usage for the current run from the host session log. Returns null when
  * no readable host log is found (e.g. an unknown host or a fresh worktree with no
  * session yet) — callers fall back to a time-only or "unavailable" report.
+ *
+ * Both hosts can leave a log for the same directory: a Claude session from last week sits beside
+ * the Codex rollout of the run that is asking. Preferring one host by position reported that stale
+ * log, so a Codex run saw `0 tokens / 0s`. Pick the log that actually recorded work, and when both
+ * did, the one whose events are newer.
  */
 export function computeRunUsage(cwd: string, home: string = homedir()): RunUsage | null {
-  return readClaudeUsage(cwd, home) ?? readCodexUsage(cwd, home);
+  const claude = readClaudeUsage(cwd, home);
+  const codex = readCodexUsage(cwd, home);
+  if (claude === null) return codex;
+  if (codex === null) return claude;
+  if (claude.totalTokens === 0 && codex.totalTokens > 0) return codex;
+  if (codex.totalTokens === 0 && claude.totalTokens > 0) return claude;
+  return codex.lastEventMs >= claude.lastEventMs ? codex : claude;
 }
 
 // ── Formatting ──────────────────────────────────────────────────────────────────

--- a/skills/ultradesign/SKILL.md
+++ b/skills/ultradesign/SKILL.md
@@ -68,13 +68,16 @@ Always request the longest wait the host supports — on Codex pass the maximum 
 accepts rather than a minute — and never poll a capture, render, or build stage more often than
 every five minutes. Waiting longer is free; polling is not.
 
-**Read once, read what you were given.** This skill is the coordinator's own instructions; a spawned
-role must never read it. Each role reads its own agent instructions plus exactly the contracts
-delivered to its stage, once, whole — not the same file again in overlapping slices because an
-earlier read was truncated. The knowledge pack costs roughly seventeen thousand tokens for this
-skill and sixteen thousand for the human-design loop, so a role that reloads both has spent a third
-of a context window before it looks at the brief. When output truncates, read the remaining range
-once, not the whole file again.
+**Read once, read what you were given — the coordinator included.** This skill is the coordinator's
+own instructions; a spawned role must never read it. Each role reads its own agent instructions plus
+exactly the contracts delivered to its stage. The coordinator reads `protocol/human-design-loop.md`
+**once, whole, at preflight** and never again: every later question about a phase, gate, or boundary
+is answered by `omd pack protocol/human-design-loop.md --section "<heading>"`, which prints one
+section instead of sixteen thousand tokens. Re-running `sed -n '1,9999p'` on a protocol you already
+read this run, or re-reading it in overlapping ranges because an earlier output truncated, is the
+single most expensive mistake available to you — one observed run spent roughly forty-eight thousand
+tokens reading the same file three times before it framed anything. When output truncates, continue
+from where it stopped.
 For the scout specifically, acquisition and browser work can be quiet while a batch is active.
 Allow at least fifteen minutes for its first final state, and never retry or cancel it while its
 child state or a capture/browser tool is active. Six empty chat polls are not a timeout. Inspecting
@@ -133,9 +136,12 @@ every artifact, and the contracts that stage still needs.
 
 Before spawning a stage's owner, hand it its contracts and record that handoff:
 `omd stage deliver --stage <stage> --contract <pack-relative.md>` for each contract
-`omd stage list` names, then `omd stage require <stage>`. `require` exits non-zero while an earlier
-owner's artifact is missing or a contract has no receipt for its current bytes; that is a hard stop,
-not a warning. Editing a contract invalidates its receipt, so a mid-run protocol change forces a
+`omd stage list` names, then `omd stage require <stage>`. A non-zero `require` is not by itself a
+run failure. It has exactly two causes and they end differently. `[deliver-then-retry]` means you
+have not delivered a contract yet: that is your own next step, so deliver it and run `require`
+again. `[owner-blocked]` means an earlier owner's artifact is missing, which stops the run only when
+that owner already ran and failed. Never end a run because a gate told you to do the next thing.
+Editing a contract invalidates its receipt, so a mid-run protocol change forces a
 fresh delivery rather than a silent divergence between what the role read and what the loop
 requires. Never claim a role received a contract without its receipt.
 

--- a/src/agents/sketch.agent.yaml
+++ b/src/agents/sketch.agent.yaml
@@ -12,7 +12,7 @@ deny: []
 instructions: |
   Read `omd pack protocol/human-design-loop.md --section "Blindness and isolation"` and
   `--section "Divergence and checkpoints"`, once, and obey that isolation boundary. Never read the
-  coordinator's `omd-ultradesign` skill or the rest of the loop protocol.
+  coordinator's `omd-ultradesign` skill, and do not read the rest of the loop protocol.
   You receive only a sanitized frame/concept, `.omd/copy-deck.md`, approved typography and
   composition contracts, an anonymous candidate id, and one axis assigned from the
   composition contract's Candidate axes section. The contracts contain approved dependency,

--- a/src/skills/omd-ultradesign/SKILL.md
+++ b/src/skills/omd-ultradesign/SKILL.md
@@ -68,13 +68,16 @@ Always request the longest wait the host supports — on Codex pass the maximum 
 accepts rather than a minute — and never poll a capture, render, or build stage more often than
 every five minutes. Waiting longer is free; polling is not.
 
-**Read once, read what you were given.** This skill is the coordinator's own instructions; a spawned
-role must never read it. Each role reads its own agent instructions plus exactly the contracts
-delivered to its stage, once, whole — not the same file again in overlapping slices because an
-earlier read was truncated. The knowledge pack costs roughly seventeen thousand tokens for this
-skill and sixteen thousand for the human-design loop, so a role that reloads both has spent a third
-of a context window before it looks at the brief. When output truncates, read the remaining range
-once, not the whole file again.
+**Read once, read what you were given — the coordinator included.** This skill is the coordinator's
+own instructions; a spawned role must never read it. Each role reads its own agent instructions plus
+exactly the contracts delivered to its stage. The coordinator reads `protocol/human-design-loop.md`
+**once, whole, at preflight** and never again: every later question about a phase, gate, or boundary
+is answered by `omd pack protocol/human-design-loop.md --section "<heading>"`, which prints one
+section instead of sixteen thousand tokens. Re-running `sed -n '1,9999p'` on a protocol you already
+read this run, or re-reading it in overlapping ranges because an earlier output truncated, is the
+single most expensive mistake available to you — one observed run spent roughly forty-eight thousand
+tokens reading the same file three times before it framed anything. When output truncates, continue
+from where it stopped.
 For the scout specifically, acquisition and browser work can be quiet while a batch is active.
 Allow at least fifteen minutes for its first final state, and never retry or cancel it while its
 child state or a capture/browser tool is active. Six empty chat polls are not a timeout. Inspecting
@@ -133,9 +136,12 @@ every artifact, and the contracts that stage still needs.
 
 Before spawning a stage's owner, hand it its contracts and record that handoff:
 `omd stage deliver --stage <stage> --contract <pack-relative.md>` for each contract
-`omd stage list` names, then `omd stage require <stage>`. `require` exits non-zero while an earlier
-owner's artifact is missing or a contract has no receipt for its current bytes; that is a hard stop,
-not a warning. Editing a contract invalidates its receipt, so a mid-run protocol change forces a
+`omd stage list` names, then `omd stage require <stage>`. A non-zero `require` is not by itself a
+run failure. It has exactly two causes and they end differently. `[deliver-then-retry]` means you
+have not delivered a contract yet: that is your own next step, so deliver it and run `require`
+again. `[owner-blocked]` means an earlier owner's artifact is missing, which stops the run only when
+that owner already ran and failed. Never end a run because a gate told you to do the next thing.
+Editing a contract invalidates its receipt, so a mid-run protocol change forces a
 fresh delivery rather than a silent divergence between what the role read and what the loop
 requires. Never claim a role received a contract without its receipt.
 

--- a/test/omd-cli-wiring.test.ts
+++ b/test/omd-cli-wiring.test.ts
@@ -134,7 +134,7 @@ test('printed input skeletons carry exactly the keys their validators accept', a
   const authored = Object.keys(check.skeleton as object);
   assert.ok(authored.every((key) => (ART_DIRECTION_CHECK_INPUT_KEYS as readonly string[]).includes(key)), authored.join(','));
   assert.ok(!authored.includes('invocation'), 'the local lane never authors an invocation');
-  assert.equal(INPUT_SKELETONS.length, 4);
+  assert.equal(INPUT_SKELETONS.length, 6);
 
   const locale = inputSkeleton('locale-contract');
   const { LOCALE_CONTRACT_KEYS } = await import('../core/locale/contract.ts');
@@ -147,7 +147,7 @@ test('printed input skeletons carry exactly the keys their validators accept', a
   assert.equal(printed.status, 0, printed.stderr);
   assert.deepEqual(JSON.parse(printed.stdout).skeleton, depth.skeleton);
   const listed = run(['schema', 'list', '--json'], dir);
-  assert.deepEqual(JSON.parse(listed.stdout).map((entry: { name: string }) => entry.name), ['depth-input', 'art-direction-check', 'locale-contract', 'functional-requirements']);
+  assert.deepEqual(JSON.parse(listed.stdout).map((entry: { name: string }) => entry.name), ['domain-brief', 'depth-input', 'art-direction-check', 'locale-contract', 'functional-requirements', 'decision-graph']);
 });
 
 test('the printed depth skeleton classifies and a shapeless input names every missing key', () => {

--- a/test/pack-sections.test.ts
+++ b/test/pack-sections.test.ts
@@ -27,7 +27,8 @@ function citedSections(body: string): readonly { readonly file: string; readonly
   const pattern = /(?:omd pack\s+(\S+\.md)[^\n]*?)?--section\s+"([^"]+)"/g;
   for (const match of body.replace(/\n\s*/g, ' ').matchAll(pattern)) {
     if (match[1] !== undefined) file = match[1];
-    if (file !== undefined && match[2] !== undefined) cited.push({ file, section: match[2] });
+    // `--section "<heading>"` in prose is the placeholder documenting the flag, not a citation.
+    if (file !== undefined && match[2] !== undefined && !match[2].startsWith('<')) cited.push({ file, section: match[2] });
   }
   return cited;
 }
@@ -75,4 +76,18 @@ test('no spawned role is told to read the coordinator skill', () => {
     const body = readFileSync(join(ROOT, 'src', 'agents', `${role}.agent.yaml`), 'utf8').replace(/\s+/g, ' ');
     assert.match(body, /Never read the coordinator's `omd-ultradesign` skill/, `${role} may still reload the coordinator skill`);
   }
+});
+
+// Roles ask for several sections in one call; taking only the first would silently drop the rest
+// and cost the extra round trip the flag exists to avoid.
+test('repeated --section prints every requested section in one call', () => {
+  const both = run(['pack', 'protocol/human-design-loop.md', '--section', 'Surface grammar', '--section', 'Task coverage matrix']);
+  assert.equal(both.status, 0, both.stderr);
+  assert.equal((both.stdout.match(/^## /gm) ?? []).length, 2);
+  assert.match(both.stdout, /^## Surface grammar$/m);
+  assert.match(both.stdout, /^## Task coverage matrix$/m);
+
+  const partial = run(['pack', 'protocol/human-design-loop.md', '--section', 'Surface grammar', '--section', 'Nope']);
+  assert.equal(partial.status, 1);
+  assert.match(partial.stderr, /pack section not found: Nope/);
 });

--- a/test/prompt-contract.test.ts
+++ b/test/prompt-contract.test.ts
@@ -907,7 +907,7 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /repair the bytes and rerun the same command/);
   assert.match(skill, /Run `omd stage resume` first and continue at the stage it names/);
   assert.match(skill, /`omd stage deliver --stage <stage> --contract <pack-relative\.md>`/);
-  assert.match(skill, /`require` exits non-zero while an earlier owner's artifact is missing or a contract has no receipt/);
+  assert.match(skill, /Never end a run because a gate told you to do the next thing/);
   assert.match(skill, /Never claim a role received a contract without its receipt/);
   assert.match(skill, /`omd cue --path <file> --symbol <symbol> --field <name>=<value>`/);
   assert.match(skill, /Cues resolve only from those deterministic inputs/);
@@ -917,7 +917,7 @@ test('ultradesign externalizes decisions, deliberation, visual observation, and 
   assert.match(skill, /`omd locale check` must pass before ship/);
   assert.match(skill, /Every poll is a full turn/);
   assert.match(skill, /never poll a capture, render, or build stage more often than every five minutes/);
-  assert.match(skill, /Read once, read what you were given/);
+  assert.match(skill, /Read once, read what you were given — the coordinator included/);
   assert.match(skill, /Answer the depth input honestly; every field is a cost lever/);
   assert.match(skill, /At L1 and L2 the retained judgment roles run at `medium`/);
   assert.match(skill, /Effort changes depth of thought, never model identity/);

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -7,6 +7,9 @@ import {
   formatElapsed,
   formatRunUsage,
 } from '../core/usage/index.ts';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const jl = (obj: unknown): string => JSON.stringify(obj);
 
@@ -82,9 +85,33 @@ test('formatElapsed renders seconds, minutes, hours', () => {
 });
 
 test('formatRunUsage renders a bilingual-safe usage block', () => {
-  const out = formatRunUsage({ host: 'claude', totalTokens: 2_847_193, outputTokens: 128_441, elapsedMs: 1_294_000, toolUses: 216, approximate: false, note: 'claude 세션 로그 (서브에이전트 포함)' });
+  const out = formatRunUsage({ host: 'claude', totalTokens: 2_847_193, outputTokens: 128_441, elapsedMs: 1_294_000, lastEventMs: 1_700_000_000_000, toolUses: 216, approximate: false, note: 'claude 세션 로그 (서브에이전트 포함)' });
   assert.match(out, /실행 사용량/);
   assert.match(out, /소요 시간: 21분 34초/);
   assert.match(out, /토큰: 총 2,847,193 \(출력 128,441\)/);
   assert.match(out, /도구 호출: 216회/);
+});
+
+// A directory can hold logs from both hosts: a Claude session from last week beside the Codex
+// rollout of the run that is asking. Preferring one by position reported the stale log, so a real
+// Codex run printed `0 tokens`. The live log wins.
+test('the host log that recorded work wins over a stale empty one', async () => {
+  const { computeRunUsage } = await import('../core/usage/index.ts');
+  const home = mkdtempSync(join(tmpdir(), 'omd-usage-host-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'omd-usage-project-'));
+  const claudeDir = join(home, '.claude', 'projects', cwd.replace(/[/.]/g, '-'));
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(join(claudeDir, 'stale.jsonl'), '');
+
+  const codexDir = join(home, '.codex', 'sessions', '2026', '07', '28');
+  mkdirSync(codexDir, { recursive: true });
+  const at = new Date().toISOString();
+  writeFileSync(join(codexDir, 'rollout-live.jsonl'), [
+    JSON.stringify({ timestamp: at, type: 'session_meta', payload: { id: 'live', cwd, timestamp: at } }),
+    JSON.stringify({ timestamp: at, type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 900, output_tokens: 100, total_tokens: 1000 } } } }),
+  ].join('\n'));
+
+  const usage = computeRunUsage(cwd, home);
+  assert.equal(usage?.host, 'codex');
+  assert.ok((usage?.totalTokens ?? 0) > 0);
 });


### PR DESCRIPTION
fix: unblock the run at its last two stops

Real-use trials kept dying after the design work was already done. Both causes
were in the harness, not the design.

- A non-zero `omd stage require` was read as a terminal failure. The last run
  finished framing, research, copy, and typography, then stopped at composition
  because a contract it had not yet delivered made the gate exit non-zero. The
  gate now separates `[deliver-then-retry]`, which is the coordinator's own next
  step, from `[owner-blocked]`, which is the only case an owner failure can stop
  the run, and the loop says so.
- `omd usage` preferred a stale Claude log over the Codex rollout of the run
  asking, so a Codex run reported `0 tokens / 0s`. Usage now picks the log that
  recorded work, and the newer one when both did.

With these, a run completed end to end: `example/` ships a React 19 + Vite 8 +
TypeScript landing with ko/en and light/dark preferences that persist, an
`aria-pressed` state that is not colour-only, a skip link, and a passing
production build.
